### PR TITLE
build(*): using a relative file path to retreive VERSION file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ defaultTasks 'jars'
 
 archivesBaseName = 'fjage'
 group = 'com.github.org-arl'
-version = new File('VERSION').text.trim()
+version = new File(projectDir, 'VERSION').text.trim()
 
 // get git commit
 def stdout = new ByteArrayOutputStream()


### PR DESCRIPTION
Using `projectDir` to access the `VERSION` file. This allows `gradle` to be run from anywhere with the `-p` to choose the project directory.

This is critical to be able to use source dependencies https://blog.gradle.org/introducing-source-dependencies with `fjåge` as gradle automatically builds the source dependency using `gradle -p`.