### PR TITLE
Ignore all empty and small (<2) strings.

### DIFF
--- a/src/main/java/org/arl/fjage/remote/ConnectionHandler.java
+++ b/src/main/java/org/arl/fjage/remote/ConnectionHandler.java
@@ -111,6 +111,7 @@ class ConnectionHandler extends Thread {
         }
       }
       // handle JSON messages
+      if (s.length() < 2) continue;
       try {
         JsonMessage rq = JsonMessage.fromJson(s);
         if (rq.action == null) {


### PR DESCRIPTION
All empty and small strings are not valid JSON. So instead of trying to parse them and then logging an exception, we can quietly ignore them. This will stop spurious exceptions when Gateways accidentally send multiple newlines etc.