### PR TITLE
feat(build): adding a lite (non-js) build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Try to stick to the coding style already in use in the repository. Additionally,
 
 Building:
 
-* `gradle` to build the jars
+* `gradle` to build the jars including resources (webshell, fjage.js, etc.)
+* `gradle lite` to build only the jars
 * `gradle test` to run all regression tests (automated through Github actions CI)
 * `gradle publish` to upload jars to Maven staging (requires credentials)
 * `make html` to build developer's documentation (automated through ReadTheDocs)

--- a/build.gradle
+++ b/build.gradle
@@ -88,19 +88,9 @@ test {
   }
 }
 
-task jars(dependsOn: jar, type: Copy) {
+task lite(dependsOn: jar, type: Copy) {
   into "$buildDir/libs"
   from configurations.runtimeClasspath
-}
-
-jars.outputs.upToDateWhen { false }
-
-javadoc.doLast {
-  mkdir 'docs/javadoc'
-  copy {
-    from javadoc.destinationDir
-    into 'docs/javadoc'
-  }
 }
 
 task buildjs {
@@ -124,7 +114,21 @@ task buildjs {
   }
 }
 
-processResources.dependsOn("buildjs")
+task jars() {
+  dependsOn 'lite'
+  dependsOn 'buildjs'
+  tasks.findByName('buildjs').mustRunAfter 'lite'
+}
+
+jars.outputs.upToDateWhen { false }
+
+javadoc.doLast {
+  mkdir 'docs/javadoc'
+  copy {
+    from javadoc.destinationDir
+    into 'docs/javadoc'
+  }
+}
 
 task jsdoc(type: Exec){
   workingDir 'gateways/js'


### PR DESCRIPTION
Added a `gradle lite` which forgoes any of the javascript build steps for setups.

TODO : 

- [x]  Add documentation