### PR TITLE
Reverting caching the stringified version of the JSONMessage

### DIFF
--- a/src/main/java/org/arl/fjage/remote/JsonMessage.java
+++ b/src/main/java/org/arl/fjage/remote/JsonMessage.java
@@ -58,13 +58,10 @@ public class JsonMessage {
   }
 
   public static JsonMessage fromJson(String s) {
-    JsonMessage j = gson.fromJson(s, JsonMessage.class);
-    if (j.message != null) j.message.setJsonCache(s);
     return gson.fromJson(s, JsonMessage.class);
   }
 
   public String toJson() {
-    if (this.message != null && this.message.getJsonCache() != null) return this.message.getJsonCache();
     return gson.toJson(this);
   }
 


### PR DESCRIPTION
Reverting this feature since it doesn't deal with the `relay` property which does get unset when a message is relayed. 

Also, the implementation had a bug, and it wasn't actually being used.