### PR TITLE
Fjagepy Test Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ compileGroovy {
 
 test {
   systemProperties project.properties.subMap(["manualJSTest"])
+  systemProperties project.properties.subMap(["manualPyTest"])
 }
 
 tasks.withType(Javadoc) {

--- a/src/main/python/fjagepy/__init__.py
+++ b/src/main/python/fjagepy/__init__.py
@@ -362,16 +362,16 @@ class Gateway:
 
     def _socket_reconnect(self, keepalive):
         if keepalive:
-            print('The master container is closed, trying to reconnect..\n')
+            self.logger.info('The master container is closed, trying to reconnect..\n')
             while True:
                 try:
                     self._socket_connect(self.hostname, self.port)
-                    print('Reconnected..')
+                    self.logger.info('Reconnected..')
                     break
                 except Exception as e:
                     _time.sleep(5)
         else:
-            print('The remote connection is closed..\n')
+            self.logger.info('The remote connection is closed..\n')
 
     def __recv_proc(self, q, subscribers):
         """Receive process.

--- a/src/test/groovy/org/arl/fjage/test/fjagepyTest.groovy
+++ b/src/test/groovy/org/arl/fjage/test/fjagepyTest.groovy
@@ -1,12 +1,10 @@
 package org.arl.fjage.test
 
 import org.arl.fjage.*
-import org.arl.fjage.remote.*
 import org.arl.fjage.remote.MasterContainer
 import org.junit.Test
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.assertFalse
 
+import static org.junit.Assert.assertTrue
 
 class fjagepyTest {
 
@@ -29,15 +27,23 @@ class fjagepyTest {
 	      }
 	    })
 	    def ret = 0;
-	    println "Running automated tests.";
-	    def proc = "python src/test/groovy/org/arl/fjage/test/BasicTests.py".execute();
-	    def sout = new StringBuilder(), serr = new StringBuilder()
-	    proc.consumeProcessOutput(sout, serr)
-	    proc.waitFor();
-	    ret = proc.exitValue();
-	    println "NPM : out> $sout err> $serr \n ret = $ret \n testStatus = $testStatus"
-	    platform.shutdown()
-    	assertTrue(ret == 0 && testStatus)
+		if (System.getProperty('manualPyTest') == null){
+			println "Running automated tests.";
+			def proc = "python src/test/groovy/org/arl/fjage/test/BasicTests.py".execute();
+			def sout = new StringBuilder(), serr = new StringBuilder()
+			proc.consumeProcessOutput(sout, serr)
+			proc.waitFor();
+			ret = proc.exitValue();
+			println "Python : out> $sout err> $serr \n ret = $ret \n testStatus = $testStatus"
+		}else{
+			println "waiting for user to run manual tests"
+			while (!testStatus){
+				platform.delay(1000)
+			}
+		}
+		container.shutdown()
+		platform.shutdown()
+		assertTrue(ret == 0 && testStatus)
   	}
 
 }


### PR DESCRIPTION
Cleaned up the fjagepy tests

- Changed the `print`s in the reconnection logic to `logger.info`
- Changed the fjagepy test to use Class level setup/teardown
- Changed the fjagepy test to send the "Success/Failure" after all the tests have passed instead of as part of one of the tests.
- Added support for manual fjagepy tests using the `manualPyTest ` flag.