### PR TITLE
Update __init__.py

### DIFF
--- a/gateways/python/fjagepy/__init__.py
+++ b/gateways/python/fjagepy/__init__.py
@@ -205,7 +205,7 @@ class AgentID:
 
 def getter(self, param):
     rsp = self.request(ParameterReq(index=self.index).get(param))
-    if (rsp is None) or (rsp.__dict__['param'] is None and rsp.__dict__['value'] is None):
+    if (rsp is None) or (rsp.perf is not Performative.INFORM) or (rsp.__dict__['param'] is None and rsp.__dict__['value'] is None):
         return None
     ursp = ParameterRsp()
     ursp.__dict__.update(rsp.__dict__)
@@ -223,7 +223,7 @@ def setter(self, param, value):
         self.__dict__[param] = value
         return value
     rsp = self.request(ParameterReq(index=self.index).set(param, value))
-    if (rsp is None) or (rsp.__dict__['param'] is None and rsp.__dict__['value'] is None):
+    if (rsp is None) or (rsp.perf is not Performative.INFORM) or (rsp.__dict__['param'] is None and rsp.__dict__['value'] is None):
         _warn('Could not set parameter ' + param)
         return None
     ursp = ParameterRsp()


### PR DESCRIPTION
Checking for response message types before trying to access the `.dict['param']`. Otherwise, this throws an error. 

```
Traceback (most recent call last):
  ...
  File "verification.py", line 433, in check_post
    if phy.post is None:
  File "/Users/chinmay/Library/Python/3.8/lib/python/site-packages/fjagepy/__init__.py", line 207, in getter
    if (rsp is None) or (rsp.__dict__['param'] is None and rsp.__dict__['value'] is None):
KeyError: 'param'
```