### PR TITLE
Set base64 encoding threshold to 0 by default

### DIFF
--- a/src/main/java/org/arl/fjage/remote/ArrayAdapterFactory.java
+++ b/src/main/java/org/arl/fjage/remote/ArrayAdapterFactory.java
@@ -30,7 +30,7 @@ class ArrayAdapterFactory implements TypeAdapterFactory {
 
   public ArrayAdapterFactory() {
     bare = false;
-    threshold = 16;
+    threshold = 0;
   }
 
   public ArrayAdapterFactory(boolean bare, int threshold) {


### PR DESCRIPTION
Fixes https://github.com/org-arl/unet-contrib/issues/69#issuecomment-1068863834 by encoding `NaN`s using base64.

### Related issues
- https://github.com/org-arl/unet-contrib/issues/69#issuecomment-1068863834
- https://github.com/org-arl/fjage/issues/109

### Discussion notes
- We can't recall why we wanted a threshold in the first place. If we find a reason, we may want to revert this and perhaps consider the logic below.
- We can set threshold to non-zero (used to be 16) and force base64 encoding if the small array has any `NaN` or `Inf`.
