### PR TITLE
Checking if the executor pool is shutdown before executing

### DIFF
--- a/src/main/java/org/arl/fjage/remote/ConnectionHandler.java
+++ b/src/main/java/org/arl/fjage/remote/ConnectionHandler.java
@@ -160,6 +160,13 @@ class ConnectionHandler extends Thread {
     fw.signoff();
     close();
     pool.shutdown();
+    try {
+      if (!pool.awaitTermination(200, TimeUnit.MILLISECONDS)) {
+        pool.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      pool.shutdownNow();
+    }
   }
 
   @Override
@@ -226,7 +233,7 @@ class ConnectionHandler extends Thread {
   }
 
   void printlnQueued(String s) {
-    if (pool != null) pool.execute(() -> println(s));
+    if (pool != null && !pool.isShutdown()) pool.execute(() -> println(s));
   }
 
   JsonMessage printlnAndGetResponse(String s, String id, long timeout) {


### PR DESCRIPTION
ConnectionHandler uses `SingleThreadExecutor` to send messages on a given Connector. If the Connector stops, it can cause the ExecutorPool to be stopped. So we need to check if the Executor has not stopped before trying to send something on the connector.