### PR TITLE
Improving jetty warnings

### DIFF
--- a/src/main/java/org/arl/fjage/connectors/WebServer.java
+++ b/src/main/java/org/arl/fjage/connectors/WebServer.java
@@ -52,7 +52,10 @@ public class WebServer {
       @Override public String getName()                         { return "[jetty]"; }
       @Override public Logger getLogger(String name)            { return this;      }
       @Override public boolean isDebugEnabled()                 { return false;     }
-      @Override public void warn(String msg, Object... args)    { log.warning(msg);          }
+      @Override public void warn(String msg, Object... args)    {
+        if (msg.contains("{}")) for (Object a: args) msg = msg.replaceFirst("\\{}", a.toString());
+        log.warning(msg);
+      }
       @Override public void warn(Throwable t)                   { log.warning(t.toString()); }
       @Override public void warn(String msg, Throwable thrown)  { log.warning(msg);          }
       @Override public void info(String msg, Object... args)    { }


### PR DESCRIPTION
We shim the Jetty Logger to redirect the logs to standard fjåge logs. But jetty tends to use SLFJ style log statements with implicit string interpolation using `{}`.

This PR adds a very simple mechanism in the shim to interpolate and replace all the `{}` with the `toString` version of the argument objects. This would enable the warnings from jetty to be printed completely in fjage logs..

For example, before : 

```
1675069150492|WARNING|org.arl.fjage.connectors.WebServer@1:warn|bad alias ({} {}) for {}
```

after : 

```
1675131104860|WARNING|org.arl.fjage.connectors.WebServer@1:warn|bad alias (java.security.AccessControlException access denied ("java.io.FilePermission" "/home/unet/logs" "readlink")) for /home/unet/logs
```