### PR TITLE
Update fjagec Makefile

### DIFF
--- a/gateways/c/Makefile
+++ b/gateways/c/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-std=c99 -Wall -O2 -D_DEFAULT_SOURCE
+CFLAGS=-std=c99 -Wall -O2 -D_BSD_SOURCE
 
 all: libfjage.a
 


### PR DESCRIPTION
Using the now recommended `-_DEFAULT_SOURCE` flag instead of the `_BSD_SOURCE` flag