### PR TITLE
Fjagejs events

### DIFF
--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -493,7 +493,7 @@ export class Gateway {
     return new Promise(resolve => {
       let timer = setTimeout(() => {
         delete this.pending[rq.id];
-        console.log('Receive Timeout : ' + rq);
+        if (this.debug) console.log('Receive Timeout : ' + rq);
         resolve();
       }, this.sock.readyState == this.sock.CONNECTING ? 8*this._timeout : this._timeout);
       this.pending[rq.id] = rsp => {
@@ -762,7 +762,7 @@ export class Gateway {
       if (timeout > 0){
         timer = setTimeout(() => {
           delete this.listener[lid];
-          console.log('Receive Timeout : ' + filter);
+          if (this.debug) console.log('Receive Timeout : ' + filter);
           resolve();
         }, timeout);
       }

--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -447,6 +447,9 @@ export class Gateway {
       this.sock = new WebSocket(url);
       this.sock.onerror = this._websockReconnect.bind(this);
       this.sock.onopen = this._onWebsockOpen.bind(this);
+      this.sock.onclose = () => {
+        this._sendEvent('conn', false);
+      };
     } catch (error) {
       if(this.debug) console.log('Connection failed to ', this.sock.url);
       return;

--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -353,8 +353,8 @@ export class Gateway {
   _sendEvent(type, val) {
     if (Array.isArray(this.eventListeners[type])) {
       this.eventListeners[type].forEach(l => {
-        l && {}.toString.call(l) === '[object Function]' && l(val)
-      })
+        l && {}.toString.call(l) === '[object Function]' && l(val);
+      });
     }
   }
 
@@ -376,14 +376,14 @@ export class Gateway {
   _onWebsockRx(data) {
     var obj;
     if (this.debug) console.log('< '+data);
-    this._sendEvent('rx', data)
+    this._sendEvent('rx', data);
     try {
       obj = JSON.parse(data, _decodeBase64);
     }catch(e){
       console.warn('JSON Parsing error: ' + e + '\nJSON : ' + data);
       return;
     }
-    this._sendEvent('rxp', obj)
+    this._sendEvent('rxp', obj);
     if ('id' in obj && obj.id in this.pending) {
       // response to a pending request to master
       this.pending[obj.id](obj);
@@ -392,7 +392,7 @@ export class Gateway {
       // incoming message from master
       let msg = Message._deserialize(obj.message);
       if (!msg) return;
-      this._sendEvent('rxmsg', msg)
+      this._sendEvent('rxmsg', msg);
       if ((msg.recipient == this.aid.toJSON() )|| this.subscriptions[msg.recipient]) {
         var consumed = false;
         if (Array.isArray(this.eventListeners['message'])){
@@ -403,7 +403,7 @@ export class Gateway {
             }
           }
         }
-         // iterate over internal callbacks, until one consumes the message
+        // iterate over internal callbacks, until one consumes the message
         for (var key in this.listener){
           // callback returns true if it has consumed the message
           if (this.listener[key](msg)) {
@@ -474,7 +474,7 @@ export class Gateway {
     if (typeof s != 'string' && !(s instanceof String)) s = JSON.stringify(s);
     if (sock.readyState == sock.OPEN) {
       if(this.debug) console.log('> '+s);
-      this._sendEvent('tx', s)
+      this._sendEvent('tx', s);
       sock.send(s+'\n');
       return true;
     } else if (sock.readyState == sock.CONNECTING) {
@@ -530,7 +530,7 @@ export class Gateway {
     let matchedMsg = this.queue.find( msg => this._matchMessage(filter, msg));
     if (matchedMsg) this.queue.splice(this.queue.indexOf(matchedMsg), 1);
 
-    return matchedMsg
+    return matchedMsg;
   }
 
   _update_watch() {
@@ -711,6 +711,7 @@ export class Gateway {
       if (msg.__clazz__.endsWith('Req')) msg.perf = Performative.REQUEST;
       else msg.perf = Performative.INFORM;
     }
+    this._sendEvent('txmsg', msg);
     let rq = JSON.stringify({ action: 'send', relay: true, message: '###MSG###' });
     rq = rq.replace('"###MSG###"', msg._serialize());
     return !!this._websockTx(rq);

--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -470,7 +470,7 @@ export class Gateway {
     let sock = this.sock;
     if (typeof s != 'string' && !(s instanceof String)) s = JSON.stringify(s);
     if (sock.readyState == sock.OPEN) {
-      console.log('> '+s);
+      if(this.debug) console.log('> '+s);
       this._sendEvent('tx', s)
       sock.send(s+'\n');
       return true;

--- a/src/test/groovy/org/arl/fjage/test/playground.html
+++ b/src/test/groovy/org/arl/fjage/test/playground.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>fjåge test!</title>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@creativebulma/bulma-collapsible@1.0.4/dist/css/bulma-collapsible.min.css">
+	<script
+		src="https://cdn.jsdelivr.net/npm/@creativebulma/bulma-collapsible@1.0.4/dist/js/bulma-collapsible.min.js"></script>
+	<script type="module" src="../fjage.js"></script>
+</head>
+
+<body>
+	<template id="tmsg">
+		<a class="panel-block">
+			<span class="panel-icon"> </span>
+		</a>
+	</template>
+	<section class="section">
+		<div class="container">
+			<h1 class="title">
+				fjåge Playground
+			</h1>
+			<nav class="level">
+				<div class="level-left">
+					<div class="level-item">
+						<div class="field has-addons">
+							<p class="control">
+								<input class="input" type="text" placeholder="IP address" id="ipaddr" value="13.212.107.168">
+							</p>
+							<p class="control">
+								<a class="button is-info" id="connect">Connect</a>
+							</p>
+						</div>
+					</div>
+				</div>
+				<div class="level-right"></div>
+					<div class="level-item"></div>
+						<label class="checkbox">
+							<input type="checkbox" id="raw">
+							Raw mode
+						</label>
+					</div>
+				</div>
+			</nav>
+			<div class="pt-4">
+				<nav class="panel">
+					<p class="panel-heading"> Messages </p>
+					<div class="panel-msglist" id="mlist">
+
+					</div>
+					<div class="panel-block">
+							<input class="input" type="text" placeholder="Send a JSON" id="send" disabled>
+					</div>
+				</nav>
+			</div>
+		</div>
+	</section>
+</body>
+<style>
+	.panel-msglist {
+		overflow-y: scroll;
+		height: 65vh;
+	}
+
+	a.panel-block {
+		overflow-wrap: anywhere;
+	}
+</style>
+<script type="module">
+	import { AgentID, Gateway, MessageClass, Message, Performative, Services } from './fjage.js';
+	window.addEventListener('load', () => {
+		bulmaCollapsible.attach();
+
+		const ipaddr = document.getElementById('ipaddr');
+		const send = document.getElementById('send');
+		const raw = document.getElementById('raw');
+		const tmsg = document.getElementById('tmsg');
+		const mlist = document.getElementById('mlist');
+		var gw;
+		var history = []
+		var hcount;
+
+		var filtMsg = ["DatagramNtf", "PosePositionNtf"]
+
+		document.getElementById('connect').addEventListener('click', ({target}) => {
+			if (target.innerHTML == "Connect"){
+				connectToMaster(ipaddr.value)
+				target.classList.replace('is-info', 'is-warning')
+				target.innerHTML = "Disconnect"
+				ipaddr.disabled = true
+				send.disabled = false
+				raw.disabled = true
+			}else if (target.innerHTML == "Disconnect"){
+				target.classList.replace('is-warning', 'is-info')
+				disconnectFromMaster()
+				target.innerHTML = "Connect"
+				ipaddr.disabled = false
+				send.disabled = true
+				raw.disabled = false
+				send.value = ""
+			}
+		});
+
+		send.addEventListener('keyup', ({key}) => {
+			if (key === "Enter") {
+			let j = send.value
+			try {
+				JSON.parse(j)
+			} catch (error) {
+				console.log("Invalid JSON : " + j)
+				return;
+			}
+			console.log(">>> " + j)
+			gw.sock.send(j+"\n")
+			const msgel = tmsg.content.cloneNode(true)
+			msgel.firstElementChild.firstElementChild.innerText = "＜"
+			let t = document.createTextNode(j.toString().substring(0, 240))
+			msgel.firstElementChild.appendChild(t)
+			mlist.appendChild(msgel);
+			mlist.scrollTop = mlist.scrollHeight;
+			history.push(j);
+			send.value = ""
+			hcount = 0;
+			}else if (key == "ArrowUp"){
+				if (hcount < -(history.length+1)) hcount = -history.length+1;
+				var h = history[history.length - 1 + hcount]
+				send.value = h ? h : ""
+				hcount--;
+			} else if (key == "ArrowDown") {
+				if(hcount>0) hcount=0;
+				var h = history[history.length - 1 + hcount]
+				send.value = h ? h : ""
+				hcount++;
+			}
+		});
+
+		function connectToMaster(ipaddr) {
+			console.log("Connecting to " + ipaddr);
+			gw = new Gateway(ipaddr,8080)
+			gw.addEventListener(raw.checked ? 'rx' : 'rxmsg', msg => {
+				console.log(">>> " + msg)
+				var chk = (filtMsg.find(f => msg.toString().includes(f)));
+				if (chk && chk.length > 0) return;
+				const msgel = tmsg.content.cloneNode(true)
+				msgel.firstElementChild.firstElementChild.innerText = "＞"
+				let t = document.createTextNode(msg.toString().substring(0, 240))
+				msgel.firstElementChild.appendChild(t)
+				mlist.appendChild(msgel);
+				mlist.scrollTop = mlist.scrollHeight;
+			})
+		}
+
+		function disconnectFromMaster() {
+			console.log("Disconnecting..");
+			gw.close()
+			gw = null
+		}
+	})
+
+</script>
+
+</html>


### PR DESCRIPTION
Restructuring internal events [`conn`, `rx`, `rxmsg`, `txmsg`, `tx`] to be accessible to user of the fjage.js Gateways using the standard `addEventListener` `removeEventListener` interface. This makes it easy to add more events in the future without having to add new external-facing APIs.

This mechanism replaces the "observers", but keeps the external facings `addMessageListener ` , `removeMessageListener ` and `addConnListener` and `removeConnListener` APIs for now.

Also adding the playground UI in the test repository for testing fjage messages.