### PR TITLE
fix(travis): using trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 sudo: false
 jdk:


### PR DESCRIPTION
oraclejdk8 isn't available on the latest `xenial` instances of Travis CI. Using `trusty` instead.

Fixed : https://travis-ci.org/org-arl/fjage/builds/538074837