### PR TITLE
Fix get_param_str in fjage.c

### DIFF
--- a/gateways/c/src/fjage.c
+++ b/gateways/c/src/fjage.c
@@ -1365,7 +1365,10 @@ int fjage_param_get_string(fjage_gw_t gw, fjage_aid_t aid, const char* param, in
     if (fjage_msg_get_performative(msg) == FJAGE_INFORM) {
       const char* v = fjage_msg_get_string(msg, "value");
       if (v != NULL){
-        if (strval != NULL && len > 0) rv = strlcpy((char*)strval, v, len);
+        if (strval != NULL && len > 0) {
+          strncpy((char*)strval, v, len);
+          rv = strlen(v) > len ? len : strlen(v);
+        }
         else rv = strlen(v);
       }
     }

--- a/gateways/c/src/fjage.c
+++ b/gateways/c/src/fjage.c
@@ -1354,19 +1354,21 @@ bool fjage_param_get_bool(fjage_gw_t gw, fjage_aid_t aid, const char* param, int
   return v;
 }
 
-const char* fjage_param_get_string(fjage_gw_t gw, fjage_aid_t aid, const char* param, int ndx) {
-  const char* v = NULL;
+int fjage_param_get_string(fjage_gw_t gw, fjage_aid_t aid, const char* param, int ndx, const char* strval, int len) {
+  int rv = -1;
   fjage_msg_t msg = fjage_msg_create(PARAM_REQ, FJAGE_REQUEST);
   fjage_msg_set_recipient(msg, aid);
   fjage_msg_add_int(msg, "index", ndx);
   fjage_msg_add_string(msg, "param", param);
   msg = fjage_request(gw, msg, PARAM_TIMEOUT);
   if (msg != NULL) {
-    if (fjage_msg_get_performative(msg) == FJAGE_INFORM) v = fjage_msg_get_string(msg, "value");
-    if (v != NULL) v = strdup(v);
+    if (fjage_msg_get_performative(msg) == FJAGE_INFORM) {
+      const char* v = fjage_msg_get_string(msg, "value");
+      if (v != NULL) rv = strlcpy((char*)strval, v, len);
+    }
     fjage_msg_destroy(msg);
   }
-  return v;
+  return rv;
 }
 
 int fjage_param_set_int(fjage_gw_t gw, fjage_aid_t aid, const char* param, int value, int ndx) {

--- a/gateways/c/src/fjage.c
+++ b/gateways/c/src/fjage.c
@@ -1145,7 +1145,7 @@ static const int fjage_msg_get_array(fjage_msg_t msg, const char* key, const cha
           sscanf(tt, "%d", &x);
           *((uint8_t*)value) = (uint8_t)(x & 0xff);
         }
-#ifdef _WIN32        
+#ifdef _WIN32
         ((uint8_t*)value) += sz;
 #else
         value += sz;
@@ -1363,6 +1363,7 @@ const char* fjage_param_get_string(fjage_gw_t gw, fjage_aid_t aid, const char* p
   msg = fjage_request(gw, msg, PARAM_TIMEOUT);
   if (msg != NULL) {
     if (fjage_msg_get_performative(msg) == FJAGE_INFORM) v = fjage_msg_get_string(msg, "value");
+    if (v != NULL) v = strdup(v);
     fjage_msg_destroy(msg);
   }
   return v;

--- a/gateways/c/src/fjage.c
+++ b/gateways/c/src/fjage.c
@@ -1364,7 +1364,10 @@ int fjage_param_get_string(fjage_gw_t gw, fjage_aid_t aid, const char* param, in
   if (msg != NULL) {
     if (fjage_msg_get_performative(msg) == FJAGE_INFORM) {
       const char* v = fjage_msg_get_string(msg, "value");
-      if (v != NULL) rv = strlcpy((char*)strval, v, len);
+      if (v != NULL){
+        if (strval != NULL && len > 0) rv = strlcpy((char*)strval, v, len);
+        else rv = strlen(v);
+      }
     }
     fjage_msg_destroy(msg);
   }

--- a/gateways/c/src/fjage.h
+++ b/gateways/c/src/fjage.h
@@ -517,7 +517,7 @@ bool fjage_param_get_bool(fjage_gw_t gw, fjage_aid_t aid, const char* param, int
 /// @param ndx            Index of the parameter (-1 for non-indexed parameters)
 /// @param strval         Pointer to a string to receive data, or NULL
 /// @param len            Size of the buffer, or 0 if strval is NULL
-/// @return               Length of the string copied into the buffer, or -1 if an error occurred
+/// @return               Length of the string copied into the buffer, or length of the string returned by the agent if strval is NULL, or -1 on error.
 
 int fjage_param_get_string(fjage_gw_t gw, fjage_aid_t aid, const char* param, int ndx, const char* strval, int len);
 

--- a/gateways/c/src/fjage.h
+++ b/gateways/c/src/fjage.h
@@ -508,7 +508,8 @@ float fjage_param_get_float(fjage_gw_t gw, fjage_aid_t aid, const char* param, i
 bool fjage_param_get_bool(fjage_gw_t gw, fjage_aid_t aid, const char* param, int ndx, bool defval);
 
 /// Get a string parameter from an agent. This is a utility function that sends a ParameterReq to an
-/// agent, and returns the value from the agent's response.
+/// agent, and returns the value from the agent's response. The returned pointer should be freed by
+/// the caller after use.
 ///
 /// @param gw             Gateway
 /// @param aid            AgentID of the target agent

--- a/gateways/c/src/fjage.h
+++ b/gateways/c/src/fjage.h
@@ -515,9 +515,11 @@ bool fjage_param_get_bool(fjage_gw_t gw, fjage_aid_t aid, const char* param, int
 /// @param aid            AgentID of the target agent
 /// @param param          Name of the parameter
 /// @param ndx            Index of the parameter (-1 for non-indexed parameters)
-/// @return               Parameter value, NULL if unavailable
+/// @param strval         Pointer to a string to receive data, or NULL
+/// @param len            Size of the buffer, or 0 if strval is NULL
+/// @return               Length of the string copied into the buffer, or -1 if an error occurred
 
-const char* fjage_param_get_string(fjage_gw_t gw, fjage_aid_t aid, const char* param, int ndx);
+int fjage_param_get_string(fjage_gw_t gw, fjage_aid_t aid, const char* param, int ndx, const char* strval, int len);
 
 /// Set an integer parameter on an agent. This is a utility function that sends a ParameterReq to an
 /// agent, and returns the value from the agent's response.

--- a/gateways/c/tests/test_fjage.c
+++ b/gateways/c/tests/test_fjage.c
@@ -232,6 +232,7 @@ int main(int argc, char* argv[]) {
   aid = fjage_agent_for_service(gw, "org.arl.fjage.shell.Services.SHELL");
   const char* lang = fjage_param_get_string(gw, aid, "org.arl.fjage.shell.ShellParam.language", -1);
   test_assert("get param (+string)", lang != NULL && !strcmp(lang, "Groovy"));
+  free((char *)lang);
   test_assert("get param (+int)", fjage_param_get_int(gw, aid, "BLOCKING", -1, 0) == -1);
   test_assert("get param (+long)", fjage_param_get_long(gw, aid, "BLOCKING", -1, 0) == -1);
   test_assert("get param (+float)", fjage_param_get_float(gw, aid, "BLOCKING", -1, 0) == -1.0);

--- a/gateways/c/tests/test_fjage.c
+++ b/gateways/c/tests/test_fjage.c
@@ -80,6 +80,7 @@ static void* intr_thread(void* p) {
 int main(int argc, char* argv[]) {
   printf("\n");
   fjage_gw_t gw;
+  char buf[256];
   if (argc > 1) {
 #ifdef _WIN32
     return error("Connection over serial port not supported on Windows");
@@ -230,13 +231,13 @@ int main(int argc, char* argv[]) {
   fjage_aid_destroy(topic);
   // FIXME: param tests are not perfect, since we don't have default agents with many params, but better than nothing...
   aid = fjage_agent_for_service(gw, "org.arl.fjage.shell.Services.SHELL");
-  const char* lang = fjage_param_get_string(gw, aid, "org.arl.fjage.shell.ShellParam.language", -1);
-  test_assert("get param (+string)", lang != NULL && !strcmp(lang, "Groovy"));
-  free((char *)lang);
+  int rv = fjage_param_get_string(gw, aid, "org.arl.fjage.shell.ShellParam.language", -1, buf, sizeof(buf));
+  test_assert("get param (rv)", rv > 0);
+  test_assert("get param (+string)", !strcmp(buf, "Groovy"));
   test_assert("get param (+int)", fjage_param_get_int(gw, aid, "BLOCKING", -1, 0) == -1);
   test_assert("get param (+long)", fjage_param_get_long(gw, aid, "BLOCKING", -1, 0) == -1);
   test_assert("get param (+float)", fjage_param_get_float(gw, aid, "BLOCKING", -1, 0) == -1.0);
-  test_assert("get param (-string)", fjage_param_get_string(gw, aid, "dummy", -1) == NULL);
+  test_assert("get param (-string)", fjage_param_get_string(gw, aid, "dummy", -1, buf, sizeof(buf)) == -1);
   test_assert("get param (-int)", fjage_param_get_int(gw, aid, "dummy", -1, 0) == 0);
   test_assert("get param (-long)", fjage_param_get_long(gw, aid, "dummy", -1, 0) == 0);
   test_assert("get param (-float)", fjage_param_get_float(gw, aid, "dummy", -1, 0) == 0.0);

--- a/gateways/c/tests/test_fjage.c
+++ b/gateways/c/tests/test_fjage.c
@@ -232,7 +232,9 @@ int main(int argc, char* argv[]) {
   // FIXME: param tests are not perfect, since we don't have default agents with many params, but better than nothing...
   aid = fjage_agent_for_service(gw, "org.arl.fjage.shell.Services.SHELL");
   int rv = fjage_param_get_string(gw, aid, "org.arl.fjage.shell.ShellParam.language", -1, buf, sizeof(buf));
-  test_assert("get param (rv)", rv > 0);
+  test_assert("get param (+string/rv)", rv == 6);
+  rv = fjage_param_get_string(gw, aid, "org.arl.fjage.shell.ShellParam.language", -1, NULL, 0);
+  test_assert("get param (+string/bufsize)", rv == 6);
   test_assert("get param (+string)", !strcmp(buf, "Groovy"));
   test_assert("get param (+int)", fjage_param_get_int(gw, aid, "BLOCKING", -1, 0) == -1);
   test_assert("get param (+long)", fjage_param_get_long(gw, aid, "BLOCKING", -1, 0) == -1);


### PR DESCRIPTION
This is a bug fix for a bug in `fjage.c` where `fjage_get_param_str` causes a null pointer to be returned even if there is a valid string available.

The reason is : 

https://github.com/org-arl/fjage/blob/master/gateways/c/src/fjage.c#L1365..L1366
`v = fjage_msg_get_string(msg, "value");`
`v` is a pointer into the message's body to the string..
And then we free the message body with `fjage_msg_destroy(msg);`
So `v` is now pointing into freed memory.

The fix is to return a copy of the string instead.