### PR TITLE
Use the canonicalPath when serving local directories

### DIFF
--- a/src/main/java/org/arl/fjage/connectors/WebServer.java
+++ b/src/main/java/org/arl/fjage/connectors/WebServer.java
@@ -287,15 +287,20 @@ public class WebServer {
    * @param cacheControl cache control header.
    */
   public void add(String context, File dir, String cacheControl) {
-    ContextHandler handler = new ContextHandler(context);
-    ResourceHandler resHandler = new ResourceHandler();
-    resHandler.setResourceBase(dir.getAbsolutePath());
-    resHandler.setWelcomeFiles(new String[]{ "index.html" });
-    resHandler.setDirectoriesListed(false);
-    resHandler.setCacheControl(cacheControl);
-    handler.setHandler(resHandler);
-    staticContexts.put(context, handler);
-    add(handler);
+    try {
+      ContextHandler handler = new ContextHandler(context);
+      ResourceHandler resHandler = new ResourceHandler();
+      resHandler.setResourceBase(dir.getCanonicalPath());
+      resHandler.setWelcomeFiles(new String[]{ "index.html" });
+      resHandler.setDirectoriesListed(false);
+      resHandler.setCacheControl(cacheControl);
+      handler.setHandler(resHandler);
+      staticContexts.put(context, handler);
+      add(handler);
+    }catch (IOException ex){
+      log.warning("Unable to find the directory : " + dir.toString());
+      return;
+    }
   }
 
   /**


### PR DESCRIPTION
Instead of using `getAbsolutePath`, use `getCanonicalPath` when adding contexts for serving local directories. `getCanonicalPath` traverses symlinks, while `getAbsolutePath` doesn't.

Serving something across a symlink is frowned upon by jetty. So it's recommended to use the canonical paths to add context for statically serving files.