### PR TITLE
feat(remote): Use LONG_OR_DOUBLE parsing for Json numbers

### DIFF
--- a/src/main/java/org/arl/fjage/remote/JsonMessage.java
+++ b/src/main/java/org/arl/fjage/remote/JsonMessage.java
@@ -47,6 +47,8 @@ public class JsonMessage {
     .registerTypeAdapterFactory(new MessageAdapterFactory())
     .registerTypeAdapterFactory(new ArrayAdapterFactory())
     .registerTypeAdapterFactory(new GenericValueAdapterFactory())
+    .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+    .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
     .serializeSpecialFloatingPointValues()
     .enableComplexMapKeySerialization();
 


### PR DESCRIPTION
`gson.fromJson(json, Object.class)` and `gson.fromJson(json, Number.class)` [by default](https://javadoc.io/static/com.google.code.gson/gson/2.10.1/com.google.gson/com/google/gson/ToNumberPolicy.html#DOUBLE) parse any numeric input as a `Double` even when the input is actually an integer. This PR uses the [`setObjectToNumber()`](https://javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/GsonBuilder.html#setObjectToNumberStrategy(com.google.gson.ToNumberStrategy)) and [`setNumberToNumber()`](https://javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/GsonBuilder.html#setNumberToNumberStrategy(com.google.gson.ToNumberStrategy)) functions to change the parsing strategy to [`LONG_OR_DOUBLE`](https://javadoc.io/static/com.google.code.gson/gson/2.10.1/com.google.gson/com/google/gson/ToNumberPolicy.html#LONG_OR_DOUBLE) so that (small enough) integers are read as `Long` and only true floating-point numbers (or very large integers) are read as `Double`. This feels like a more reasonable default for two reasons:

- Using `Long` whenever possible is more accurate. 
- Floating-point numbers suggest that rounding is acceptable when really it may not be. 