### PR TITLE
Use the name() method instead of the name field in AgentID.metaClass.getAllParameters

### DIFF
--- a/src/main/groovy/org/arl/fjage/GroovyExtensions.groovy
+++ b/src/main/groovy/org/arl/fjage/GroovyExtensions.groovy
@@ -84,7 +84,7 @@ class GroovyExtensions {
       List<String> out = new ArrayList<String>()
       rsp.parameters().each {
         if (it instanceof NamedParameter) {
-          if (it.name != 'title' && it.name != 'description') {
+          if (it.name() != 'title' && it.name() != 'description') {
             String s = "${rsp.get(it)}"
             String p = "$it"
             if (!p.contains('.')) p = ".$p"


### PR DESCRIPTION
Using the `.name()` method instead of the `.name` field to get the name of a `NamedParameter` in `AgentID.metaClass.getAllParameters`

Fix https://github.com/org-arl/fjage/issues/253