### PR TITLE
Adds GetFileRsp message in fjagepy

### DIFF
--- a/gateways/python/fjagepy/__init__.py
+++ b/gateways/python/fjagepy/__init__.py
@@ -420,6 +420,7 @@ _ParameterRsp = MessageClass('org.arl.fjage.param.ParameterRsp')
 PutFileReq = MessageClass('org.arl.fjage.shell.PutFileReq')
 GetFileReq = MessageClass('org.arl.fjage.shell.GetFileReq')
 ShellExecReq = MessageClass('org.arl.fjage.shell.ShellExecReq')
+GetFileRsp = MessageClass('org.arl.fjage.shell.GetFileRsp')
 
 
 class ParameterReq(_ParameterReq):


### PR DESCRIPTION
This fixes issue https://github.com/org-arl/fjage/issues/257

Note that only `GetFileRsp` message is availble. There is no `PutFileRsp` message in fjage.