### PR TITLE
Fix gateway names to avoid clashes with wormhole agent

### DIFF
--- a/gateways/c/src/fjage.c
+++ b/gateways/c/src/fjage.c
@@ -550,7 +550,7 @@ fjage_gw_t fjage_tcp_open(const char* hostname, int port) {
   fgw->intr = 0;
 #endif
   char s[64];
-  sprintf(s, "CGatewayAgent@%08x", rand());
+  sprintf(s, "CGateway-%08x", rand());
   fgw->aid = fjage_aid_create(s);
   fgw->head = 0;
   update_watch(fgw);
@@ -620,7 +620,7 @@ fjage_gw_t fjage_rs232_open(const char* devname, int baud, const char* settings)
   fgw->intr = 0;
 #endif
   char s[64];
-  sprintf(s, "CGatewayAgent@%08x", rand());
+  sprintf(s, "CGateway-%08x", rand());
   fgw->aid = fjage_aid_create(s);
   fgw->head = 0;
   return fgw;

--- a/src/main/java/org/arl/fjage/remote/Gateway.java
+++ b/src/main/java/org/arl/fjage/remote/Gateway.java
@@ -57,7 +57,7 @@ public class Gateway implements Messenger, Closeable {
    * @param port TCP port to connect to.
    */
   public Gateway(Platform platform, String hostname, int port) throws IOException {
-    container = new SlaveContainer(platform, "Gateway-"+hashCode(), hostname, port);
+    container = new SlaveContainer(platform, getAgentID().getName(), hostname, port);
     init();
     platform.start();
   }
@@ -70,7 +70,7 @@ public class Gateway implements Messenger, Closeable {
    */
   public Gateway(String hostname, int port) throws IOException {
     Platform platform = new RealTimePlatform();
-    container = new SlaveContainer(platform, "Gateway-"+hashCode(), hostname, port);
+    container = new SlaveContainer(platform, getAgentID().getName(), hostname, port);
     init();
     platform.start();
   }
@@ -86,7 +86,7 @@ public class Gateway implements Messenger, Closeable {
    * @param settings RS232 settings (null for defaults, or "N81" for no parity, 8 bits, 1 stop bit).
    */
   public Gateway(Platform platform, String devname, int baud, String settings) throws IOException {
-    container = new SlaveContainer(platform, "Gateway-"+hashCode(), devname, baud, settings);
+    container = new SlaveContainer(platform, getAgentID().getName(), devname, baud, settings);
     init();
     platform.start();
   }
@@ -100,7 +100,7 @@ public class Gateway implements Messenger, Closeable {
    */
   public Gateway(String devname, int baud, String settings) throws IOException {
     Platform platform = new RealTimePlatform();
-    container = new SlaveContainer(platform, "Gateway-"+hashCode(), devname, baud, settings);
+    container = new SlaveContainer(platform, getAgentID().getName(), devname, baud, settings);
     init();
     platform.start();
   }
@@ -177,7 +177,7 @@ public class Gateway implements Messenger, Closeable {
    * @return agent ID
    */
   public AgentID getAgentID() {
-    return new AgentID("GatewayAgent@"+hashCode());
+    return new AgentID("JavaGateway-"+hashCode());
   }
 
   /**


### PR DESCRIPTION
- Changes the agent ID of the C gateway from `CGatewayAgent@...` to `CGateway-...` to avoid clashes with the Unet wormhole agent (see https://github.com/org-arl/fjage/pull/294). 
- Factors out the agent ID creation in the Java gateway so all ways of creating a Java gateway lead to the same agent ID.