### PR TITLE
Add a SIGSEGV signal handler for debugging on C gateway

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.5]
+        python-version: [3.x]
         node-version: [16.x]
         os: [ubuntu-latest, windows-latest]
     steps:

--- a/gateways/c/Makefile
+++ b/gateways/c/Makefile
@@ -1,5 +1,10 @@
 CFLAGS=-std=c99 -Wall -O2 -D_DEFAULT_SOURCE
 
+DEBUG ?= 0
+ifeq ($(DEBUG), 1)
+    CFLAGS += -DDEBUG
+endif
+
 all: libfjage.a
 
 libfjage.a: fjage.o jsmn.o encode.o decode.o

--- a/gateways/c/fjage.c
+++ b/gateways/c/fjage.c
@@ -513,6 +513,7 @@ fjage_gw_t fjage_tcp_open(const char* hostname, int port) {
   u_long NONBLOCK_MODE = 1;
   ioctlsocket(fgw->sockfd, FIONBIO, &NONBLOCK_MODE);
 #else
+  signal(SIGPIPE, SIG_IGN);
   fcntl(fgw->sockfd, F_SETFL, O_NONBLOCK);
 #endif
 


### PR DESCRIPTION
- Add a SIGSEGV signal handler which will print out a stack trace when it encounters a SIGSEGV (enabled with DEBUG=1 at compile time) on C gateway
- Add a SIGPIPE signal handler which ignores any SIGPIPE errors on C gateway
- Fix CI by bumping python version to `3.x`