### PR TITLE
Allow named params to match with param enums in `get()`

### DIFF
--- a/src/main/java/org/arl/fjage/param/NamedParameter.java
+++ b/src/main/java/org/arl/fjage/param/NamedParameter.java
@@ -74,20 +74,22 @@ public class NamedParameter implements Parameter, Serializable {
   }
 
   /**
-   * Compares if two named parameters are equals.
+   * Compares if a parameter is equivalent to the named parameter.
    *
    * @return true if two parameters are equal
    */
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof NamedParameter)) return false;
-    NamedParameter p = (NamedParameter)obj;
+    if (!(obj instanceof Parameter)) return false;
     String name1 = name;
     if (name1.contains(".")) name1 = name1.substring(name1.indexOf('.')+1);
-    String name2 = p.name;
+    String name2 = obj.toString();
     if (name2.contains(".")) name2 = name2.substring(name2.indexOf('.')+1);
     if (!name1.equals(name2)) return false;
-    if (ord >= 0 && p.ord >= 0 && p.ord != ord) return false;
+    if (obj instanceof NamedParameter) {
+      NamedParameter p = (NamedParameter)obj;
+      if (ord >= 0 && p.ord >= 0 && p.ord != ord) return false;
+    }
     return true;
   }
 

--- a/src/main/java/org/arl/fjage/param/NamedParameter.java
+++ b/src/main/java/org/arl/fjage/param/NamedParameter.java
@@ -74,22 +74,20 @@ public class NamedParameter implements Parameter, Serializable {
   }
 
   /**
-   * Compares if a parameter is equivalent to the named parameter.
+   * Compares if two named parameters are equal.
    *
    * @return true if two parameters are equal
    */
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof Parameter)) return false;
+    if (!(obj instanceof NamedParameter)) return false;
+    NamedParameter p = (NamedParameter)obj;
     String name1 = name;
     if (name1.contains(".")) name1 = name1.substring(name1.indexOf('.')+1);
-    String name2 = obj.toString();
+    String name2 = p.name;
     if (name2.contains(".")) name2 = name2.substring(name2.indexOf('.')+1);
     if (!name1.equals(name2)) return false;
-    if (obj instanceof NamedParameter) {
-      NamedParameter p = (NamedParameter)obj;
-      if (ord >= 0 && p.ord >= 0 && p.ord != ord) return false;
-    }
+    if (ord >= 0 && p.ord >= 0 && p.ord != ord) return false;
     return true;
   }
 

--- a/src/main/java/org/arl/fjage/param/Parameter.java
+++ b/src/main/java/org/arl/fjage/param/Parameter.java
@@ -22,4 +22,11 @@ public interface Parameter {
    */
   public int ordinal();
 
+  /**
+   * Gets the parameter name.
+   *
+   * @return unqualified parameter name
+   */
+  public String name();
+
 }

--- a/src/main/java/org/arl/fjage/param/ParameterRsp.java
+++ b/src/main/java/org/arl/fjage/param/ParameterRsp.java
@@ -90,10 +90,10 @@ public class ParameterRsp extends Message {
    * @return value of requested parameter
    */
   public Object get(Parameter param) {
-    if (param == null) return null;
-    if (this.param == null) return null;
+    if (this.param == null || param == null) return null;
+    param = resolve(param);
     Object rv = null;
-    if (param.equals(this.param)) {
+    if (this.param.equals(param)) {
       if (value == null) return null;
       rv = value.getValue();
     } else {
@@ -113,6 +113,8 @@ public class ParameterRsp extends Message {
    * @return true if parameter is read-only, false if read-write
    */
   public boolean isReadonly(Parameter param) {
+    if (param == null) return false;
+    param = resolve(param);
     return readonly.contains(param);
   }
 
@@ -138,6 +140,24 @@ public class ParameterRsp extends Message {
     if (param != null) map.put(param, value);
     if (values != null) map.putAll(values);
     return map;
+  }
+
+  /**
+   * Convert named parameters to qualified parameters, if they match.
+   *
+   * @param param parameter to resolve
+   * @return resolved parameter
+   */
+  protected Parameter resolve(Parameter param) {
+    if (!(param instanceof NamedParameter)) return param;
+    String p = ((NamedParameter)param).name();
+    if (this.param != null && this.param.name().equals(p)) return this.param;
+    if (values != null) {
+      for (Entry<Parameter, GenericValue> e : values.entrySet()) {
+        if (e.getKey().name().equals(p)) return e.getKey();
+      }
+    }
+    return param;
   }
 
   @Override

--- a/src/main/java/org/arl/fjage/param/ParameterRsp.java
+++ b/src/main/java/org/arl/fjage/param/ParameterRsp.java
@@ -90,9 +90,10 @@ public class ParameterRsp extends Message {
    * @return value of requested parameter
    */
   public Object get(Parameter param) {
+    if (param == null) return null;
     if (this.param == null) return null;
     Object rv = null;
-    if (this.param.equals(param)) {
+    if (param.equals(this.param)) {
       if (value == null) return null;
       rv = value.getValue();
     } else {


### PR DESCRIPTION
Fixes #284

After fix:
```groovy
> node.nodeName
Barrackpore.local
> import org.arl.fjage.param.*
> req = new ParameterReq(node).get(new NamedParameter("nodeName"))
ParameterReq[nodeName:?]
> x = node.request(req)
ParameterRsp[nodeName:Barrackpore.local]
> x.get(org.arl.unet.nodeinfo.NodeInfoParam.nodeName)
Barrackpore.local
> x.get(new NamedParameter("nodeName"))
Barrackpore.local
> node.get(new NamedParameter("nodeName"))
Barrackpore.local
> req = new ParameterReq(node)
ParameterReq[]
> x = node.request(req)
ParameterRsp[address:99 origin:[D@10ef0353 canForward:true heading:null depth:null description*:Manages and maintains node information and attributes. nodeName:Barrackpore.local title*:Node information pitch:null speed:null time*:Tue Aug 08 15:48:44 SGT 2023 roll:null addressSize:8 turnRate:null location:[D@2911ab14 diveRate:null mobility:false]
> x.get(org.arl.unet.nodeinfo.NodeInfoParam.nodeName)
Barrackpore.local
> x.get(new NamedParameter("nodeName"))
Barrackpore.local
```