### PR TITLE
fix(shell):fix to overwrite file contents in PutFileReq

### DIFF
--- a/src/main/java/org/arl/fjage/shell/ShellAgent.java
+++ b/src/main/java/org/arl/fjage/shell/ShellAgent.java
@@ -623,8 +623,8 @@ public class ShellAgent extends Agent {
           } else {
             // Overwrite if ofs == 0
             os = new RandomAccessFile(f, "rw");
-            ((RandomAccessFile) os).setLength(ofs);
-            if (ofs > 0) ((RandomAccessFile) os).skipBytes((int) ofs);
+            if(ofs == 0)((RandomAccessFile) os).setLength(ofs);
+            else if (ofs > 0) ((RandomAccessFile) os).skipBytes((int) ofs);
             else if (ofs < 0) ((RandomAccessFile) os).skipBytes((int) (f.length() - ofs));
             ((RandomAccessFile) os).write(contents);
             ((RandomAccessFile) os).getFD().sync();

--- a/src/main/java/org/arl/fjage/shell/ShellAgent.java
+++ b/src/main/java/org/arl/fjage/shell/ShellAgent.java
@@ -623,6 +623,7 @@ public class ShellAgent extends Agent {
           } else {
             // Overwrite if ofs == 0
             os = new RandomAccessFile(f, "rw");
+            ((RandomAccessFile) os).setLength(ofs);
             if (ofs > 0) ((RandomAccessFile) os).skipBytes((int) ofs);
             else if (ofs < 0) ((RandomAccessFile) os).skipBytes((int) (f.length() - ofs));
             ((RandomAccessFile) os).write(contents);

--- a/src/main/java/org/arl/fjage/shell/ShellAgent.java
+++ b/src/main/java/org/arl/fjage/shell/ShellAgent.java
@@ -623,9 +623,9 @@ public class ShellAgent extends Agent {
           } else {
             // Overwrite if ofs == 0
             os = new RandomAccessFile(f, "rw");
-            if(ofs == 0)((RandomAccessFile) os).setLength(ofs);
-            else if (ofs > 0) ((RandomAccessFile) os).skipBytes((int) ofs);
-            else if (ofs < 0) ((RandomAccessFile) os).skipBytes((int) (f.length() - ofs));
+            if(ofs >= 0)((RandomAccessFile) os).setLength(ofs + contents.length);
+            if (ofs > 0) ((RandomAccessFile) os).skipBytes((int) ofs);
+            else if (ofs < 0) ((RandomAccessFile) os).skipBytes((int) (f.length() + ofs));
             ((RandomAccessFile) os).write(contents);
             ((RandomAccessFile) os).getFD().sync();
           }

--- a/src/test/groovy/org/arl/fjage/test/spec/fjageSpec.js
+++ b/src/test/groovy/org/arl/fjage/test/spec/fjageSpec.js
@@ -3,6 +3,7 @@ import { Performative, AgentID, Message, Gateway, MessageClass } from '../../fja
 const DIRNAME = '/tmp';
 const FILENAME = 'fjage-test.txt';
 const TEST_STRING = 'this is a test';
+const NEW_STRING = 'new test';
 const GetFileReq = MessageClass('org.arl.fjage.shell.GetFileReq');
 const GetFileRsp = MessageClass('org.arl.fjage.shell.GetFileRsp');
 const ShellExecReq = MessageClass('org.arl.fjage.shell.ShellExecReq');
@@ -407,6 +408,117 @@ describe('Shell GetFile/PutFile', function () {
       expect(rsp2).not.toBeNull();
       rsp2.then((msg) => {
         expect(msg.perf).toEqual(Performative.FAILURE);
+        done();
+      }).catch((ex) => {
+        console.error(ex);
+        fail();
+      });
+    });
+  });
+
+  it('should be able to append a file using PutFileReq', function (done) {
+    const pfr = new PutFileReq();
+    pfr.recipient = shell;
+    pfr.filename = DIRNAME + '/' + FILENAME;
+    pfr.contents = Array.from((new TextEncoder('utf-8').encode(TEST_STRING + ' ' + TEST_STRING)));
+    const rsp = gw.request(pfr);
+    expect(rsp).not.toBeNull();
+    rsp.then(msg => {
+      expect(msg).toBeTruthy();
+      expect(msg.perf).toEqual(Performative.AGREE);
+      var gfr = new GetFileReq();
+      gfr.recipient = shell;
+      gfr.filename = DIRNAME + '/' + FILENAME;
+      const rsp2 = gw.request(gfr);
+      expect(rsp2).not.toBeNull();
+      rsp2.then((msg) => {
+        expect(msg instanceof GetFileRsp).toBeTruthy();
+        expect(msg.contents).not.toBeUndefined();
+        expect(new TextDecoder('utf-8').decode(new Uint8Array(msg.contents))).toEqual(TEST_STRING + ' ' + TEST_STRING);
+        done();
+      }).catch((ex) => {
+        console.error(ex);
+        fail();
+      });
+    });
+  });
+
+  it('should be able to save the file using PutFileReq when some content is removed', function (done) {
+    const pfr = new PutFileReq();
+    pfr.recipient = shell;
+    pfr.filename = DIRNAME + '/' + FILENAME;
+    pfr.contents = Array.from((new TextEncoder('utf-8').encode(TEST_STRING.slice(-4))));
+    const rsp = gw.request(pfr);
+    expect(rsp).not.toBeNull();
+    rsp.then(msg => {
+      expect(msg).toBeTruthy();
+      expect(msg.perf).toEqual(Performative.AGREE);
+      var gfr = new GetFileReq();
+      gfr.recipient = shell;
+      gfr.filename = DIRNAME + '/' + FILENAME;
+      const rsp2 = gw.request(gfr);
+      expect(rsp2).not.toBeNull();
+      rsp2.then((msg) => {
+        expect(msg instanceof GetFileRsp).toBeTruthy();
+        expect(msg.contents).not.toBeUndefined();
+        expect(new TextDecoder('utf-8').decode(new Uint8Array(msg.contents))).toEqual(TEST_STRING.slice(-4));
+        done();
+      }).catch((ex) => {
+        console.error(ex);
+        fail();
+      });
+    });
+  });
+
+  it('should be able to append the file using PutFileReq using offset', function (done) {
+    const pfr = new PutFileReq();
+    pfr.recipient = shell;
+    pfr.filename = DIRNAME + '/' + FILENAME;
+    pfr.ofs = 10;
+    pfr.contents = Array.from((new TextEncoder('utf-8').encode(TEST_STRING)));
+    const rsp = gw.request(pfr);
+    expect(rsp).not.toBeNull();
+    rsp.then(msg => {
+      expect(msg).toBeTruthy();
+      expect(msg.perf).toEqual(Performative.AGREE);
+      var gfr = new GetFileReq();
+      gfr.recipient = shell;
+      gfr.filename = DIRNAME + '/' + FILENAME;
+      const rsp2 = gw.request(gfr);
+      expect(rsp2).not.toBeNull();
+      rsp2.then((msg) => {
+        expect(msg instanceof GetFileRsp).toBeTruthy();
+        expect(msg.contents).not.toBeUndefined();
+        expect(new TextDecoder('utf-8').decode(new Uint8Array(msg.contents))).toEqual(TEST_STRING.substring(0,10)+TEST_STRING);
+        done();
+      }).catch((ex) => {
+        console.error(ex);
+        fail();
+      });
+    });
+  });
+
+  it('should be able to append the file using PutFileReq using offset less than 0', function (done) {
+    const pfr = new PutFileReq();
+    pfr.recipient = shell;
+    pfr.filename = DIRNAME + '/' + FILENAME;
+    pfr.ofs = -4;
+    pfr.contents = Array.from((new TextEncoder('utf-8').encode(NEW_STRING)));
+    const rsp = gw.request(pfr);
+    expect(rsp).not.toBeNull();
+    rsp.then(msg => {
+      expect(msg).toBeTruthy();
+      expect(msg.perf).toEqual(Performative.AGREE);
+      var gfr = new GetFileReq();
+      gfr.recipient = shell;
+      gfr.filename = DIRNAME + '/' + FILENAME;
+      const rsp2 = gw.request(gfr);
+      expect(rsp2).not.toBeNull();
+      rsp2.then((msg) => {
+        expect(msg instanceof GetFileRsp).toBeTruthy();
+        expect(msg.contents).not.toBeUndefined();
+        expect(msg.contents.length).toBe(TEST_STRING.length-4+NEW_STRING.length);
+        expect(new TextDecoder('utf-8').decode(new Uint8Array(msg.contents))).toEqual(TEST_STRING.substring(0,10) + NEW_STRING);
         done();
       }).catch((ex) => {
         console.error(ex);

--- a/src/test/groovy/org/arl/fjage/test/spec/fjageSpec.js
+++ b/src/test/groovy/org/arl/fjage/test/spec/fjageSpec.js
@@ -416,7 +416,7 @@ describe('Shell GetFile/PutFile', function () {
     });
   });
 
-  it('should be able to append a file using PutFileReq', function (done) {
+  it('should be able to edit the file correctly using PutFileReq when offset is 0', function (done) {
     const pfr = new PutFileReq();
     pfr.recipient = shell;
     pfr.filename = DIRNAME + '/' + FILENAME;
@@ -443,7 +443,7 @@ describe('Shell GetFile/PutFile', function () {
     });
   });
 
-  it('should be able to save the file using PutFileReq when some content is removed', function (done) {
+  it('should be able to update the file correctly using PutFileReq when some content is removed', function (done) {
     const pfr = new PutFileReq();
     pfr.recipient = shell;
     pfr.filename = DIRNAME + '/' + FILENAME;
@@ -470,7 +470,7 @@ describe('Shell GetFile/PutFile', function () {
     });
   });
 
-  it('should be able to append the file using PutFileReq using offset', function (done) {
+  it('should be able to edit the file correctly using PutFileReq when offset greater than 0', function (done) {
     const pfr = new PutFileReq();
     pfr.recipient = shell;
     pfr.filename = DIRNAME + '/' + FILENAME;
@@ -498,7 +498,7 @@ describe('Shell GetFile/PutFile', function () {
     });
   });
 
-  it('should be able to append the file using PutFileReq using offset less than 0', function (done) {
+  it('should be able to edit the file correctly using PutFileReq when offset less than 0', function (done) {
     const pfr = new PutFileReq();
     pfr.recipient = shell;
     pfr.filename = DIRNAME + '/' + FILENAME;


### PR DESCRIPTION
When some content is removed from a file, the `RandomAccessFile` was not saving the file correctly with the modified content. Adding `setLength(ofs)`, where ofs value is 0, seems to fix the issue.