### PR TITLE
Add syntax highlighting for fjåge log files

### DIFF
--- a/vscode/fjage-log.tmLanguage.json
+++ b/vscode/fjage-log.tmLanguage.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "fjage-log",
+  "patterns": [{  "include": "#entry" }],
+  "repository": {
+    "entry": {
+      "patterns": [{
+          "match": "^([0-9]{10})([0-9]{3})\\|([A-Z]+)\\|([^\\|]+)\\|",
+          "captures": {
+            "1": { "name": "markup.changed.fjage-log" },
+            "2": { "name": "comment.block.fjage-log" },
+            "3": { "name": "keyword.fjage-log" },
+            "4": { "name": "comment.block.fjage-log" }
+          }
+        }
+      ]
+    }
+  },
+  "scopeName": "source.fjage-log"
+}

--- a/vscode/language-configuration.json
+++ b/vscode/language-configuration.json
@@ -1,0 +1,24 @@
+{
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ],
+    // symbols that that can be used to surround a selection
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ]
+}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "fjage-log",
+  "displayName": "Fjåge log syntax",
+  "description": "Syntax highlighting for fjåge log files.",
+  "version": "0.0.1",
+  "publisher": "Mandar Chitre",
+  "engines": { "vscode": "^1.74.0" },
+  "categories": [ "Languages" ],
+  "contributes": {
+      "languages": [{
+          "id": "fjage-log",
+          "extensions": [],
+          "configuration": "./language-configuration.json"
+      }],
+      "grammars": [{
+          "language": "fjage-log",
+          "scopeName": "source.fjage-log",
+          "path": "./fjage-log.tmLanguage.json"
+      }]
+  }
+}


### PR DESCRIPTION
To install, simply `Cmd-shift-P` and choose "Developer: Install extension from location..." and select the `vscode` folder. Then open the log file and select `fjage-log` in the language selection in the status bar at the bottom-right.

Example screenshot:
<img width="1413" alt="image" src="https://user-images.githubusercontent.com/3949878/209975556-a4c067de-3b39-4a55-81e5-a4249ca47d77.png">
