### PR TITLE
Updating dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,18 +38,18 @@ repositories {
 }
 
 dependencies {
-  api 'org.codehaus.groovy:groovy:2.5.9'
-  api 'org.jline:jline:3.12.1'
-  api 'org.apache.commons:commons-lang3:3.9'
-  api 'commons-io:commons-io:2.6'
+  api 'org.codehaus.groovy:groovy:2.5.20'
+  api 'org.jline:jline:3.21.0'
+  api 'org.apache.commons:commons-lang3:3.12.0'
+  api 'commons-io:commons-io:2.11.0'
   api 'uk.com.robust-it:cloning:1.9.12'
-  api 'org.eclipse.jetty:jetty-server:9.4.26.v20200117'
-  api 'org.eclipse.jetty:jetty-servlet:9.4.26.v20200117'
-  api 'org.eclipse.jetty:jetty-rewrite:9.4.26.v20200117'
-  api 'org.eclipse.jetty.websocket:websocket-server:9.4.26.v20200117'
-  api 'com.google.code.gson:gson:2.8.5'
-  api 'com.fazecast:jSerialComm:2.5.1'
-  testImplementation 'junit:junit:4.12'
+  api 'org.eclipse.jetty:jetty-server:9.4.50.v20221201'
+  api 'org.eclipse.jetty:jetty-servlet:9.4.50.v20221201'
+  api 'org.eclipse.jetty:jetty-rewrite:9.4.50.v20221201'
+  api 'org.eclipse.jetty.websocket:websocket-server:9.4.50.v20221201'
+  api 'com.google.code.gson:gson:2.10'
+  api 'com.fazecast:jSerialComm:2.9.3'
+  testImplementation 'junit:junit:4.13.2'
   testImplementation 'net.jodah:concurrentunit:0.4.6'
 }
 


### PR DESCRIPTION
As a first step to upgrading to newer Groovy/Java, this upgrades all the dependencies to the latest of MINOR/PATCH.

I verified that jSerialComm which had broken when we upgraded to jSerialComm 2.9.2 (https://github.com/org-arl/fjage/commit/624a3c291c2447d5d04ea6db7fbf0d085e0b4365) has been fixed in jSerialComm v2.9.3 (https://github.com/Fazecast/jSerialComm/releases/tag/v2.9.3) and doesn't break modem builds.