### PR TITLE
fjage.js: defensive check for null in _decodeBase64()

### DIFF
--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -70,6 +70,9 @@ function _b64toArray(base64, dtype, littleEndian=true) {
 
 // base 64 JSON decoder
 function _decodeBase64(k, d) {
+  if (d === null) {
+    return null;
+  }
   if (typeof d == 'object' && 'clazz' in d) {
     let clazz = d.clazz;
     if (clazz.startsWith('[') && clazz.length == 2 && 'data' in d) {


### PR DESCRIPTION
# Sample error

Location: `fjage.js` `_decodeBase64()`
```
JSON Parsing error: TypeError: right-hand side of 'in' should be an object, got null
JSON : {"id":"a6145a373f06d7b85783585800eb66e0","inResponseTo":"agentForService","agentID":"remote","message":null}
```

# Probable cause
`typeof null` evaluates to `'object'`.