### PR TITLE
Fix in send() method to return False when master container is unavailable

### DIFF
--- a/gateways/python/fjagepy/__init__.py
+++ b/gateways/python/fjagepy/__init__.py
@@ -735,8 +735,7 @@ class Gateway:
             self.logger.debug(str(name[0]) + ":" + str(name[1]) + " >>> " + rq)
         except Exception as e:
             self.logger.critical("Exception: " + str(e))
-            self.keepalive = True
-            self._socket_reconnect(self.keepalive)
+            return False
         self.socket.sendall((rq + '\n').encode())
         return True
 


### PR DESCRIPTION
Currently, inside `send()` method we try to reconnect to the master container if it goes offline. There is no need to do this here and therefore, I have removed it and instead, it returns `False` if the connection to the master container is not available.