### PR TITLE
Avoid web server blocking JVM exit

### DIFF
--- a/src/main/java/org/arl/fjage/connectors/WebServer.java
+++ b/src/main/java/org/arl/fjage/connectors/WebServer.java
@@ -18,6 +18,8 @@ import org.eclipse.jetty.server.handler.*;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
 
 import java.io.File;
 import java.io.IOException;
@@ -157,6 +159,8 @@ public class WebServer {
     gzipHandler.setHandler(rewrite);
     rewrite.setHandler(handlerCollection);
     server.setHandler(gzipHandler);
+    ThreadPool pool = server.getThreadPool();
+    if (pool instanceof QueuedThreadPool) ((QueuedThreadPool)pool).setDaemon(true);
     started = false;
   }
 


### PR DESCRIPTION
Jetty web server threads at some point in time seem to have become non-daemon by default, and this prevents proper termination of JVM when fjåge container exits. This PR marks these threads as daemon threads to avoid this.