### PR TITLE
Add option to reject various APIs and added new agents API

### DIFF
--- a/gateways/js/dist/esm/fjage.js
+++ b/gateways/js/dist/esm/fjage.js
@@ -499,7 +499,7 @@ class AgentID {
     const rsp = await this.owner.request(msg, timeout);
     var ret = Array.isArray(params) ? new Array(params.length).fill(null) : null;
     if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) {
-      if (this.owner._returnNullOnError) return ret;
+      if (this.owner._returnNullOnFailedResponse) return ret;
       else throw new Error(`Unable to set ${this.name}.${params} to ${values}`);
     }
     if (Array.isArray(params)) {
@@ -540,7 +540,7 @@ class AgentID {
     const rsp = await this.owner.request(msg, timeout);
     var ret = Array.isArray(params) ? new Array(params.length).fill(null) : null;
     if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) {
-      if (this.owner._returnNullOnError) return ret;
+      if (this.owner._returnNullOnFailedResponse) return ret;
       else throw new Error(`Unable to get ${this.name}.${params}`);
     }
     // Request for listing of all parameters.
@@ -649,7 +649,6 @@ class Message {
       console.warn('Error trying to deserialize JSON object : ', obj, err);
       return null;
     }
-
   }
 }
 
@@ -681,7 +680,7 @@ class GenericMessage extends Message {
  * @param {string} [opts.keepAlive=true]     - try to reconnect if the connection is lost
  * @param {number} [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
  * @param {number} [opts.timeout=1000]       - timeout for fjage level messages in ms
- * @param {boolean} [opts.returnNullOnError=true] - return null instead of throwing an error when a parameter is not found
+ * @param {boolean} [opts.returnNullOnFailedResponse=true] - return null instead of throwing an error when a parameter is not found
  * @param {string} [hostname="localhost"]    - <strike>Deprecated : hostname/ip address of the master container to connect to</strike>
  * @param {number} [port=]                   - <strike>Deprecated : port number of the master container to connect to</strike>
  * @param {string} [pathname=="/ws/"]        - <strike>Deprecated : path of the master container to connect to (for WebSockets)</strike>
@@ -710,7 +709,7 @@ class Gateway {
     this._timeout = opts.timeout;         // timeout for fjage level messages (agentForService etc)
     this._keepAlive = opts.keepAlive;     // reconnect if connection gets closed/errored
     this._queueSize = opts.queueSize;      // size of queue
-    this._returnNullOnError = opts.returnNullOnError; // null or error
+    this._returnNullOnFailedResponse = opts.returnNullOnFailedResponse; // null or error
     this.pending = {};                    // msgid to callback mapping for pending requests to server
     this.subscriptions = {};              // hashset for all topics that are subscribed
     this.listener = {};                   // set of callbacks that want to listen to incoming messages
@@ -1095,7 +1094,11 @@ class Gateway {
   async agentForService(service) {
     let rq = { action: 'agentForService', service: service };
     let rsp = await this._msgTxRx(rq);
-    if (!rsp || !rsp.agentID) return;
+    if (!rsp) {
+      if (this._returnNullOnFailedResponse) return null;
+      else throw new Error('Unable to get agent for service');
+    }
+    if (!rsp.agentID) return null;
     return new AgentID(rsp.agentID, false, this);
   }
 
@@ -1109,7 +1112,11 @@ class Gateway {
     let rq = { action: 'agentsForService', service: service };
     let rsp = await this._msgTxRx(rq);
     let aids = [];
-    if (!rsp || !Array.isArray(rsp.agentIDs)) return aids;
+    if (!rsp) {
+      if (this._returnNullOnFailedResponse) return aids;
+      else throw new Error('Unable to get agents for service');
+    }
+    if (!Array.isArray(rsp.agentIDs)) return aids;
     for (var i = 0; i < rsp.agentIDs.length; i++)
       aids.push(new AgentID(rsp.agentIDs[i], false, this));
     return aids;
@@ -1329,7 +1336,7 @@ if (isBrowser || isWebWorker){
     'timeout': 1000,
     'keepAlive' : true,
     'queueSize': DEFAULT_QUEUE_SIZE,
-    'returnNullOnError': true
+    'returnNullOnFailedResponse': true
   });
   DEFAULT_URL = new URL('ws://localhost');
   // Enable caching of Gateways
@@ -1344,7 +1351,7 @@ if (isBrowser || isWebWorker){
     'timeout': 1000,
     'keepAlive' : true,
     'queueSize': DEFAULT_QUEUE_SIZE,
-    'returnNullOnError': true
+    'returnNullOnFailedResponse': true
   });
   DEFAULT_URL = new URL('tcp://localhost');
   gObj.atob = a => Buffer.from(a, 'base64').toString('binary');

--- a/gateways/js/dist/esm/fjage.js
+++ b/gateways/js/dist/esm/fjage.js
@@ -1062,6 +1062,30 @@ class Gateway {
   }
 
   /**
+   * Gets a list of all agents in the container.
+   * @returns {Promise<AgentID[]>} - a promise which returns an array of all agent ids when resolved
+   */
+  async agents() {
+    let rq = { action: 'agents' };
+    let rsp = await this._msgTxRx(rq);
+    if (!rsp || !Array.isArray(rsp.agentIDs)) throw new Error('Unable to get agents');
+    return rsp.agentIDs.map(aid => new AgentID(aid, false, this));
+  }
+
+  /**
+   * Check if an agent with a given name exists in the container.
+   *
+   * @param {AgentID|String} agentID - the agent id to check
+   * @returns {Promise<boolean>} - a promise which returns true if the agent exists when resolved
+   */
+  async containsAgent(agentID) {
+    let rq = { action: 'containsAgent', agentID: agentID instanceof AgentID ? agentID.getName() : agentID };
+    let rsp = await this._msgTxRx(rq);
+    if (!rsp) throw new Error('Unable to check if agent exists');
+    return !!rsp.answer;
+  }
+
+  /**
    * Finds an agent that provides a named service. If multiple agents are registered
    * to provide a given service, any of the agents' id may be returned.
    *

--- a/gateways/js/dist/esm/fjage.js
+++ b/gateways/js/dist/esm/fjage.js
@@ -498,14 +498,17 @@ class AgentID {
     msg.index = Number.isInteger(index) ? index : -1;
     const rsp = await this.owner.request(msg, timeout);
     var ret = Array.isArray(params) ? new Array(params.length).fill(null) : null;
-    if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) return ret;
+    if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) {
+      if (this.owner._returnNullOnError) return ret;
+      else throw new Error(`Unable to set ${this.name}.${params} to ${values}`);
+    }
     if (Array.isArray(params)) {
       if (!rsp.values) rsp.values = {};
       if (rsp.param) rsp.values[rsp.param] = rsp.value;
       const rvals = Object.keys(rsp.values);
       return params.map( p => {
         let f = rvals.find(rv => rv.endsWith(p));
-        return f ? rsp.values[f] : null;
+        return f ? rsp.values[f] : undefined;
       });
     } else {
       return rsp.value;
@@ -536,7 +539,10 @@ class AgentID {
     msg.index = Number.isInteger(index) ? index : -1;
     const rsp = await this.owner.request(msg, timeout);
     var ret = Array.isArray(params) ? new Array(params.length).fill(null) : null;
-    if (!rsp || rsp.perf != Performative.INFORM || (params && (!rsp.param))) return ret;
+    if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) {
+      if (this.owner._returnNullOnError) return ret;
+      else throw new Error(`Unable to get ${this.name}.${params}`);
+    }
     // Request for listing of all parameters.
     if (!params) {
       if (!rsp.values) rsp.values = {};
@@ -548,7 +554,7 @@ class AgentID {
       const rvals = Object.keys(rsp.values);
       return params.map(p => {
         let f = rvals.find(rv => rv.endsWith(p));
-        return f ? rsp.values[f] : null;
+        return f ? rsp.values[f] : undefined;
       });
     } else {
       return rsp.value;
@@ -675,6 +681,7 @@ class GenericMessage extends Message {
  * @param {string} [opts.keepAlive=true]     - try to reconnect if the connection is lost
  * @param {number} [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
  * @param {number} [opts.timeout=1000]       - timeout for fjage level messages in ms
+ * @param {boolean} [opts.returnNullOnError=true] - return null instead of throwing an error when a parameter is not found
  * @param {string} [hostname="localhost"]    - <strike>Deprecated : hostname/ip address of the master container to connect to</strike>
  * @param {number} [port=]                   - <strike>Deprecated : port number of the master container to connect to</strike>
  * @param {string} [pathname=="/ws/"]        - <strike>Deprecated : path of the master container to connect to (for WebSockets)</strike>
@@ -703,6 +710,7 @@ class Gateway {
     this._timeout = opts.timeout;         // timeout for fjage level messages (agentForService etc)
     this._keepAlive = opts.keepAlive;     // reconnect if connection gets closed/errored
     this._queueSize = opts.queueSize;      // size of queue
+    this._returnNullOnError = opts.returnNullOnError; // null or error
     this.pending = {};                    // msgid to callback mapping for pending requests to server
     this.subscriptions = {};              // hashset for all topics that are subscribed
     this.listener = {};                   // set of callbacks that want to listen to incoming messages
@@ -1296,7 +1304,8 @@ if (isBrowser || isWebWorker){
     'pathname' : '/ws/',
     'timeout': 1000,
     'keepAlive' : true,
-    'queueSize': DEFAULT_QUEUE_SIZE
+    'queueSize': DEFAULT_QUEUE_SIZE,
+    'returnNullOnError': true
   });
   DEFAULT_URL = new URL('ws://localhost');
   // Enable caching of Gateways
@@ -1310,7 +1319,8 @@ if (isBrowser || isWebWorker){
     'pathname': '',
     'timeout': 1000,
     'keepAlive' : true,
-    'queueSize': DEFAULT_QUEUE_SIZE
+    'queueSize': DEFAULT_QUEUE_SIZE,
+    'returnNullOnError': true
   });
   DEFAULT_URL = new URL('tcp://localhost');
   gObj.atob = a => Buffer.from(a, 'base64').toString('binary');

--- a/gateways/js/dist/fjage.js
+++ b/gateways/js/dist/fjage.js
@@ -1068,6 +1068,30 @@
     }
 
     /**
+     * Gets a list of all agents in the container.
+     * @returns {Promise<AgentID[]>} - a promise which returns an array of all agent ids when resolved
+     */
+    async agents() {
+      let rq = { action: 'agents' };
+      let rsp = await this._msgTxRx(rq);
+      if (!rsp || !Array.isArray(rsp.agentIDs)) throw new Error('Unable to get agents');
+      return rsp.agentIDs.map(aid => new AgentID(aid, false, this));
+    }
+
+    /**
+     * Check if an agent with a given name exists in the container.
+     *
+     * @param {AgentID|String} agentID - the agent id to check
+     * @returns {Promise<boolean>} - a promise which returns true if the agent exists when resolved
+     */
+    async containsAgent(agentID) {
+      let rq = { action: 'containsAgent', agentID: agentID instanceof AgentID ? agentID.getName() : agentID };
+      let rsp = await this._msgTxRx(rq);
+      if (!rsp) throw new Error('Unable to check if agent exists');
+      return !!rsp.answer;
+    }
+
+    /**
      * Finds an agent that provides a named service. If multiple agents are registered
      * to provide a given service, any of the agents' id may be returned.
      *

--- a/gateways/js/src/fjage.js
+++ b/gateways/js/src/fjage.js
@@ -728,7 +728,11 @@ export class Gateway {
   async agentForService(service) {
     let rq = { action: 'agentForService', service: service };
     let rsp = await this._msgTxRx(rq);
-    if (!rsp || !rsp.agentID) return;
+    if (!rsp) {
+      if (this._returnNullOnError) return null;
+      else throw new Error('Unable to get agent for service');
+    }
+    if (!rsp.agentID) return null;
     return new AgentID(rsp.agentID, false, this);
   }
 
@@ -742,7 +746,11 @@ export class Gateway {
     let rq = { action: 'agentsForService', service: service };
     let rsp = await this._msgTxRx(rq);
     let aids = [];
-    if (!rsp || !Array.isArray(rsp.agentIDs)) return aids;
+    if (!rsp) {
+      if (this._returnNullOnError) return aids;
+      else throw new Error('Unable to get agents for service');
+    }
+    if (!Array.isArray(rsp.agentIDs)) return aids;
     for (var i = 0; i < rsp.agentIDs.length; i++)
       aids.push(new AgentID(rsp.agentIDs[i], false, this));
     return aids;

--- a/gateways/js/src/fjage.js
+++ b/gateways/js/src/fjage.js
@@ -132,14 +132,17 @@ export class AgentID {
     msg.index = Number.isInteger(index) ? index : -1;
     const rsp = await this.owner.request(msg, timeout);
     var ret = Array.isArray(params) ? new Array(params.length).fill(null) : null;
-    if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) return ret;
+    if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) {
+      if (this.owner._returnNullOnError) return ret;
+      else throw new Error(`Unable to set ${this.name}.${params} to ${values}`);
+    }
     if (Array.isArray(params)) {
       if (!rsp.values) rsp.values = {};
       if (rsp.param) rsp.values[rsp.param] = rsp.value;
       const rvals = Object.keys(rsp.values);
       return params.map( p => {
         let f = rvals.find(rv => rv.endsWith(p));
-        return f ? rsp.values[f] : null;
+        return f ? rsp.values[f] : undefined;
       });
     } else {
       return rsp.value;
@@ -170,7 +173,10 @@ export class AgentID {
     msg.index = Number.isInteger(index) ? index : -1;
     const rsp = await this.owner.request(msg, timeout);
     var ret = Array.isArray(params) ? new Array(params.length).fill(null) : null;
-    if (!rsp || rsp.perf != Performative.INFORM || (params && (!rsp.param))) return ret;
+    if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) {
+      if (this.owner._returnNullOnError) return ret;
+      else throw new Error(`Unable to get ${this.name}.${params}`);
+    }
     // Request for listing of all parameters.
     if (!params) {
       if (!rsp.values) rsp.values = {};
@@ -182,7 +188,7 @@ export class AgentID {
       const rvals = Object.keys(rsp.values);
       return params.map(p => {
         let f = rvals.find(rv => rv.endsWith(p));
-        return f ? rsp.values[f] : null;
+        return f ? rsp.values[f] : undefined;
       });
     } else {
       return rsp.value;
@@ -308,6 +314,7 @@ export class GenericMessage extends Message {
  * @param {string} [opts.keepAlive=true]     - try to reconnect if the connection is lost
  * @param {number} [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
  * @param {number} [opts.timeout=1000]       - timeout for fjage level messages in ms
+ * @param {boolean} [opts.returnNullOnError=true] - return null instead of throwing an error when a parameter is not found
  * @param {string} [hostname="localhost"]    - <strike>Deprecated : hostname/ip address of the master container to connect to</strike>
  * @param {number} [port=]                   - <strike>Deprecated : port number of the master container to connect to</strike>
  * @param {string} [pathname=="/ws/"]        - <strike>Deprecated : path of the master container to connect to (for WebSockets)</strike>
@@ -336,6 +343,7 @@ export class Gateway {
     this._timeout = opts.timeout;         // timeout for fjage level messages (agentForService etc)
     this._keepAlive = opts.keepAlive;     // reconnect if connection gets closed/errored
     this._queueSize = opts.queueSize;      // size of queue
+    this._returnNullOnError = opts.returnNullOnError; // null or error
     this.pending = {};                    // msgid to callback mapping for pending requests to server
     this.subscriptions = {};              // hashset for all topics that are subscribed
     this.listener = {};                   // set of callbacks that want to listen to incoming messages
@@ -929,7 +937,8 @@ if (isBrowser || isWebWorker){
     'pathname' : '/ws/',
     'timeout': 1000,
     'keepAlive' : true,
-    'queueSize': DEFAULT_QUEUE_SIZE
+    'queueSize': DEFAULT_QUEUE_SIZE,
+    'returnNullOnError': true
   });
   DEFAULT_URL = new URL('ws://localhost');
   // Enable caching of Gateways
@@ -943,7 +952,8 @@ if (isBrowser || isWebWorker){
     'pathname': '',
     'timeout': 1000,
     'keepAlive' : true,
-    'queueSize': DEFAULT_QUEUE_SIZE
+    'queueSize': DEFAULT_QUEUE_SIZE,
+    'returnNullOnError': true
   });
   DEFAULT_URL = new URL('tcp://localhost');
   gObj.atob = a => Buffer.from(a, 'base64').toString('binary');

--- a/gateways/js/src/fjage.js
+++ b/gateways/js/src/fjage.js
@@ -695,6 +695,30 @@ export class Gateway {
   }
 
   /**
+   * Gets a list of all agents in the container.
+   * @returns {Promise<AgentID[]>} - a promise which returns an array of all agent ids when resolved
+   */
+  async agents() {
+    let rq = { action: 'agents' };
+    let rsp = await this._msgTxRx(rq);
+    if (!rsp || !Array.isArray(rsp.agentIDs)) throw new Error('Unable to get agents');
+    return rsp.agentIDs.map(aid => new AgentID(aid, false, this));
+  }
+
+  /**
+   * Check if an agent with a given name exists in the container.
+   *
+   * @param {AgentID|String} agentID - the agent id to check
+   * @returns {Promise<boolean>} - a promise which returns true if the agent exists when resolved
+   */
+  async containsAgent(agentID) {
+    let rq = { action: 'containsAgent', agentID: agentID instanceof AgentID ? agentID.getName() : agentID };
+    let rsp = await this._msgTxRx(rq);
+    if (!rsp) throw new Error('Unable to check if agent exists');
+    return !!rsp.answer;
+  }
+
+  /**
    * Finds an agent that provides a named service. If multiple agents are registered
    * to provide a given service, any of the agents' id may be returned.
    *

--- a/gateways/js/src/fjage.js
+++ b/gateways/js/src/fjage.js
@@ -133,7 +133,7 @@ export class AgentID {
     const rsp = await this.owner.request(msg, timeout);
     var ret = Array.isArray(params) ? new Array(params.length).fill(null) : null;
     if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) {
-      if (this.owner._returnNullOnError) return ret;
+      if (this.owner._returnNullOnFailedResponse) return ret;
       else throw new Error(`Unable to set ${this.name}.${params} to ${values}`);
     }
     if (Array.isArray(params)) {
@@ -174,7 +174,7 @@ export class AgentID {
     const rsp = await this.owner.request(msg, timeout);
     var ret = Array.isArray(params) ? new Array(params.length).fill(null) : null;
     if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) {
-      if (this.owner._returnNullOnError) return ret;
+      if (this.owner._returnNullOnFailedResponse) return ret;
       else throw new Error(`Unable to get ${this.name}.${params}`);
     }
     // Request for listing of all parameters.
@@ -314,7 +314,7 @@ export class GenericMessage extends Message {
  * @param {string} [opts.keepAlive=true]     - try to reconnect if the connection is lost
  * @param {number} [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
  * @param {number} [opts.timeout=1000]       - timeout for fjage level messages in ms
- * @param {boolean} [opts.returnNullOnError=true] - return null instead of throwing an error when a parameter is not found
+ * @param {boolean} [opts.returnNullOnFailedResponse=true] - return null instead of throwing an error when a parameter is not found
  * @param {string} [hostname="localhost"]    - <strike>Deprecated : hostname/ip address of the master container to connect to</strike>
  * @param {number} [port=]                   - <strike>Deprecated : port number of the master container to connect to</strike>
  * @param {string} [pathname=="/ws/"]        - <strike>Deprecated : path of the master container to connect to (for WebSockets)</strike>
@@ -343,7 +343,7 @@ export class Gateway {
     this._timeout = opts.timeout;         // timeout for fjage level messages (agentForService etc)
     this._keepAlive = opts.keepAlive;     // reconnect if connection gets closed/errored
     this._queueSize = opts.queueSize;      // size of queue
-    this._returnNullOnError = opts.returnNullOnError; // null or error
+    this._returnNullOnFailedResponse = opts.returnNullOnFailedResponse; // null or error
     this.pending = {};                    // msgid to callback mapping for pending requests to server
     this.subscriptions = {};              // hashset for all topics that are subscribed
     this.listener = {};                   // set of callbacks that want to listen to incoming messages
@@ -729,7 +729,7 @@ export class Gateway {
     let rq = { action: 'agentForService', service: service };
     let rsp = await this._msgTxRx(rq);
     if (!rsp) {
-      if (this._returnNullOnError) return null;
+      if (this._returnNullOnFailedResponse) return null;
       else throw new Error('Unable to get agent for service');
     }
     if (!rsp.agentID) return null;
@@ -747,7 +747,7 @@ export class Gateway {
     let rsp = await this._msgTxRx(rq);
     let aids = [];
     if (!rsp) {
-      if (this._returnNullOnError) return aids;
+      if (this._returnNullOnFailedResponse) return aids;
       else throw new Error('Unable to get agents for service');
     }
     if (!Array.isArray(rsp.agentIDs)) return aids;
@@ -970,7 +970,7 @@ if (isBrowser || isWebWorker){
     'timeout': 1000,
     'keepAlive' : true,
     'queueSize': DEFAULT_QUEUE_SIZE,
-    'returnNullOnError': true
+    'returnNullOnFailedResponse': true
   });
   DEFAULT_URL = new URL('ws://localhost');
   // Enable caching of Gateways
@@ -985,7 +985,7 @@ if (isBrowser || isWebWorker){
     'timeout': 1000,
     'keepAlive' : true,
     'queueSize': DEFAULT_QUEUE_SIZE,
-    'returnNullOnError': true
+    'returnNullOnFailedResponse': true
   });
   DEFAULT_URL = new URL('tcp://localhost');
   gObj.atob = a => Buffer.from(a, 'base64').toString('binary');

--- a/gateways/js/test/spec/fjage.spec.js
+++ b/gateways/js/test/spec/fjage.spec.js
@@ -402,6 +402,24 @@ describe('An AgentID', function () {
     });
   });
 
+  it('should be able to get all the agents on the platform', async function () {
+    let val = await gw.agents();
+    let aids = val.map(a => a.name);
+    expect(aids).toContain('shell');
+    expect(aids).toContain('S');
+    expect(aids).toContain('echo');
+    expect(aids).toContain('test');
+  });
+
+  it('should be able to check if an agent exists on the container', async function () {
+    let aid = new AgentID('S', false, gw);
+    let val = await gw.containsAgent(aid);
+    expect(val).toEqual(true);
+    aid = new AgentID('T', false, gw);
+    val = await gw.containsAgent(aid);
+    expect(val).toEqual(false);
+  });
+
 });
 
 describe('An AgentID setup to reject promises', function () {

--- a/gateways/js/test/spec/fjage.spec.js
+++ b/gateways/js/test/spec/fjage.spec.js
@@ -1,4 +1,4 @@
-/* global global isBrowser isJsDom isNode Performative, AgentID, Message, Gateway, MessageClass it expect describe spyOn beforeAll afterAll beforeEach jasmine*/
+/* global global isBrowser isJsDom isNode Performative, AgentID, Message, Gateway, MessageClass it expect expectAsync describe spyOn beforeAll afterAll beforeEach jasmine*/
 
 const DIRNAME = '.';
 const FILENAME = 'fjage-test.txt';
@@ -403,6 +403,41 @@ describe('An AgentID', function () {
   });
 
 });
+
+describe('An AgentID setup to reject promises', function () {
+  var gw;
+
+  beforeAll(() => {
+    gw = new Gateway(Object.assign({}, gwOpts, {returnNullOnError: false}));
+  });
+
+  afterAll(async () => {
+    await delay(300);
+    gw.close();
+  });
+
+  it('should reject the promise if asked to get the value of unknown parameter', async function () {
+    const aid = new AgentID('S', false, gw);
+    await expectAsync(aid.get('k')).toBeRejected();
+  });
+
+  it('should reject the promise if asked to set the value of unknown parameter',  async function () {
+    const aid = new AgentID('S', false, gw);
+    await expectAsync(aid.set('k', 42)).toBeRejected();
+  });
+
+  it('should reject the promise if asked to get the value of unknown indexed parameter', async function () {
+    const aid = new AgentID('S', false, gw);
+    await expectAsync(aid.get('k', 1)).toBeRejected();
+  });
+
+  it('should reject the promise if asked to set the value of unknown indexed parameter', async function () {
+    const aid = new AgentID('S', false, gw);
+    await expectAsync(aid.set('k', 42, 1)).toBeRejected();
+  });
+
+});
+
 
 describe('A Message', function () {
   it('should be able to be consuctured', function () {

--- a/gateways/js/test/spec/fjage.spec.js
+++ b/gateways/js/test/spec/fjage.spec.js
@@ -249,7 +249,7 @@ describe('A Gateway', function () {
         console.warn('Error getting SendMsgRsp #'+type+' : ' + m);
       }
     }
-    expect(rxed.filter(r => !r).length).toBe(0)
+    expect(rxed.filter(r => !r).length).toBe(0);
   });
 
   it('should generate trigger connListener when the underlying transport is disconnected/reconnected', async function() {
@@ -426,7 +426,7 @@ describe('An AgentID setup to reject promises', function () {
   var gw;
 
   beforeAll(() => {
-    gw = new Gateway(Object.assign({}, gwOpts, {returnNullOnError: false}));
+    gw = new Gateway(Object.assign({}, gwOpts, {returnNullOnFailedResponse: false}));
   });
 
   afterAll(async () => {


### PR DESCRIPTION
- Added a `Gateway.agents()` API to get a list of AgentIDs available on the platform
- Added a `Gateway.containsAgent()` API to check if a given AgentID is available on the platform
- Updated the following APIs to reject Promises if unable to get a response for a given Request instead of just returning `null`.
  - `Gateway.agentForService`
  - `Gateway.agentsForService`
  - `AgentID.get`
  - `AgentID.set`
- For backward compatibility, this functionality is disabled by default but it can be enabled using `Gateway({returnNullOnError: true})` in the Gateway constructor. This will be the default in some future releases.

---

With this feature, parameter set/get can be done using the construct 

```
t = await device.get("time").catch(() => {console.warn("couldn't get time")})
```

