### PR TITLE
fix(gateway): fix indexing in message queue get operation in fjage.c …

### DIFF
--- a/gateways/c/fjage.c
+++ b/gateways/c/fjage.c
@@ -256,8 +256,7 @@ static fjage_msg_t mqueue_get(fjage_gw_t gw, const char* clazz, const char* id) 
   if (gw == NULL) return NULL;
   _fjage_gw_t* fgw = gw;
   fjage_msg_t msg = NULL;
-  for (int i = fgw->mqueue_tail; i != fgw->mqueue_head && msg == NULL;) {
-    i = (i + 1) % QUEUE_LEN;
+  for (int i = fgw->mqueue_tail; i != fgw->mqueue_head && msg == NULL; i = (i + 1) % QUEUE_LEN) {
     if (fgw->mqueue[i] != NULL) {
       if (clazz != NULL) {
         const char* clazz1 = fjage_msg_get_clazz(fgw->mqueue[i]);
@@ -287,8 +286,7 @@ static fjage_msg_t mqueue_get_any(fjage_gw_t gw, const char** clazzes, int clazz
   _fjage_gw_t* fgw = gw;
   fjage_msg_t msg = NULL;
   if (clazzes == NULL || clazzlen < 1) return msg;
-  for (int i = fgw->mqueue_tail; i != fgw->mqueue_head && msg == NULL;) {
-    i = (i+1)%QUEUE_LEN;
+  for (int i = fgw->mqueue_tail; i != fgw->mqueue_head && msg == NULL; i = (i + 1) % QUEUE_LEN) {
     if (fgw->mqueue[i] != NULL) {
       const char* clazz1 = fjage_msg_get_clazz(fgw->mqueue[i]);
       if (clazz1 == NULL || ! mqueue_compare_any(clazz1, clazzes, clazzlen)) continue;

--- a/gateways/c/fjage.c
+++ b/gateways/c/fjage.c
@@ -256,8 +256,8 @@ static fjage_msg_t mqueue_get(fjage_gw_t gw, const char* clazz, const char* id) 
   if (gw == NULL) return NULL;
   _fjage_gw_t* fgw = gw;
   fjage_msg_t msg = NULL;
-  for (int i = fgw->mqueue_tail; i != fgw->mqueue_head && msg == NULL; i++) {
-    if (i >= QUEUE_LEN) i = i%QUEUE_LEN;
+  for (int i = fgw->mqueue_tail; i != fgw->mqueue_head && msg == NULL;) {
+    i = (i + 1) % QUEUE_LEN;
     if (fgw->mqueue[i] != NULL) {
       if (clazz != NULL) {
         const char* clazz1 = fjage_msg_get_clazz(fgw->mqueue[i]);
@@ -287,8 +287,8 @@ static fjage_msg_t mqueue_get_any(fjage_gw_t gw, const char** clazzes, int clazz
   _fjage_gw_t* fgw = gw;
   fjage_msg_t msg = NULL;
   if (clazzes == NULL || clazzlen < 1) return msg;
-  for (int i = fgw->mqueue_tail; i != fgw->mqueue_head && msg == NULL; i++) {
-    if (i >= QUEUE_LEN) i = i%QUEUE_LEN;
+  for (int i = fgw->mqueue_tail; i != fgw->mqueue_head && msg == NULL;) {
+    i = (i+1)%QUEUE_LEN;
     if (fgw->mqueue[i] != NULL) {
       const char* clazz1 = fjage_msg_get_clazz(fgw->mqueue[i]);
       if (clazz1 == NULL || ! mqueue_compare_any(clazz1, clazzes, clazzlen)) continue;

--- a/gateways/c/fjage.c
+++ b/gateways/c/fjage.c
@@ -257,6 +257,7 @@ static fjage_msg_t mqueue_get(fjage_gw_t gw, const char* clazz, const char* id) 
   _fjage_gw_t* fgw = gw;
   fjage_msg_t msg = NULL;
   for (int i = fgw->mqueue_tail; i != fgw->mqueue_head && msg == NULL; i++) {
+    if (i >= QUEUE_LEN) i = i%QUEUE_LEN;
     if (fgw->mqueue[i] != NULL) {
       if (clazz != NULL) {
         const char* clazz1 = fjage_msg_get_clazz(fgw->mqueue[i]);
@@ -287,13 +288,13 @@ static fjage_msg_t mqueue_get_any(fjage_gw_t gw, const char** clazzes, int clazz
   fjage_msg_t msg = NULL;
   if (clazzes == NULL || clazzlen < 1) return msg;
   for (int i = fgw->mqueue_tail; i != fgw->mqueue_head && msg == NULL; i++) {
+    if (i >= QUEUE_LEN) i = i%QUEUE_LEN;
     if (fgw->mqueue[i] != NULL) {
       const char* clazz1 = fjage_msg_get_clazz(fgw->mqueue[i]);
       if (clazz1 == NULL || ! mqueue_compare_any(clazz1, clazzes, clazzlen)) continue;
       msg = fgw->mqueue[i];
       fgw->mqueue[i] = NULL;
       if (i == fgw->mqueue_tail) fgw->mqueue_tail = (fgw->mqueue_tail+1) % QUEUE_LEN;
-      // break out
     }
   }
   return msg;


### PR DESCRIPTION
…gateway causing errors

This bug was found when long-running instances of `fjage.c` based gateways would crash with a segfault inside a `strcmp` called by `mqueue_get_any`. 

Investigating deeper it was discovered that this happened with the loop searching for messages in `mqueue` accessed memory outside the `mqueue` array because of this indexing error.