### PR TITLE
Adding a new param wsservpath to shell html

### DIFF
--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -32,7 +32,9 @@
   function setupHterm() {
     const term = new hterm.Terminal();
     term.onTerminalReady = function() {
-      const ws = new WebSocket('ws://'+window.location.hostname+':'+window.location.port+'/shell/ws/');
+      let params = new URLSearchParams(window.location.search.substring(1));
+      const wsservpath = params.get('wsservpath')|| '/shell/ws/';
+      const ws = new WebSocket('ws://'+window.location.hostname+':'+window.location.port+wsservpath);
       ws.onerror = (e) => {console.log('WebSocket error : ' + e.toString());};
       ws.onopen = () => {
         const io = this.io.push();


### PR DESCRIPTION
This optional query param will be used to decide where to look for the shell websocket server.

So for example just requesting for 

```html
<iframe src="/fjage/shell/index.html" style="width: 1024; height: 768; padding: 5; background: black;"></iframe>
```

will have the shell javascript trying to connect to `<host:port>/shell/ws/`.

But 

```html
<iframe src="/fjage/shell/index.html?wsservpath=/fjage/shell/ws/" style="width: 1024; height: 768; padding: 5; background: black;"></iframe>
```

will have the shell javascript trying to connect to `<host:port>/fjage/shell/ws/`.
