### PR TITLE
Added a feature to initialize remote containers on user specified port

### DIFF
--- a/src/main/java/org/arl/fjage/rmi/MasterContainer.java
+++ b/src/main/java/org/arl/fjage/rmi/MasterContainer.java
@@ -35,6 +35,7 @@ public class MasterContainer extends Container implements RemoteContainer {
   private Map<String,RemoteContainer> slaves = new ConcurrentHashMap<String,RemoteContainer>();
   private String myurl = null;
   private RemoteContainerProxy proxy = null;
+  private int containerPort = 0;
   
   ////////////// Constructors
 
@@ -49,6 +50,18 @@ public class MasterContainer extends Container implements RemoteContainer {
   }
 
   /**
+   * Creates a master container, runs its container stub on a specified port.
+   * 
+   * @param platform platform on which the container runs.
+   * @param port port on which the container's stub runs.
+   */
+  public MasterContainer(Platform platform, int port) throws IOException {
+	  super(platform);
+	  containerPort = port;
+	  enableRMI();
+  }
+  
+  /**
    * Creates a named master container.
    * 
    * @param platform platform on which the container runs.
@@ -56,6 +69,19 @@ public class MasterContainer extends Container implements RemoteContainer {
    */
   public MasterContainer(Platform platform, String name) throws IOException {
     super(platform, name);
+    enableRMI();
+  }
+  
+  /**
+   * Creates a named master container, runs its container stub on a specified port.
+   * 
+   * @param platform platform on which the container runs.
+   * @param name of the container.
+   * @param port port on which the container's stub runs.
+   */
+  public MasterContainer(Platform platform, String name, int port) throws IOException {
+    super(platform, name);
+    containerPort = port;
     enableRMI();
   }
   
@@ -198,7 +224,12 @@ public class MasterContainer extends Container implements RemoteContainer {
     } catch (java.rmi.server.ExportException ex) {
       log.info("Could not create registry, perhaps one is already running!");
     }
-    proxy = new RemoteContainerProxy(this);
+    if (containerPort != 0) {
+      proxy = new RemoteContainerProxy(this, containerPort);
+    }
+    else {
+      proxy = new RemoteContainerProxy(this);
+    }
     Naming.rebind(myurl, proxy);
   }
 

--- a/src/main/java/org/arl/fjage/rmi/RemoteContainerProxy.java
+++ b/src/main/java/org/arl/fjage/rmi/RemoteContainerProxy.java
@@ -36,6 +36,11 @@ public class RemoteContainerProxy extends UnicastRemoteObject implements RemoteC
     super();
     this.delegate = delegate;
   }
+  
+  RemoteContainerProxy(RemoteContainer delegate, int port) throws RemoteException {
+	  super(port);
+	  this.delegate = delegate;
+  }
 
   /////////// Delegated methods
 

--- a/src/main/java/org/arl/fjage/rmi/SlaveContainer.java
+++ b/src/main/java/org/arl/fjage/rmi/SlaveContainer.java
@@ -38,6 +38,7 @@ public class SlaveContainer extends Container implements RemoteContainer {
   private String myurl = null;
   private String masterUrl = null;
   private RemoteContainerProxy proxy = null;
+  private int containerPort = 0;
 
   ////////////// Constructors
 
@@ -54,7 +55,24 @@ public class SlaveContainer extends Container implements RemoteContainer {
     masterUrl = url;
     attach(url);
   }
-
+  
+  
+  /**
+   * Creates a slave container, runs its container stub on a specified port.
+   * 
+   * @param platform platform on which the container runs.
+   * @param port port on which the container's stub runs.
+   * @param url URL of master platform to connect to.
+   */
+  public SlaveContainer(Platform platform, int port, String url) throws IOException, NotBoundException {
+	  super(platform);
+	  if (platform.getNetworkInterface() == null) determineNetworkInterface(url);
+	  containerPort = port;
+	  enableRMI(true);
+	  masterUrl = url;
+	  attach(url);
+  }
+  
   /**
    * Creates a named slave container.
    * 
@@ -65,6 +83,23 @@ public class SlaveContainer extends Container implements RemoteContainer {
   public SlaveContainer(Platform platform, String name, String url) throws IOException, NotBoundException {
     super(platform, name);
     if (platform.getNetworkInterface() == null) determineNetworkInterface(url);
+    enableRMI(true);
+    masterUrl = url;
+    attach(url);
+  }
+  
+  /**
+   * Creates a named slave container, runs its container stub on a specified port.
+   * 
+   * @param platform platform on which the container runs.
+   * @param name name of the container.
+   * @param port port on which the container's stub runs.
+   * @param url URL of master platform to connect to.
+   */
+  public SlaveContainer(Platform platform, String name, int port, String url) throws IOException, NotBoundException {
+    super(platform, name);
+    if (platform.getNetworkInterface() == null) determineNetworkInterface(url);
+    containerPort = port;
     enableRMI(true);
     masterUrl = url;
     attach(url);
@@ -248,7 +283,12 @@ public class SlaveContainer extends Container implements RemoteContainer {
     } catch (NotBoundException e) {
       // do nothing, since this is fine
     }
-    proxy = new RemoteContainerProxy(this);
+    if (containerPort != 0) {
+      proxy = new RemoteContainerProxy(this, containerPort);
+    }
+    else {
+      proxy = new RemoteContainerProxy(this);	
+    }
     Naming.rebind(myurl, proxy);
   }
 


### PR DESCRIPTION
Useful while SSH tunneling the remote containers running behind a NAT (or firewall)
