### PR TITLE
Fjagejs inheritance

### DIFF
--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -3,86 +3,6 @@
 const TIMEOUT = 1000;              // ms, timeout to get response from to master container
 const RECONNECT_TIME = 5000;       // ms, delay between retries to connect to the server.
 
-////// global
-
-if (typeof window.fjage === 'undefined') {
-  window.fjage = {};
-  window.fjage.gateways = [];
-  window.fjage.MessageClass = MessageClass;
-  window.fjage.getGateway = function (url){
-    var f = window.fjage.gateways.filter(g => g.sock.url == url);
-    if (f.length ) return f[0];
-  };
-}
-
-////// private utilities
-
-// generate random ID with length 4*len characters
-function _guid(len) {
-  function s4() {
-    return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
-  }
-  let s = s4();
-  for (var i = 0; i < len-1; i++)
-    s += s4();
-  return s;
-}
-
-// convert from base 64 to array
-function _b64toArray(base64, dtype, littleEndian=true) {
-  let s =  window.atob(base64);
-  let len = s.length;
-  let bytes = new Uint8Array(len);
-  for (var i = 0; i < len; i++)
-    bytes[i] = s.charCodeAt(i);
-  let rv = [];
-  let view = new DataView(bytes.buffer);
-  switch (dtype) {
-  case '[B': // byte array
-    for (i = 0; i < len; i++)
-      rv.push(view.getUint8(i));
-    break;
-  case '[S': // short array
-    for (i = 0; i < len; i+=2)
-      rv.push(view.getInt16(i, littleEndian));
-    break;
-  case '[I': // integer array
-    for (i = 0; i < len; i+=4)
-      rv.push(view.getInt32(i, littleEndian));
-    break;
-  case '[J': // long array
-    for (i = 0; i < len; i+=8)
-      rv.push(view.getInt64(i, littleEndian));
-    break;
-  case '[F': // float array
-    for (i = 0; i < len; i+=4)
-      rv.push(view.getFloat32(i, littleEndian));
-    break;
-  case '[D': // double array
-    for (i = 0; i < len; i+=8)
-      rv.push(view.getFloat64(i, littleEndian));
-    break;
-  default:
-    return;
-  }
-  return rv;
-}
-
-// base 64 JSON decoder
-function _decodeBase64(k, d) {
-  if (d === null) {
-    return null;
-  }
-  if (typeof d == 'object' && 'clazz' in d) {
-    let clazz = d.clazz;
-    if (clazz.startsWith('[') && clazz.length == 2 && 'data' in d) {
-      let x = _b64toArray(d.data, d.clazz);
-      if (x) d = x;
-    }
-  }
-  return d;
-}
-
 ////// interface classes
 
 /**
@@ -269,9 +189,6 @@ export class Message {
     return rv;
   }
 }
-
-Message.__clazz__ = 'org.arl.fjage.Message';
-if (!window['Message']) window['Message'] = Message;
 
 /**
  * A message class that can convey generic messages represented by key-value pairs.
@@ -743,4 +660,86 @@ export function MessageClass(name, parent=Message) {
   };
   window[sname].__clazz__ = name;
   return window[sname];
+}
+
+////// global
+
+if (typeof window.fjage === 'undefined') {
+  window.fjage = {};
+  window.fjage.gateways = [];
+  window.fjage.MessageClass = MessageClass;
+  window.fjage.getGateway = function (url){
+    var f = window.fjage.gateways.filter(g => g.sock.url == url);
+    if (f.length ) return f[0];
+  };
+  Message.__clazz__ = 'org.arl.fjage.Message';
+  window['Message'] = Message;
+}
+
+////// private utilities
+
+// generate random ID with length 4*len characters
+function _guid(len) {
+  function s4() {
+    return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+  }
+  let s = s4();
+  for (var i = 0; i < len-1; i++)
+    s += s4();
+  return s;
+}
+
+// convert from base 64 to array
+function _b64toArray(base64, dtype, littleEndian=true) {
+  let s =  window.atob(base64);
+  let len = s.length;
+  let bytes = new Uint8Array(len);
+  for (var i = 0; i < len; i++)
+    bytes[i] = s.charCodeAt(i);
+  let rv = [];
+  let view = new DataView(bytes.buffer);
+  switch (dtype) {
+  case '[B': // byte array
+    for (i = 0; i < len; i++)
+      rv.push(view.getUint8(i));
+    break;
+  case '[S': // short array
+    for (i = 0; i < len; i+=2)
+      rv.push(view.getInt16(i, littleEndian));
+    break;
+  case '[I': // integer array
+    for (i = 0; i < len; i+=4)
+      rv.push(view.getInt32(i, littleEndian));
+    break;
+  case '[J': // long array
+    for (i = 0; i < len; i+=8)
+      rv.push(view.getInt64(i, littleEndian));
+    break;
+  case '[F': // float array
+    for (i = 0; i < len; i+=4)
+      rv.push(view.getFloat32(i, littleEndian));
+    break;
+  case '[D': // double array
+    for (i = 0; i < len; i+=8)
+      rv.push(view.getFloat64(i, littleEndian));
+    break;
+  default:
+    return;
+  }
+  return rv;
+}
+
+// base 64 JSON decoder
+function _decodeBase64(k, d) {
+  if (d === null) {
+    return null;
+  }
+  if (typeof d == 'object' && 'clazz' in d) {
+    let clazz = d.clazz;
+    if (clazz.startsWith('[') && clazz.length == 2 && 'data' in d) {
+      let x = _b64toArray(d.data, d.clazz);
+      if (x) d = x;
+    }
+  }
+  return d;
 }

--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -644,7 +644,6 @@ export class Gateway {
  */
 export function MessageClass(name, parent=Message) {
   let sname = name.replace(/^.*\./, '');
-  if (window[sname]) return window[sname];
   let pname = parent.__clazz__.replace(/^.*\./, '');
   window[sname] = class extends window[pname] {
     constructor(params) {

--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -270,6 +270,9 @@ export class Message {
   }
 }
 
+Message.__clazz__ = 'org.arl.fjage.Message';
+if (!window['Message']) window['Message'] = Message;
+
 /**
  * A message class that can convey generic messages represented by key-value pairs.
  * @extends Message
@@ -719,11 +722,14 @@ export class Gateway {
 /**
  * Creates a unqualified message class based on a fully qualified name.
  * @param {string} name - fully qualified name of the message class to be created.
+ * @param {string} [parent] - Class of the parent MessageClass to inherit from.
  * @returns {function} constructor for the unqualified message class.
  */
-export function MessageClass(name) {
+export function MessageClass(name, parent=Message) {
   let sname = name.replace(/^.*\./, '');
-  window[sname] = class extends Message {
+  if (window[sname]) return window[sname];
+  let pname = parent.__clazz__.replace(/^.*\./, '');
+  window[sname] = class extends window[pname] {
     constructor(params) {
       super();
       this.__clazz__ = name;

--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -637,6 +637,13 @@ export class Gateway {
 }
 
 /**
+ * Services supported by fjage agents.
+ */
+export const Services = {
+  SHELL : 'org.arl.fjage.shell.Services.SHELL'
+};
+
+/**
  * Creates a unqualified message class based on a fully qualified name.
  * @param {string} name - fully qualified name of the message class to be created.
  * @param {string} [parent] - Class of the parent MessageClass to inherit from.

--- a/src/test/groovy/org/arl/fjage/test/spec/.eslintrc
+++ b/src/test/groovy/org/arl/fjage/test/spec/.eslintrc
@@ -8,9 +8,6 @@
             "ecmaVersion": 2017,
             "sourceType": "module"
     },
-    "plugins": [
-            "html"
-    ],
     "extends": "eslint:recommended",
     "rules": {
         "no-console": 0,

--- a/src/test/groovy/org/arl/fjage/test/spec/fjageSpec.js
+++ b/src/test/groovy/org/arl/fjage/test/spec/fjageSpec.js
@@ -28,7 +28,7 @@ function fjageMessageChecker() {
 
       if (!msg.message) return ret;
 
-      ret = ret && (!msg.message.clazz || typeof msg.message.clazz === "string");
+      ret = ret && (!msg.message.clazz || typeof msg.message.clazz === 'string');
 
       if (!msg.message.data) return ret;
 
@@ -254,6 +254,32 @@ describe('A Message', function () {
     const txMsg = new TxFrameReq();
     expect(msg1).toEqual(msg2);
     expect(Message._deserialize(txMsg._serialize())).toEqual(txMsg);
+  });
+});
+
+describe('A MessageClass', function () {
+  it('should be able to create a custom Message', function () {
+    expect(() => {
+      let msgName = 'NewMessage';
+      const NewMessage = MessageClass(msgName);
+      expect(typeof NewMessage).toEqual('function');
+      expect(NewMessage.__clazz__).toEqual(msgName);
+      let nm = new NewMessage();
+    }).not.toThrow();
+  });
+
+  it('should be able to create a custom Message with parent Message', function () {
+    expect(() => {
+      let msgName = 'New2Message';
+      let parentName = 'ParentMessage';
+      const ParentMessage = MessageClass(parentName);
+      const NewMessage = MessageClass(msgName, ParentMessage);
+      expect(typeof NewMessage).toEqual('function');
+      expect(NewMessage.__clazz__).toEqual(msgName);
+      let nm = new NewMessage();
+      expect(nm instanceof NewMessage).toBeTruthy();
+      expect(nm instanceof ParentMessage).toBeTruthy();
+    }).not.toThrow();
   });
 });
 


### PR DESCRIPTION
Support for inheritance in fjagejs MessageClass using an optional second parameter in the function. For eg. `MessageClass(classname, parentname)`

The diff looks huge, but most of the changes are because of reorganizing fjage.js to move all the exports to the top of the file.

Also added a `Services` class which exports the SHELL Service.