### PR TITLE
Auth/firewall revamp

### DIFF
--- a/src/main/java/org/arl/fjage/auth/AbstractFirewall.java
+++ b/src/main/java/org/arl/fjage/auth/AbstractFirewall.java
@@ -17,7 +17,7 @@ import org.arl.fjage.remote.JsonMessage;
 /**
  * An abstract firewall class that allows all traffic to pass through once
  * authenticated. Authentication is implemented by a class that extends this
- * class by implemeting the {@link Firewall#authenticate(Connector,String)} method.
+ * class by implementing the {@link Firewall#authenticate(String)} method.
  */
 public abstract class AbstractFirewall implements Firewall {
 

--- a/src/main/java/org/arl/fjage/auth/AllowAfterAuth.java
+++ b/src/main/java/org/arl/fjage/auth/AllowAfterAuth.java
@@ -35,4 +35,9 @@ public class AllowAfterAuth extends AbstractFirewall {
     return auth;
   }
 
+  @Override
+  public void signoff() {
+    // do nothing
+  }
+
 }

--- a/src/main/java/org/arl/fjage/auth/AllowAfterAuth.java
+++ b/src/main/java/org/arl/fjage/auth/AllowAfterAuth.java
@@ -10,7 +10,7 @@ for full license details.
 
 package org.arl.fjage.auth;
 
-import org.arl.fjage.connectors.Connector;
+import java.util.function.Supplier;
 
 /**
  * A permissive firewall that allows all traffic to pass through, but requires
@@ -20,8 +20,13 @@ import org.arl.fjage.connectors.Connector;
  */
 public class AllowAfterAuth extends AbstractFirewall {
 
+  /**
+   * AllowAfterAuth supplier.
+   */
+  public static final Supplier<Firewall> SUPPLIER = AllowAfterAuth::new;
+
   @Override
-  public boolean authenticate(Connector conn, String creds) {
+  public boolean authenticate(String creds) {
     if (creds == null) auth = false;
     else {
       log.fine("Authentication successful ["+creds+"]");

--- a/src/main/java/org/arl/fjage/auth/AllowAll.java
+++ b/src/main/java/org/arl/fjage/auth/AllowAll.java
@@ -10,18 +10,34 @@ for full license details.
 
 package org.arl.fjage.auth;
 
-import org.arl.fjage.connectors.Connector;
+import org.arl.fjage.AgentID;
+import org.arl.fjage.remote.JsonMessage;
+
+import java.util.function.Supplier;
 
 /**
  * A permissive firewall that allows all traffic to pass through.
  */
-public class AllowAll extends AbstractFirewall {
+public class AllowAll implements Firewall {
+
+  /**
+   * AllowAll supplier.
+   */
+  public static final Supplier<Firewall> SUPPLIER = AllowAll::new;
 
   @Override
-  public boolean authenticate(Connector conn, String creds) {
-    if (creds != null) log.fine("Authentication successful [AllowAll]");
-    auth = true;
-    return auth;
+  public boolean authenticate(String creds) {
+    return true;
+  }
+
+  @Override
+  public boolean permit(JsonMessage rq) {
+    return true;
+  }
+
+  @Override
+  public boolean permit(AgentID aid) {
+    return true;
   }
 
 }

--- a/src/main/java/org/arl/fjage/auth/AllowAll.java
+++ b/src/main/java/org/arl/fjage/auth/AllowAll.java
@@ -40,4 +40,9 @@ public class AllowAll implements Firewall {
     return true;
   }
 
+  @Override
+  public void signoff() {
+    // do nothing
+  }
+
 }

--- a/src/main/java/org/arl/fjage/auth/DenyAll.java
+++ b/src/main/java/org/arl/fjage/auth/DenyAll.java
@@ -10,18 +10,34 @@ for full license details.
 
 package org.arl.fjage.auth;
 
-import org.arl.fjage.connectors.Connector;
+import org.arl.fjage.AgentID;
+import org.arl.fjage.remote.JsonMessage;
+
+import java.util.function.Supplier;
 
 /**
  * A reluctant firewall that denies all traffic to pass through.
  */
-public class DenyAll extends AbstractFirewall {
+public class DenyAll implements Firewall {
+
+  /**
+   * DenyAll supplier.
+   */
+  public static final Supplier<Firewall> SUPPLIER = DenyAll::new;
 
   @Override
-  public boolean authenticate(Connector conn, String creds) {
-    if (creds != null) log.fine("Authentication unsuccessful [DenyAll]");
-    auth = false;
-    return auth;
+  public boolean authenticate(String creds) {
+    return false;
+  }
+
+  @Override
+  public boolean permit(JsonMessage rq) {
+    return false;
+  }
+
+  @Override
+  public boolean permit(AgentID aid) {
+    return false;
   }
 
 }

--- a/src/main/java/org/arl/fjage/auth/DenyAll.java
+++ b/src/main/java/org/arl/fjage/auth/DenyAll.java
@@ -40,4 +40,9 @@ public class DenyAll implements Firewall {
     return false;
   }
 
+  @Override
+  public void signoff() {
+    // do nothing
+  }
+
 }

--- a/src/main/java/org/arl/fjage/auth/Firewall.java
+++ b/src/main/java/org/arl/fjage/auth/Firewall.java
@@ -46,4 +46,10 @@ public interface Firewall {
    */
   public boolean permit(AgentID aid);
 
+  /**
+   * Called when the connection is closed.
+   * The <code>Firewall</code> instance should perform cleanup.
+   */
+  public void signoff();
+
 }

--- a/src/main/java/org/arl/fjage/auth/Firewall.java
+++ b/src/main/java/org/arl/fjage/auth/Firewall.java
@@ -11,26 +11,23 @@ for full license details.
 package org.arl.fjage.auth;
 
 import org.arl.fjage.AgentID;
-import org.arl.fjage.connectors.Connector;
 import org.arl.fjage.remote.JsonMessage;
 
 /**
  * Firewall interface for API access to fjage master containers.
+ *
+ * Each connection to a master container should and will be assigned its own <code>Firewall</code> instance.
+ * <code>Firewall</code> instances should be considered stateful.
  */
 public interface Firewall {
 
   /**
    * Authenticates peer using specified credentials.
-   * <p>
-   * When a firewall is first bound to a connection handler, this method is
-   * called with null credentials to bind a connector to the firewall. The
-   * method is also called with null credentials when a connection is closed.
    *
-   * @param conn connection to peer.
    * @param creds credentials, or null if logging out.
    * @return true if authenticated successfully, false otherwise.
    */
-  public boolean authenticate(Connector conn, String creds);
+  public boolean authenticate(String creds);
 
   /**
    * Checks whether a JSON message can be accepted over this connection.

--- a/src/main/java/org/arl/fjage/remote/Action.java
+++ b/src/main/java/org/arl/fjage/remote/Action.java
@@ -15,7 +15,7 @@ import com.google.gson.annotations.SerializedName;
 /**
  * JSON message actions.
  */
-enum Action {
+public enum Action {
   @SerializedName("auth")             AUTH,
   @SerializedName("agents")           AGENTS,
   @SerializedName("containsAgent")    CONTAINS_AGENT,

--- a/src/main/java/org/arl/fjage/remote/ConnectionHandler.java
+++ b/src/main/java/org/arl/fjage/remote/ConnectionHandler.java
@@ -95,7 +95,6 @@ class ConnectionHandler extends Thread {
         println(ALIVE);
       }
     }
-    fw.authenticate(conn, null);
     while (conn != null) {
       String s = null;
       try {
@@ -144,7 +143,7 @@ class ConnectionHandler extends Thread {
         } else {
           // new request
           if (rq.action == Action.AUTH) {
-            boolean b = fw.authenticate(conn, rq.creds);
+            boolean b = fw.authenticate(rq.creds);
             respondAuth(rq, b);
           }
           else if (fw.permit(rq)) pool.execute(new RemoteTask(rq));
@@ -154,7 +153,6 @@ class ConnectionHandler extends Thread {
         log.warning("Bad JSON request: "+ex.toString() + " in " + s);
       }
     }
-    fw.authenticate(conn, null);
     close();
     pool.shutdown();
   }

--- a/src/main/java/org/arl/fjage/remote/ConnectionHandler.java
+++ b/src/main/java/org/arl/fjage/remote/ConnectionHandler.java
@@ -153,6 +153,7 @@ class ConnectionHandler extends Thread {
         log.warning("Bad JSON request: "+ex.toString() + " in " + s);
       }
     }
+    fw.signoff();
     close();
     pool.shutdown();
   }

--- a/src/main/java/org/arl/fjage/remote/MasterContainer.java
+++ b/src/main/java/org/arl/fjage/remote/MasterContainer.java
@@ -1,12 +1,12 @@
 /******************************************************************************
 
- Copyright (c) 2015-2019, Mandar Chitre
+Copyright (c) 2015-2019, Mandar Chitre
 
- This file is part of fjage which is released under Simplified BSD License.
- See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
- for full license details.
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
 
- ******************************************************************************/
+******************************************************************************/
 
 package org.arl.fjage.remote;
 

--- a/src/test/java/org/arl/fjage/test/BasicTests.java
+++ b/src/test/java/org/arl/fjage/test/BasicTests.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.logging.Logger;
 import org.arl.fjage.*;
-import org.arl.fjage.auth.*;
 import org.arl.fjage.param.*;
 import org.arl.fjage.persistence.Store;
 import org.arl.fjage.remote.Gateway;
@@ -177,106 +176,6 @@ public class BasicTests {
     req = new NuisanceMessage(server.getAgentID());
     rsp = gw.request(req, 100);
     assertNull(rsp);
-    gw.close();
-    platform.shutdown();
-  }
-
-  @Test
-  public void testFirewall1() throws IOException {
-    log.info("testFirewall1");
-    Platform platform = new RealTimePlatform();
-    MasterContainer master = new MasterContainer(platform, new AllowAll());
-    ServerAgent server = new ServerAgent();
-    master.add("S", server);
-    platform.start();
-    Gateway gw = new Gateway("localhost", master.getPort());
-    AgentID s = gw.agentForService("server");
-    assertNotNull(s);
-    Message req = new RequestMessage(server.getAgentID());
-    Message rsp = gw.request(req, 1000);
-    assertNotNull(rsp);
-    gw.close();
-    platform.shutdown();
-    assertEquals(1, server.requests);
-  }
-
-  @Test
-  public void testFirewall2() throws IOException {
-    log.info("testFirewall2");
-    Platform platform = new RealTimePlatform();
-    MasterContainer master = new MasterContainer(platform, new DenyAll());
-    ServerAgent server = new ServerAgent();
-    master.add("S", server);
-    platform.start();
-    Gateway gw = new Gateway("localhost", master.getPort());
-    try {
-      gw.agentForService("server");
-      fail("Should have thrown AuthFailureException");
-    } catch (AuthFailureException ex) {
-      // all good
-    }
-    Message req = new RequestMessage(server.getAgentID());
-    try {
-      gw.request(req, 1000);
-      fail("Should have thrown AuthFailureException");
-    } catch (AuthFailureException ex) {
-      // all good
-    }
-    gw.close();
-    platform.shutdown();
-    assertEquals(0, server.requests);
-  }
-
-  @Test
-  public void testFirewall3() throws IOException {
-    log.info("testFirewall3");
-    Platform platform = new RealTimePlatform();
-    MasterContainer master = new MasterContainer(platform, new AllowAfterAuth());
-    ServerAgent server = new ServerAgent();
-    master.add("S", server);
-    platform.start();
-    while (!master.isRunning()) {
-      try {
-        Thread.sleep(100);
-      } catch (InterruptedException ex) {
-        // ignore
-      }
-    }
-    Gateway gw = new Gateway("localhost", master.getPort());
-    try {
-      gw.agentForService("server");
-      fail("Should have thrown AuthFailureException");
-    } catch (AuthFailureException ex) {
-      // all good
-    }
-    gw.authenticate("somecreds");
-    AgentID s = gw.agentForService("server");
-    assertNotNull(s);
-    Message req = new RequestMessage(server.getAgentID());
-    Message rsp = gw.request(req, 1000);
-    assertNotNull(rsp);
-    gw.close();
-    platform.shutdown();
-    assertEquals(1, server.requests);
-  }
-
-  @Test
-  public void testFirewall4() throws IOException {
-    log.info("testFirewall4");
-    Platform platform = new RealTimePlatform();
-    MasterContainer master = new MasterContainer(platform, new AllowAfterAuth());
-    platform.start();
-    Gateway gw = new Gateway("localhost", master.getPort());
-    gw.subscribe(new AgentID("test1", true));
-    master.send(new NuisanceMessage(new AgentID("test1", true)));
-    Message msg = gw.receive(1000);
-    assertNull(msg);
-    gw.authenticate("somecreds");
-    gw.subscribe(new AgentID("test1", true));
-    master.send(new NuisanceMessage(new AgentID("test1", true)));
-    msg = gw.receive(1000);
-    assertNotNull(msg);
-    assertSame(msg.getClass(), NuisanceMessage.class);
     gw.close();
     platform.shutdown();
   }

--- a/src/test/java/org/arl/fjage/test/FirewallTests.java
+++ b/src/test/java/org/arl/fjage/test/FirewallTests.java
@@ -1,0 +1,304 @@
+/******************************************************************************
+
+Copyright (c) 2013, Mandar Chitre
+
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
+
+******************************************************************************/
+
+package org.arl.fjage.test;
+
+import org.arl.fjage.*;
+import org.arl.fjage.auth.*;
+import org.arl.fjage.param.Parameter;
+import org.arl.fjage.remote.Gateway;
+import org.arl.fjage.remote.MasterContainer;
+import org.arl.fjage.test.auth.SimpleFirewallSupplier;
+import org.arl.fjage.test.auth.TracedFirewallSupplier;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.*;
+
+public class FirewallTests {
+
+  @Rule
+  public TestName testName = new TestName();
+  private final Logger log = Logger.getLogger(getClass().getName());
+
+  @Before
+  public void beforeTesting() {
+    LogFormatter.install(null);
+    log.info(String.format("==== BEGIN %s ====", testName.getMethodName()));
+  }
+
+  @After
+  public void afterTesting() {
+    log.info(String.format("==== END %s ====", testName.getMethodName()));
+  }
+
+  @Test
+  public void testFirewall1() throws IOException {
+    Platform platform = new RealTimePlatform();
+    MasterContainer master = new MasterContainer(platform, AllowAll.SUPPLIER);
+    ServerAgent server = new ServerAgent();
+    master.add("S", server);
+    platform.start();
+    Gateway gw = new Gateway("localhost", master.getPort());
+    AgentID s = gw.agentForService("server");
+    assertNotNull(s);
+    Message req = new RequestMessage(server.getAgentID());
+    Message rsp = gw.request(req, 1000);
+    assertNotNull(rsp);
+    gw.close();
+    platform.shutdown();
+    assertEquals(1, server.requests);
+  }
+
+  @Test
+  public void testFirewall2() throws IOException {
+    Platform platform = new RealTimePlatform();
+    MasterContainer master = new MasterContainer(platform, DenyAll.SUPPLIER);
+    ServerAgent server = new ServerAgent();
+    master.add("S", server);
+    platform.start();
+    Gateway gw = new Gateway("localhost", master.getPort());
+    try {
+      gw.agentForService("server");
+      fail("Should have thrown AuthFailureException");
+    } catch (AuthFailureException ex) {
+      // all good
+    }
+    Message req = new RequestMessage(server.getAgentID());
+    try {
+      gw.request(req, 1000);
+      fail("Should have thrown AuthFailureException");
+    } catch (AuthFailureException ex) {
+      // all good
+    }
+    gw.close();
+    platform.shutdown();
+    assertEquals(0, server.requests);
+  }
+
+  @Test
+  public void testFirewall3() throws IOException {
+    Platform platform = new RealTimePlatform();
+    MasterContainer master = new MasterContainer(platform, AllowAfterAuth.SUPPLIER);
+    ServerAgent server = new ServerAgent();
+    master.add("S", server);
+    platform.start();
+    while (!master.isRunning()) {
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException ex) {
+        // ignore
+      }
+    }
+    Gateway gw = new Gateway("localhost", master.getPort());
+    try {
+      gw.agentForService("server");
+      fail("Should have thrown AuthFailureException");
+    } catch (AuthFailureException ex) {
+      // all good
+    }
+    gw.authenticate("somecreds");
+    AgentID s = gw.agentForService("server");
+    assertNotNull(s);
+    Message req = new RequestMessage(server.getAgentID());
+    Message rsp = gw.request(req, 1000);
+    assertNotNull(rsp);
+    gw.close();
+    platform.shutdown();
+    assertEquals(1, server.requests);
+  }
+
+  @Test
+  public void testFirewall4() throws IOException {
+    Platform platform = new RealTimePlatform();
+    MasterContainer master = new MasterContainer(platform, AllowAfterAuth.SUPPLIER);
+    platform.start();
+    Gateway gw = new Gateway("localhost", master.getPort());
+    gw.subscribe(new AgentID("test1", true));
+    master.send(new NuisanceMessage(new AgentID("test1", true)));
+    Message msg = gw.receive(1000);
+    assertNull(msg);
+    gw.authenticate("somecreds");
+    gw.subscribe(new AgentID("test1", true));
+    master.send(new NuisanceMessage(new AgentID("test1", true)));
+    msg = gw.receive(1000);
+    assertNotNull(msg);
+    assertSame(msg.getClass(), NuisanceMessage.class);
+    gw.close();
+    platform.shutdown();
+  }
+
+  @Test
+  public void testSimpleFirewall1() throws IOException {
+    final SimpleFirewallSupplier simpleFirewallSupplier = new SimpleFirewallSupplier()
+        .addUserConfiguration("somecreds", userConfiguration -> userConfiguration
+            .allowedServiceNames("server")
+            .allowedAgentNames("server1")
+            .allowedTopicNames("server1__ntf")
+        );
+    final Supplier<Firewall> fwSupplier = new TracedFirewallSupplier(simpleFirewallSupplier);
+
+    final Platform platform = new RealTimePlatform();
+    final MasterContainer master = new MasterContainer(platform, fwSupplier);
+
+    final ServerAgent serverAgent1 = new ServerAgent();
+    master.add("server1", serverAgent1);
+
+    final ServerAgent2 serverAgent2 = new ServerAgent2();
+    master.add("server2", serverAgent2);
+
+    platform.start();
+
+    while (!master.isRunning()) {
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException ex) {
+        // ignore
+      }
+    }
+
+    final Gateway gw = new Gateway("localhost", master.getPort());
+
+    try {
+      gw.agentForService("server");
+      fail("Should have thrown AuthFailureException");
+    } catch (AuthFailureException ex) {
+      // all good
+    }
+
+    gw.authenticate("somecreds");
+
+    {
+      final AgentID serverAgentId = gw.agentForService("server");
+      assertNotNull(serverAgentId);
+      gw.subscribe(gw.topic(serverAgentId));
+      final Message req = new RequestMessage(serverAgentId);
+      final Message rsp = gw.request(req, 1000);
+      assertNotNull(rsp);
+    }
+
+    try {
+      final AgentID server2AgentId = gw.agentForService("server2");
+      fail("Should have thrown AuthFailureException");
+    } catch (AuthFailureException ex) {
+      // all good
+    }
+
+    {
+      final Message msg = gw.receive(1000);
+      assertNotNull(msg);
+    }
+
+    while (!master.isRunning()) {
+      try {
+        Thread.sleep(2000);
+      } catch (InterruptedException ex) {
+        // ignore
+      }
+    }
+
+    gw.close();
+    platform.shutdown();
+    assertEquals(1, serverAgent1.requests);
+  }
+
+  private static class RequestMessage extends Message {
+    private static final long serialVersionUID = 1L;
+    public int x;
+
+    public RequestMessage(AgentID recipient) {
+      super(recipient, Performative.REQUEST);
+    }
+  }
+
+  private static class ResponseMessage extends Message {
+    private static final long serialVersionUID = 1L;
+    public int x, y;
+
+    public ResponseMessage(Message request) {
+      super(request, Performative.INFORM);
+    }
+  }
+
+  private static class NuisanceMessage extends Message {
+    private static final long serialVersionUID = 1L;
+
+    public NuisanceMessage(AgentID recipient) {
+      super(recipient, Performative.INFORM);
+    }
+  }
+
+  public enum Params implements Parameter {
+    x, y, s
+  }
+
+  private static class ServerAgent extends Agent {
+    public int requests = 0, nuisance = 0;
+
+    @Override
+    public void init() {
+      register("server");
+      subscribe(topic("noise"));
+      add(new MessageBehavior(RequestMessage.class) {
+        @Override
+        public void onReceive(Message msg) {
+          requests++;
+          RequestMessage req = (RequestMessage) msg;
+          ResponseMessage rsp = new ResponseMessage(req);
+          rsp.x = req.x;
+          rsp.y = 2 * req.x + 1;
+          agent.send(rsp);
+        }
+      });
+      add(new MessageBehavior(NuisanceMessage.class) {
+        @Override
+        public void onReceive(Message msg) {
+          nuisance++;
+        }
+      });
+      final AgentID topic = topic();
+      add(new TickerBehavior(1000, () -> send(new NuisanceMessage(topic))));
+    }
+  }
+
+  private static class ServerAgent2 extends Agent {
+    public int requests = 0, nuisance = 0;
+
+    @Override
+    public void init() {
+      register("server2");
+      subscribe(topic("noise"));
+      add(new MessageBehavior(RequestMessage.class) {
+        @Override
+        public void onReceive(Message msg) {
+          requests++;
+          RequestMessage req = (RequestMessage) msg;
+          ResponseMessage rsp = new ResponseMessage(req);
+          rsp.x = req.x;
+          rsp.y = 2 * req.x + 1;
+          agent.send(rsp);
+        }
+      });
+      add(new MessageBehavior(NuisanceMessage.class) {
+        @Override
+        public void onReceive(Message msg) {
+          nuisance++;
+        }
+      });
+    }
+  }
+}

--- a/src/test/java/org/arl/fjage/test/SimpleFirewallTests.java
+++ b/src/test/java/org/arl/fjage/test/SimpleFirewallTests.java
@@ -1,0 +1,142 @@
+/******************************************************************************
+
+Copyright (c) 2013, Mandar Chitre
+
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
+
+******************************************************************************/
+
+package org.arl.fjage.test;
+
+import org.arl.fjage.*;
+import org.arl.fjage.auth.*;
+import org.arl.fjage.remote.Action;
+import org.arl.fjage.remote.JsonMessage;
+import org.arl.fjage.test.auth.SimpleFirewallSupplier;
+import org.junit.*;
+import org.junit.rules.TestName;
+
+import java.util.logging.Logger;
+
+public class SimpleFirewallTests {
+
+  private static final String AGENT1_NAME = "agent1";
+  private static final String AGENT2_NAME = "agent2";
+  private static final String AGENT3_NAME = "agent3";
+  private static final AgentID AGENT1 = new AgentID(AGENT1_NAME);
+  private static final AgentID AGENT2 = new AgentID(AGENT2_NAME);
+  private static final AgentID AGENT3 = new AgentID(AGENT3_NAME);
+
+  @Rule
+  public TestName testName = new TestName();
+  private final Logger log = Logger.getLogger(getClass().getName());
+  private final SimpleFirewallSupplier simpleFirewallSupplier = new SimpleFirewallSupplier()
+      .addUserConfiguration("credentials1", userConfiguration -> userConfiguration
+          .allowedAgentNames("agent1")
+      )
+      .addUserConfiguration("credentials2", userConfiguration -> userConfiguration
+          .allowedAgentNames("agent2")
+      );
+
+  @Before
+  public void beforeTesting() {
+    LogFormatter.install(null);
+    log.info(String.format("==== BEGIN %s ====", testName.getMethodName()));
+  }
+
+  @After
+  public void afterTesting() {
+    log.info(String.format("==== END %s ====", testName.getMethodName()));
+  }
+
+  @Test
+  public void distinctInstances() {
+    final Firewall fw1 = simpleFirewallSupplier.get();
+    final Firewall fw2 = simpleFirewallSupplier.get();
+    final Firewall fw3 = simpleFirewallSupplier.get();
+    Assert.assertNotEquals(fw1, fw2);
+    Assert.assertNotEquals(fw1, fw3);
+    Assert.assertNotEquals(fw2, fw3);
+  }
+
+  @Test
+  public void authentication1() {
+    final Firewall fw = simpleFirewallSupplier.get();
+
+    // fw is not authenticated
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT1)));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT2)));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT3)));
+
+    // authenticate fw
+    Assert.assertEquals(true, fw.authenticate("credentials1"));
+    Assert.assertEquals(true, fw.permit(newSendJsonMessage(AGENT1)));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT2)));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT3)));
+  }
+
+  @Test
+  public void authentication2() {
+    final Firewall fw = simpleFirewallSupplier.get();
+
+    // fw is not authenticated
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT1)));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT2)));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT3)));
+
+    // authenticate fw
+    Assert.assertEquals(true, fw.authenticate("credentials2"));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT1)));
+    Assert.assertEquals(true, fw.permit(newSendJsonMessage(AGENT2)));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT3)));
+  }
+
+  @Test
+  public void badAuthentication() {
+    final Firewall fw = simpleFirewallSupplier.get();
+
+    // fw is not authenticated
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT1)));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT2)));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT3)));
+
+    // authenticate fw (with unknown credentials)
+    Assert.assertEquals(false, fw.authenticate("credentials0"));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT1)));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT2)));
+    Assert.assertEquals(false, fw.permit(newSendJsonMessage(AGENT3)));
+  }
+
+  @Test
+  public void distinctStates() {
+    final Firewall fw1 = simpleFirewallSupplier.get();
+    Assert.assertEquals(true, fw1.authenticate("credentials1"));
+
+    final Firewall fw2 = simpleFirewallSupplier.get();
+    Assert.assertEquals(true, fw2.authenticate("credentials2"));
+
+    final Firewall fw3 = simpleFirewallSupplier.get();
+    Assert.assertEquals(false, fw3.authenticate("credentials0"));
+
+    Assert.assertEquals(true, fw1.permit(newSendJsonMessage(AGENT1)));
+    Assert.assertEquals(false, fw1.permit(newSendJsonMessage(AGENT2)));
+    Assert.assertEquals(false, fw1.permit(newSendJsonMessage(AGENT3)));
+
+    Assert.assertEquals(false, fw2.permit(newSendJsonMessage(AGENT1)));
+    Assert.assertEquals(true, fw2.permit(newSendJsonMessage(AGENT2)));
+    Assert.assertEquals(false, fw2.permit(newSendJsonMessage(AGENT3)));
+
+    Assert.assertEquals(false, fw3.permit(newSendJsonMessage(AGENT1)));
+    Assert.assertEquals(false, fw3.permit(newSendJsonMessage(AGENT2)));
+    Assert.assertEquals(false, fw3.permit(newSendJsonMessage(AGENT3)));
+  }
+
+  private JsonMessage newSendJsonMessage(AgentID recipient) {
+    final JsonMessage jsonMessage = new JsonMessage();
+    jsonMessage.action = Action.SEND;
+    jsonMessage.message = new Message(recipient);
+    return jsonMessage;
+  }
+}

--- a/src/test/java/org/arl/fjage/test/auth/SimpleFirewallSupplier.java
+++ b/src/test/java/org/arl/fjage/test/auth/SimpleFirewallSupplier.java
@@ -1,0 +1,129 @@
+/******************************************************************************
+
+Copyright (c) 2013, Mandar Chitre
+
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
+
+******************************************************************************/
+
+package org.arl.fjage.test.auth;
+
+import org.arl.fjage.AgentID;
+import org.arl.fjage.auth.Firewall;
+import org.arl.fjage.remote.Action;
+import org.arl.fjage.remote.JsonMessage;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class SimpleFirewallSupplier
+    implements Supplier<Firewall> {
+
+  private final Map<String, UserConfiguration> userConfigurationMap = Collections.synchronizedMap(new HashMap<>());
+
+  public SimpleFirewallSupplier addUserConfiguration(String credentials,
+                                                     Consumer<UserConfiguration> userConfigurationConsumer) {
+    final UserConfiguration userConfiguration = new UserConfiguration();
+    userConfigurationConsumer.accept(userConfiguration);
+    userConfigurationMap.put(credentials, userConfiguration);
+    return this;
+  }
+
+  public UserConfiguration getUserConfiguration(String credentials) {
+    return userConfigurationMap.get(credentials);
+  }
+
+  @Override
+  public Firewall get() {
+    return new SimpleFirewall();
+  }
+
+  private class SimpleFirewall
+      implements Firewall {
+
+    private String creds = null;
+    private UserConfiguration userConfiguration = null;
+
+    @Override
+    public boolean authenticate(String creds) {
+      final UserConfiguration userConfiguration = getUserConfiguration(creds);
+      if (userConfiguration != null) {
+        this.creds = creds;
+        this.userConfiguration = userConfiguration;
+        return true;
+      } else {
+        this.creds = null;
+        this.userConfiguration = null;
+        return false;
+      }
+    }
+
+    @Override
+    public boolean permit(JsonMessage rq) {
+      if (userConfiguration == null) {
+        return false;
+      }
+      return userConfiguration.isPermitted(rq);
+    }
+
+    @Override
+    public boolean permit(AgentID aid) {
+      if (userConfiguration == null) {
+        return false;
+      }
+      return userConfiguration.isPermitted(aid);
+    }
+
+    @Override
+    public String toString() {
+      if (creds != null)  {
+        return String.format("@%x/%s", hashCode(), creds);
+      } else {
+        return String.format("@%x", hashCode());
+      }
+    }
+  }
+
+  public static class UserConfiguration {
+
+    private final Set<String> allowedServiceNames = new HashSet<>();
+    private final Set<String> allowedAgentNames = new HashSet<>();
+    private final Set<String> allowedTopicNames = new HashSet<>();
+
+    public UserConfiguration allowedServiceNames(String... serviceNames) {
+      allowedServiceNames.addAll(Arrays.asList(serviceNames));
+      return this;
+    }
+
+    public UserConfiguration allowedAgentNames(String... agentNames) {
+      allowedAgentNames.addAll(Arrays.asList(agentNames));
+      return this;
+    }
+
+    public UserConfiguration allowedTopicNames(String... topicNames) {
+      allowedTopicNames.addAll(Arrays.asList(topicNames));
+      return this;
+    }
+
+    public boolean isPermitted(AgentID agentID) {
+      if (agentID.isTopic()) {
+        return allowedTopicNames.contains(agentID.getName());
+      } else {
+        return true;
+      }
+    }
+
+    public boolean isPermitted(JsonMessage jsonMessage) {
+      if ((jsonMessage.action == Action.AGENT_FOR_SERVICE) || (jsonMessage.action == Action.AGENTS_FOR_SERVICE)) {
+        return allowedServiceNames.contains(jsonMessage.service);
+      } else if (jsonMessage.action == Action.SEND) {
+        return allowedAgentNames.contains(jsonMessage.message.getRecipient().getName());
+      } else {
+        return true;
+      }
+    }
+  }
+}

--- a/src/test/java/org/arl/fjage/test/auth/SimpleFirewallSupplier.java
+++ b/src/test/java/org/arl/fjage/test/auth/SimpleFirewallSupplier.java
@@ -78,6 +78,11 @@ public class SimpleFirewallSupplier
     }
 
     @Override
+    public void signoff() {
+      // do nothing
+    }
+
+    @Override
     public String toString() {
       if (creds != null)  {
         return String.format("@%x/%s", hashCode(), creds);

--- a/src/test/java/org/arl/fjage/test/auth/TracedFirewallSupplier.java
+++ b/src/test/java/org/arl/fjage/test/auth/TracedFirewallSupplier.java
@@ -1,0 +1,69 @@
+/******************************************************************************
+
+Copyright (c) 2013, Mandar Chitre
+
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
+
+******************************************************************************/
+
+package org.arl.fjage.test.auth;
+
+import org.arl.fjage.AgentID;
+import org.arl.fjage.auth.Firewall;
+import org.arl.fjage.remote.JsonMessage;
+
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+public class TracedFirewallSupplier
+    implements Supplier<Firewall> {
+
+  private final Supplier<Firewall> fwSupplier;
+  private final Logger log = Logger.getLogger(getClass().getName());
+
+  public TracedFirewallSupplier(Supplier<Firewall> fwSupplier) {
+    super();
+
+    this.fwSupplier = fwSupplier;
+  }
+
+  @Override
+  public Firewall get() {
+    return new TracedFirewall(fwSupplier.get());
+  }
+
+  private class TracedFirewall
+      implements Firewall {
+
+    private final Firewall fw;
+
+    public TracedFirewall(Firewall fw) {
+      super();
+
+      this.fw = fw;
+    }
+
+    @Override
+    public boolean authenticate(String creds) {
+      final boolean auth = fw.authenticate(creds);
+      log.info(String.format("[%s] authenticate(%s)=%s", fw, creds, auth));
+      return auth;
+    }
+
+    @Override
+    public boolean permit(JsonMessage rq) {
+      final boolean permitted = fw.permit(rq);
+      log.info(String.format("[%s] permit(%s)=%s", fw, rq.toJson(), permitted));
+      return permitted;
+    }
+
+    @Override
+    public boolean permit(AgentID aid) {
+      final boolean permitted = fw.permit(aid);
+      log.info(String.format("[%s] permit(%s)=%s", fw, aid, permitted));
+      return permitted;
+    }
+  }
+}

--- a/src/test/java/org/arl/fjage/test/auth/TracedFirewallSupplier.java
+++ b/src/test/java/org/arl/fjage/test/auth/TracedFirewallSupplier.java
@@ -65,5 +65,11 @@ public class TracedFirewallSupplier
       log.info(String.format("[%s] permit(%s)=%s", fw, aid, permitted));
       return permitted;
     }
+
+    @Override
+    public void signoff() {
+      fw.signoff();
+      log.info(String.format("[%s] signoff()", fw));
+    }
   }
 }


### PR DESCRIPTION
This revamp of auth/firewall makes it easier to differentiate between connections.

See #222

As discussed, this PR includes breaking/signature changes in the following classes:
* `org.arl.fjage.auth.AllowAfterAuth`
* `org.arl.fjage.auth.AllowAll`
* `org.arl.fjage.auth.DenyAll`
* `org.arl.fjage.auth.Firewall`
* `org.arl.fjage.remote.MasterContainer`
    * some constructors

I've also had to relax the scope of:
* `org.arl.fjage.remote.Action`
