### PR TITLE
Fix Gateway <-> Wormhole interop

### DIFF
--- a/src/main/java/org/arl/fjage/Container.java
+++ b/src/main/java/org/arl/fjage/Container.java
@@ -569,7 +569,7 @@ public class Container {
    * Starts the container and all agents in it.
    * This should be called after init().
    */
-  void start() {
+  protected void start() {
     if (!running) {
       log.info("Starting container...");
       running = true;

--- a/src/main/java/org/arl/fjage/remote/Gateway.java
+++ b/src/main/java/org/arl/fjage/remote/Gateway.java
@@ -57,7 +57,7 @@ public class Gateway implements Messenger, Closeable {
    * @param port TCP port to connect to.
    */
   public Gateway(Platform platform, String hostname, int port) throws IOException {
-    container = new SlaveContainer(platform, "Gateway@"+hashCode(), hostname, port);
+    container = new SlaveContainer(platform, "Gateway-"+hashCode(), hostname, port);
     init();
     platform.start();
   }
@@ -70,7 +70,7 @@ public class Gateway implements Messenger, Closeable {
    */
   public Gateway(String hostname, int port) throws IOException {
     Platform platform = new RealTimePlatform();
-    container = new SlaveContainer(platform, "Gateway@"+hashCode(), hostname, port);
+    container = new SlaveContainer(platform, "Gateway-"+hashCode(), hostname, port);
     init();
     platform.start();
   }
@@ -86,7 +86,7 @@ public class Gateway implements Messenger, Closeable {
    * @param settings RS232 settings (null for defaults, or "N81" for no parity, 8 bits, 1 stop bit).
    */
   public Gateway(Platform platform, String devname, int baud, String settings) throws IOException {
-    container = new SlaveContainer(platform, "Gateway@"+hashCode(), devname, baud, settings);
+    container = new SlaveContainer(platform, "Gateway-"+hashCode(), devname, baud, settings);
     init();
     platform.start();
   }
@@ -100,7 +100,7 @@ public class Gateway implements Messenger, Closeable {
    */
   public Gateway(String devname, int baud, String settings) throws IOException {
     Platform platform = new RealTimePlatform();
-    container = new SlaveContainer(platform, "Gateway@"+hashCode(), devname, baud, settings);
+    container = new SlaveContainer(platform, "Gateway-"+hashCode(), devname, baud, settings);
     init();
     platform.start();
   }
@@ -443,4 +443,3 @@ public class Gateway implements Messenger, Closeable {
   }
 
 }
-

--- a/src/main/java/org/arl/fjage/remote/SlaveContainer.java
+++ b/src/main/java/org/arl/fjage/remote/SlaveContainer.java
@@ -304,6 +304,11 @@ public class SlaveContainer extends RemoteContainer {
     return aid;
   }
 
+  protected void start() {
+    super.start();
+    updateWatchList();
+  }
+
   public boolean kill(AgentID aid) {
     boolean rv = super.kill(aid);
     if (rv) updateWatchList();


### PR DESCRIPTION
Consider a setup where a Java `Gateway` is connected to a master container with a Unet `Wormhole` agent running in it. In this scenario, the gateway will currently not receive any messages addressed to it. 

The technical reasons behind this are as follows. 

- The gateway's name is of the form `Gateway@<number>`, i.e. it looks just like an agent that is wormholed to the master container. 
- The Java gateway currently does not submit a `wantsMessagesFor` to the master container. Therefore, it receives all the messages that aren't claimed on the master container, but it also receives only those. 
- Consequently, the gateway doesn't receive messages addressed to it: the wormhole claims all messages addressed to `<name>@<number>`, and the master container doesn't know that the gateway would like to receive messages addressed to `Gateway@<number>`. 

This PR fixes both of these aspects. 

- It makes sure that Java `Gateway`s do send a `wantsMessagesFor` on startup. 
- It changes the gateway naming pattern from `Gateway@(\d+)` to `Gateway-(\d+)` to avoid confusion with wormholed agents. 

Strictly speaking, either change would have been enough on its own, but there's no reason not to fix both for extra robustness (and performance in the case of the `wantsMessagesFor`). 