### PR TITLE
Fix sporadic hanging of WebSocket Connector 

### DIFF
--- a/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
+++ b/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
@@ -262,8 +262,7 @@ public class WebSocketConnector implements Connector, WebSocketCreator {
           } catch (Exception e){
             log.warning(e.toString());
           }
-          long t = System.currentTimeMillis()-start;
-          log.finest("Sent " + s.length() + " bytes to "+session.getRemote().getInetSocketAddress() + " (" + t +" ms)");
+          log.finest("Sent " + s.length() + " bytes to "+session.getRemote().getInetSocketAddress() + " (" + (System.currentTimeMillis()-start) +" ms)");
         }
       } catch (Exception e) {
         log.warning(e.toString());

--- a/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
+++ b/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
@@ -174,12 +174,8 @@ public class WebSocketConnector implements Connector, WebSocketCreator {
           if (buf == null) break;
           s = new String(buf);
         }
-        int i = 1;
-        int l = wsHandlers.size();
-        for (WSHandler t: wsHandlers) {
-          log.finest("Writing to "+ (i++) + " of "+l+" open sessions");
+        for (WSHandler t: wsHandlers)
           t.write(s);
-        }
         try {
           Thread.sleep(10);
         } catch (InterruptedException ex) {
@@ -252,7 +248,6 @@ public class WebSocketConnector implements Connector, WebSocketCreator {
     void write(String s) {
       try {
         if (session != null && session.isOpen()) {
-          long start = System.currentTimeMillis();
           Future<Void> f = session.getRemote().sendStringByFuture(s);
           try {
             f.get(500, TimeUnit.MILLISECONDS);
@@ -262,7 +257,6 @@ public class WebSocketConnector implements Connector, WebSocketCreator {
           } catch (Exception e){
             log.warning(e.toString());
           }
-          log.finest("Sent " + s.length() + " bytes to "+session.getRemote().getInetSocketAddress() + " (" + (System.currentTimeMillis()-start) +" ms)");
         }
       } catch (Exception e) {
         log.warning(e.toString());

--- a/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
+++ b/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
@@ -171,10 +171,10 @@ public class WebSocketConnector implements Connector, WebSocketCreator {
           if (buf == null) break;
           s = new String(buf);
         }
-        int i = 0;
+        int i = 1;
         int l = wsHandlers.size();
         for (WSHandler t: wsHandlers) {
-          log.finest("Writing to "+i+ " of "+l+" open sessions");
+          log.finest("Writing to "+ (i++) + " of "+l+" open sessions");
           t.write(s);
         }
         try {


### PR DESCRIPTION
It was noticed that under some load when a WebSocket Client disconnects abruptly (for eg. Phone switching from 3G to WiFi) Jetty's `session.getRemote().sendString(s)` method can sometimes end up in a blocked state. Since the original design was single-threaded, a blocked `session.getRemote().sendString` means the entire WebSocketConnector was blocked.

This change moves to use `session.getRemote().sendStringByFuture`, the async version of the same API. But since here the underlying thread which gets blocked is provided by Jetty, WebSocketConnector can do a cleanup of async tasks that don't complete within the timeout and terminate those connections.