### PR TITLE
Adding connection observer API for fjagejs

### DIFF
--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -312,12 +312,14 @@ export class Gateway {
     this.keepAlive = true;                // reconnect if websocket connection gets closed/errored
     this.debug = false;                   // debug info to be logged to console?
     this.aid = new AgentID('WebGW-'+_guid(4));         // gateway agent name
+    this.connListener;                    // callback when a socket connection gets opened and closed
     this._websockSetup(url);
     window.fjage.gateways.push(this);
   }
 
   _onWebsockOpen() {
     if(this.debug) console.log('Connected to ', this.sock.url);
+    if (this.connListener) this.connListener(true);
     this.sock.onclose = this._websockReconnect.bind(this);
     this.sock.onmessage = event => {
       this._onWebsockRx.call(this,event.data);
@@ -392,6 +394,7 @@ export class Gateway {
 
   _websockReconnect(){
     if (this._firstConn || !this.keepAlive || this.sock.readyState == this.sock.CONNECTING || this.sock.readyState == this.sock.OPEN) return;
+    if (this.connListener) this.connListener(false);
     if(this.debug) console.log('Reconnecting to ', this.sock.url);
     setTimeout(() => {
       this.pending = {};

--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -307,8 +307,8 @@ export class Gateway {
     this.pendingOnOpen = [];              // list of callbacks make as soon as gateway is open
     this.subscriptions = {};              // hashset for all topics that are subscribed
     this.listener = {};                   // set of callbacks that want to listen to incoming messages
-    this.msgObservers = [];               // external msgObservers wanting to listen incoming messages
-    this.connObservers = [];              // external connObservers for socket connection opening and closing
+    this.msgObservers = [];               // external observers wanting to listen incoming messages
+    this.connObservers = [];              // external observers for socket connection opening and closing
     this.queue = [];                      // incoming message queue
     this.keepAlive = true;                // reconnect if websocket connection gets closed/errored
     this.debug = false;                   // debug info to be logged to console?

--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -493,9 +493,9 @@ export class Gateway {
   }
 
   /**
-   * Add a new listener to listen to all {Message}s sent to this Gateway
+   * Add a new listener to get notified when the connection to master is created and terminated.
    *
-   * @param {function} listener - new callback/function to be called when a {Message} is received.
+   * @param {function} listener - new callback/function to be called connection to master is created and terminated.
    * @returns {void}
    */
   addConnListener(listener) {
@@ -503,7 +503,7 @@ export class Gateway {
   }
 
   /**
-   * Remove a message listener.
+   * Remove a connection listener.
    *
    * @param {function} listener - removes a previously registered listener/callback.
    * @returns {void}


### PR DESCRIPTION
`fjagejs` needs to have an API to allow the user to be notified if the websocket connection gets created or terminated.