### PR TITLE
Increase TX Timeout in fjagejs when WebSocket hasn't opened yet.

### DIFF
--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -431,7 +431,7 @@ export class Gateway {
       let timer = setTimeout(() => {
         delete this.pending[rq.id];
         reject(new Error('Receive Timeout : ' + rq));
-      }, TIMEOUT);
+      }, this.sock.readyState == this.sock.CONNECTING ? TIMEOUT : 2*TIMEOUT);
       this.pending[rq.id] = rsp => {
         clearTimeout(timer);
         resolve(rsp);

--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -431,7 +431,7 @@ export class Gateway {
       let timer = setTimeout(() => {
         delete this.pending[rq.id];
         reject(new Error('Receive Timeout : ' + rq));
-      }, this.sock.readyState == this.sock.CONNECTING ? TIMEOUT : 2*TIMEOUT);
+      }, this.sock.readyState == this.sock.CONNECTING ? 8*TIMEOUT : TIMEOUT);
       this.pending[rq.id] = rsp => {
         clearTimeout(timer);
         resolve(rsp);


### PR DESCRIPTION
Once in a while, when a WebSocket takes a while to set up, the first few `_websockTxRx ` requests end up in the pending queue and get timed out.

Adding a much larger TIMEOUT for `_websockTxRx ` requests which get sent while WebSocket is still in 'CONNECTING' state.