### PR TITLE
Support for turning off scrollbars for WebUI

### DIFF
--- a/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
+++ b/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
@@ -205,7 +205,7 @@ public class WebSocketConnector implements Connector, WebSocketCreator {
 
     @OnWebSocketConnect
     public void onConnect(Session session) {
-      log.info("New connection from "+session.getRemoteAddress());
+      log.fine("New connection from "+session.getRemoteAddress());
       this.session = session;
       wsHandlers.add(this);
       if (listener != null) listener.connected(conn);
@@ -213,7 +213,7 @@ public class WebSocketConnector implements Connector, WebSocketCreator {
 
     @OnWebSocketClose
     public void onClose(int statusCode, String reason) {
-      log.info("Connection from "+session.getRemoteAddress()+" closed");
+      log.fine("Connection from "+session.getRemoteAddress()+" closed");
       session = null;
       wsHandlers.remove(this);
     }

--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -66,6 +66,9 @@
     term.decorate(document.querySelector('#terminal'));
     term.installKeyboard();
     term.setCursorBlink(true);
+    const urlParams = new URLSearchParams(window.location.search);
+    const scbVis = urlParams.get('scrollbar');
+    term.prefs_.set('scrollbar-visible', scbVis != "false");
     window.term = term;
   }
   function connectIO(io, term){


### PR DESCRIPTION
Using query parameters to support a `?scrollbar=false` query parameter on `shell/index.html` which will disable the scrollbars in the web shell.

Also turning down the log levels of WebSocketConnector for `onClose` and `onConnect` to reduce noise in logs.