### PR TITLE
Adding support for ofs param on PutFileReq

### DIFF
--- a/src/main/java/org/arl/fjage/shell/PutFileReq.java
+++ b/src/main/java/org/arl/fjage/shell/PutFileReq.java
@@ -23,6 +23,7 @@ public class PutFileReq extends Message {
 
   private String filename = null;
   private byte[] contents = null;
+  private long ofs = 0;
 
   /**
    * Create an empty request for file write.
@@ -47,9 +48,21 @@ public class PutFileReq extends Message {
    * @param contents contents to write to the file (null to delete file).
    */
   public PutFileReq(String filename, byte[] contents) {
+   this(filename, contents, 0);
+  }
+
+  /**
+   * Create request for file write.
+   *
+   * @param filename name of the file to write.
+   * @param contents contents to write to the file (null to delete file).
+   * @param ofs offset within the file to write the contents to
+   */
+  public PutFileReq(String filename, byte[] contents, long ofs) {
     super(Performative.REQUEST);
     this.filename = filename;
     this.contents = contents;
+    this.ofs = ofs;
   }
 
   /**
@@ -60,9 +73,22 @@ public class PutFileReq extends Message {
    * @param contents contents to write to the file (null to delete file).
    */
   public PutFileReq(AgentID to, String filename, byte[] contents) {
+    this(to, filename, contents, 0);
+  }
+
+  /**
+   * Create request for file write.
+   *
+   * @param to shell agent id.
+   * @param filename name of the file to write.
+   * @param contents contents to write to the file (null to delete file).
+   * @param ofs offset within the file to write the contents to.
+   */
+  public PutFileReq(AgentID to, String filename, byte[] contents, long ofs) {
     super(to, Performative.REQUEST);
     this.filename = filename;
     this.contents = contents;
+    this.ofs = ofs;
   }
 
   /**
@@ -99,6 +125,24 @@ public class PutFileReq extends Message {
    */
   public void setContents(byte[] contents) {
     this.contents = contents;
+  }
+
+  /**
+   * Get the start location in file to write to.
+   *
+   * @return start locaion in file (negative for offset relative to end of file).
+   */
+  public long getOffset() {
+    return ofs;
+  }
+
+  /**
+   * Set the start location in file to write from.
+   *
+   * @param ofs start location in file (negative for offset relative to end of file).
+   */
+  public void setOffset(long ofs) {
+    this.ofs = ofs;
   }
 
 }

--- a/src/main/java/org/arl/fjage/shell/ShellAgent.java
+++ b/src/main/java/org/arl/fjage/shell/ShellAgent.java
@@ -13,11 +13,11 @@ package org.arl.fjage.shell;
 import org.arl.fjage.*;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.Callable;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.Path;
 
 /**
  * Shell agent runs in a container and allows execution of shell commands and scripts.
@@ -587,31 +587,49 @@ public class ShellAgent extends Agent {
     byte[] contents = req.getContents();
     File f = new File(filename);
     Message rsp = null;
-    FileOutputStream os = null;
+    Closeable os = null;
+    long ofs = req.getOffset();
     try {
-      if (contents == null) {
-        if (filename.endsWith("/") || filename.endsWith(File.separator)){
-          Path pathToBeDeleted = Paths.get(filename);
+      boolean fileIsDir = filename.endsWith("/") || filename.endsWith(File.separator);
+      if (fileIsDir) {
+        if (ofs == 0) {
+          if (contents == null) {
+            Path pathToBeDeleted = Paths.get(filename);
 
-          Files.walk(pathToBeDeleted)
-            .sorted(Comparator.reverseOrder())
-            .map(Path::toFile)
-            .forEach(File::delete);
+            Files.walk(pathToBeDeleted)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
 
-          rsp = new Message(req, Performative.AGREE);
-        }
-        else if (f.delete()) rsp = new Message(req, Performative.AGREE);
-      } else if (filename.endsWith("/") || filename.endsWith(File.separator)){
-        if(!f.exists()){
-          f.mkdir();
-          rsp = new Message(req, Performative.AGREE);
+            rsp = new Message(req, Performative.AGREE);
+          } else {
+            if (!f.exists()) rsp = new Message(req, f.mkdir() ? Performative.AGREE : Performative.FAILURE);
+          }
         }
       } else {
-        os = new FileOutputStream(f);
-        os.write(contents);
-        os.flush();
-        os.getFD().sync();
-        rsp = new Message(req, Performative.AGREE);
+        if (contents == null && ofs == 0) {
+          if (f.delete()) rsp = new Message(req, Performative.AGREE);
+        } else if (contents == null) {
+          os = new RandomAccessFile(f, "rw");
+          ((RandomAccessFile) os).setLength(ofs);
+          rsp = new Message(req, Performative.AGREE);
+        } else {
+          if (ofs == f.length()) {
+            // Append if ofs != 0
+            os = new FileOutputStream(f, ofs != 0);
+            ((FileOutputStream) os).write(contents);
+            ((FileOutputStream) os).flush();
+            ((FileOutputStream) os).getFD().sync();
+          } else {
+            // Overwrite if ofs == 0
+            os = new RandomAccessFile(f, "rw");
+            if (ofs > 0) ((RandomAccessFile) os).skipBytes((int) ofs);
+            else if (ofs < 0) ((RandomAccessFile) os).skipBytes((int) (f.length() - ofs));
+            ((RandomAccessFile) os).write(contents);
+            ((RandomAccessFile) os).getFD().sync();
+          }
+          rsp = new Message(req, Performative.AGREE);
+        }
       }
     } catch (IOException ex) {
       log.warning(ex.toString());

--- a/src/test/java/org/arl/fjage/test/BasicTests.java
+++ b/src/test/java/org/arl/fjage/test/BasicTests.java
@@ -93,10 +93,10 @@ public class BasicTests {
     AgentID c = new AgentID("C");
     AgentID s = new AgentID("S");
     assertTrue(master.containsAgent(s));
-    assertTrue(!master.containsAgent(c));
+    assertFalse(master.containsAgent(c));
     assertTrue(master.canLocateAgent(c));
     assertTrue(slave.containsAgent(c));
-    assertTrue(!slave.containsAgent(s));
+    assertFalse(slave.containsAgent(s));
     assertTrue(slave.canLocateAgent(s));
     while (!client.done)
       platform.delay(DELAY);
@@ -298,27 +298,27 @@ public class BasicTests {
     store.put(new Bean2(10));
     store.put(new Bean2(7));
     List<Bean1> recs1 = store.getByType(Bean1.class);
-    assertTrue(recs1.size() == 3);
+    assertEquals(3, recs1.size());
     List<Bean2> recs2 = store.getByType(Bean2.class);
-    assertTrue(recs2.size() == 4);
+    assertEquals(4, recs2.size());
     Bean2 b2 = store.getById(Bean2.class, "7");
-    assertTrue(b2.x == 7);
+    assertEquals(7, b2.x);
     store.remove(b2);
     b2 = store.getById(Bean2.class, "7");
-    assertTrue(b2 == null);
-    assertTrue(store.getById(Bean2.class, "8") != null);
+    assertNull(b2);
+    assertNotNull(store.getById(Bean2.class, "8"));
     store.removeById(Bean2.class, "8");
-    assertTrue(store.getById(Bean2.class, "8") == null);
-    assertTrue(store.getById(Bean2.class, "9") != null);
+    assertNull(store.getById(Bean2.class, "8"));
+    assertNotNull(store.getById(Bean2.class, "9"));
     store.removeByType(Bean1.class);
     recs1 = store.getByType(Bean1.class);
-    assertTrue(recs1.size() == 0);
-    assertTrue(store.getById(Bean2.class, "9") != null);
+    assertEquals(0, recs1.size());
+    assertNotNull(store.getById(Bean2.class, "9"));
     assertTrue(store.size() > 0);
     store.delete();
     store = Store.getInstance(agent);
-    assertTrue(store.getById(Bean2.class, "9") == null);
-    assertTrue(store.size() == 0);
+    assertNull(store.getById(Bean2.class, "9"));
+    assertEquals(0, store.size());
     store.close();
   }
 
@@ -464,7 +464,10 @@ public class BasicTests {
               log.info("get data: "+new String(contents));
               get = true;
               for (int i = 0; i < contents.length; i++)
-                if (contents[i] != bytes[i]) get = false;
+                if (contents[i] != bytes[i]) {
+                  get = false;
+                  break;
+                }
             }
           }
           req = new GetFileReq(shell, DIRNAME+File.separator+FILENAME, 5, 4);
@@ -477,7 +480,10 @@ public class BasicTests {
               log.info("get data: "+new String(contents));
               get2 = true;
               for (int i = 0; i < contents.length; i++)
-                if (contents[i] != bytes[5+i]) get2 = false;
+                if (contents[i] != bytes[5 + i]) {
+                  get2 = false;
+                  break;
+                }
             }
           }
           req = new GetFileReq(shell, DIRNAME+File.separator+FILENAME, 9, 0);
@@ -490,7 +496,10 @@ public class BasicTests {
               log.info("get data: "+new String(contents));
               get3 = true;
               for (int i = 0; i < contents.length; i++)
-                if (contents[i] != bytes[9+i]) get3 = false;
+                if (contents[i] != bytes[9 + i]) {
+                  get3 = false;
+                  break;
+                }
             }
           }
           req = new GetFileReq(shell, DIRNAME+File.separator+FILENAME, 27, 1);


### PR DESCRIPTION
Adding support for a `ofs` param on `PutFileReq`, which allows appending, overwriting and truncating files.

This will enable the solution for #83

Behaviour : 

File:
`contents == null` && `ofs ==0` => Delete File
`contents == null` && `ofs !=0` => Truncate File after `ofs`
`contents != null` => Overwrite/Append File with `content` after `ofs` 

Dir :
`ofs!=0`  => REFUSE