### PR TITLE
Give Privileged access to SerialPortConnector when opening a new SerialPort

### DIFF
--- a/src/main/java/org/arl/fjage/connectors/SerialPortConnector.java
+++ b/src/main/java/org/arl/fjage/connectors/SerialPortConnector.java
@@ -29,10 +29,15 @@ public class SerialPortConnector implements Connector {
    */
   public SerialPortConnector(String devname, int baud, String settings) throws IOException {
     if (settings != null && settings != "N81") throw new IOException("Bad serial port settings");
-    com = SerialPort.getCommPort(devname);
-    com.setComPortParameters(baud, 8, SerialPort.ONE_STOP_BIT, SerialPort.NO_PARITY);
-    com.openPort();
-    com.setComPortTimeouts(SerialPort.TIMEOUT_READ_SEMI_BLOCKING, 0, 0);
+    com = AccessController.doPrivileged(new PrivilegedAction<Void>() {
+      public SerialPort run() {
+        SerialPort c = SerialPort.getCommPort(devname);
+        c.setComPortParameters(baud, 8, SerialPort.ONE_STOP_BIT, SerialPort.NO_PARITY);
+        c.openPort();
+        c.setComPortTimeouts(SerialPort.TIMEOUT_READ_SEMI_BLOCKING, 0, 0);
+        return SerialPort;
+      }
+    });
   }
 
   /**

--- a/src/main/java/org/arl/fjage/connectors/SerialPortConnector.java
+++ b/src/main/java/org/arl/fjage/connectors/SerialPortConnector.java
@@ -11,6 +11,9 @@ for full license details.
 package org.arl.fjage.connectors;
 
 import java.io.*;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 import com.fazecast.jSerialComm.SerialPort;
 
 /**
@@ -29,13 +32,13 @@ public class SerialPortConnector implements Connector {
    */
   public SerialPortConnector(String devname, int baud, String settings) throws IOException {
     if (settings != null && settings != "N81") throw new IOException("Bad serial port settings");
-    com = AccessController.doPrivileged(new PrivilegedAction<Void>() {
+    com = AccessController.doPrivileged(new PrivilegedAction<SerialPort>() {
       public SerialPort run() {
         SerialPort c = SerialPort.getCommPort(devname);
         c.setComPortParameters(baud, 8, SerialPort.ONE_STOP_BIT, SerialPort.NO_PARITY);
         c.openPort();
         c.setComPortTimeouts(SerialPort.TIMEOUT_READ_SEMI_BLOCKING, 0, 0);
-        return SerialPort;
+        return c;
       }
     });
   }


### PR DESCRIPTION
`SerialPort` from `jSerialComm` requires access to various files and system resources. This change allows `SerialPortConnector` to use its own privileges (if it has any) to open a `SerialPort` instead of relying on the caller's privileges.