### PR TITLE
adding DefaultHandler as per Jetty docs

### DIFF
--- a/src/main/java/org/arl/fjage/connectors/WebServer.java
+++ b/src/main/java/org/arl/fjage/connectors/WebServer.java
@@ -78,7 +78,7 @@ public class WebServer {
   //////// instance attributes and methods
 
   protected Server server;
-  protected HandlerCollection contexts;
+  protected ContextHandlerCollection contexts;
   protected Map<String,ContextHandler> staticContexts = new HashMap<String,ContextHandler>();
   protected boolean started;
   protected int port;
@@ -88,8 +88,10 @@ public class WebServer {
     server = new Server(port);
     server.setStopAtShutdown(true);
     if (port > 0) servers.put(port, this);
-    contexts = new HandlerCollection(true);
-    server.setHandler(contexts);
+    contexts = new ContextHandlerCollection();
+    HandlerCollection handlers = new HandlerCollection();
+    handlers.setHandlers(new Handler[] { contexts, new DefaultHandler() });
+    server.setHandler(handlers);
     started = false;
   }
 


### PR DESCRIPTION
Jetty documents suggest having a `DefaultHandler ` at last the last `Handler` after every Collection of Handlers so that errors are caught and replied with a good 404 response.

> Notice that a HandlerList is used with the ResourceHandler and a DefaultHandler, so that the DefaultHandler generates a good 404 response for any requests that do not match a static resource.

https://www.eclipse.org/jetty/documentation/current/embedding-jetty.html