### PR TITLE
feat(webshell): add ability to serve a webshell to remote devices usi…

### DIFF
--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -77,8 +77,13 @@
     },50);
   }
   function connectIO(io, term){
+    const urlParams = new URLSearchParams(window.location.search);
+    var url = urlParams.get('url');
     const path = window.location.pathname.replace(/\/[^/]*$/, '/ws/');
-    const ws = new WebSocket('ws://'+window.location.hostname+':'+window.location.port+path);
+    if (!url){
+      url = window.location.hostname + ':' + window.location.port;
+    }
+    const ws = new WebSocket('ws://' + url + path);
     window.ws = ws;
     ws.onerror = () => {
       reconnectIO(io,term,ws);


### PR DESCRIPTION
…ng iframe query param

Adding support for 

```
<iframe src="/fjage/shell/index.html?url=192.168.0.1" class="terminal shell-frame"></iframe>
<iframe src="/fjage/shell/index.html?url=localhost:8082" class="terminal shell-frame"></iframe>
```

To allow the serving of WebShells to remote nodes. This is very handy in creating dashboards.