### PR TITLE
Python Gateway cleanup

### DIFF
--- a/gateways/python/.gitignore
+++ b/gateways/python/.gitignore
@@ -1,0 +1,3 @@
+dist/
+*.egg-info/
+README.rst

--- a/gateways/python/Makefile
+++ b/gateways/python/Makefile
@@ -1,0 +1,16 @@
+.PHONY: install clean
+
+docs:
+	@sed '/^\.\. highlight.*/d' ../../src/sphinx/pythongw.rst > README.rst
+
+testupload: docs
+	python setup.py sdist bdist_wheel
+	twine upload --repository testpypi dist/*
+
+upload: docs
+	python setup.py sdist
+	twine upload --repository pypi dist/*
+
+clean:
+	find . -name *.pyc -exec rm {} \;
+	rm -rf build fjagepy.egg-info dist

--- a/gateways/python/README.md
+++ b/gateways/python/README.md
@@ -1,10 +1,10 @@
 # fjåge Python gateway (fjagepy)
 
-## Installing via Pip
+## Requirements
 
-Python comes with an inbuilt package management system, [pip](https://pip.pypa.io/en/stable/). Pip can install, update, or delete any official package.
+- [Python3](https://www.python.org/downloads/)
 
-You can install fjagepy package via the command line by entering:
+## Installing via [Pip](https://pip.pypa.io/en/stable/)
 
 ```bash
 pip install fjagepy
@@ -12,4 +12,4 @@ pip install fjagepy
 
 ## Documentation
 
-The documentation is available at [fjagepy](https://pypi.org/project/fjagepy/).
+The documentation is available at [fjagepy](https://pypi.org/project/fjagepy/)

--- a/gateways/python/fjagepy/__init__.py
+++ b/gateways/python/fjagepy/__init__.py
@@ -718,7 +718,8 @@ class Gateway:
         try:
             self.socket.close()
         except Exception as e:
-            self.logger.critical("Exception: " + str(e))
+            if (hasattr(self, 'logger') and self.logger != None):
+                self.logger.critical("Exception: " + str(e))
 
     def close(self):
         """Closes the gateway. The gateway functionality may not longer be accessed after this method is called.

--- a/gateways/python/setup.py
+++ b/gateways/python/setup.py
@@ -1,21 +1,11 @@
 from setuptools import setup, find_packages
 
-with open('../../src/sphinx/pythongw.rst') as f:
-    with open('README.rst', 'w') as f1:
-        for line in f:
-            if ".. highlight" not in line:
-                f1.write(line)
-
 with open('README.rst') as f:
     readme = f.read()
 
-# with open('../../../VERSION') as f:
-#     ver = f.read()
-#     ver = ver.split('-')[0]
-
 setup(
     name='fjagepy',
-    version='1.7.2',
+    version='1.7.4',
     description='Python Gateway',
     long_description=readme,
     author='Prasad Anjangi, Mandar Chitre, Chinmay Pendharkar, Manu Ignatius',
@@ -27,9 +17,15 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11'
     ],
-    packages=find_packages(exclude=('tests', 'docs')),
+    packages=find_packages(),
     install_requires=[
         'numpy>=1.11'
     ],
+    license_files = ('LICENSE',)
 )

--- a/src/test/groovy/org/arl/fjage/test/BasicTests.py
+++ b/src/test/groovy/org/arl/fjage/test/BasicTests.py
@@ -61,23 +61,23 @@ class FjageTest(unittest.TestCase):
 
     def test_parameters(self):
         """Test: Should be able to set and get parameter values"""
-        self.assertEquals(self.g.agent('S').y, 2)           # should get the value of a single parameter
-        self.assertEquals(self.g.agent('S').k, None)        # should return None if asked to get the value of unknown parameter
+        self.assertEqual(self.g.agent('S').y, 2)            # should get the value of a single parameter
+        self.assertEqual(self.g.agent('S').k, None)         # should return None if asked to get the value of unknown parameter
         self.g.agent('S').a = 42                            # should set the value of a single parameter and return the new value
-        self.assertEquals(self.g.agent('S').a, 42)
+        self.assertEqual(self.g.agent('S').a, 42)
         self.g.agent('S').a = 0
-        self.assertEquals(self.g.agent('S').a, 0)
+        self.assertEqual(self.g.agent('S').a, 0)
         self.g.agent('S').k = 42                            # should return None if asked to set the value of unknown parameter
-        self.assertEquals(self.g.agent('S').k, None)
+        self.assertEqual(self.g.agent('S').k, None)
         self.g.agent('S')[1].z = 4                          # should get the value of a single indexed parameter
-        self.assertEquals(self.g.agent('S')[1].z, 4)
-        self.assertEquals(self.g.agent('S')[1].k, None)     # should return None if asked to get the value of unknown indexed parameter
+        self.assertEqual(self.g.agent('S')[1].z, 4)
+        self.assertEqual(self.g.agent('S')[1].k, None)      # should return None if asked to get the value of unknown indexed parameter
         self.g.agent('S')[1].z = 42                         # should set the value of a single indexed parameter and return the new value
-        self.assertEquals(self.g.agent('S')[1].z, 42)
+        self.assertEqual(self.g.agent('S')[1].z, 42)
         self.g.agent('S')[1].z = 4
-        self.assertEquals(self.g.agent('S')[1].z, 4)
+        self.assertEqual(self.g.agent('S')[1].z, 4)
         self.g.agent('S')[1].k = 1
-        self.assertEquals(self.g.agent('S')[1].k, None)     # should return None if asked to set the value of unknown indexed test_parameters
+        self.assertEqual(self.g.agent('S')[1].k, None)     # should return None if asked to set the value of unknown indexed test_parameters
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Fixing a few things in the Fjage Gateway

- Fixed deprecated `assertEquals` calls in the tests
- Added a Makefile for ease of publishing to PyPi and TestPyPi
- Moving the login inside `setup.py` to generate Readme.rst to the Makefile
- Fixing the incorrect exception when `fjage.Gateway()` was called without any arguments