### PR TITLE
Change the websocket connection timeout log from warning to fine

### DIFF
--- a/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
+++ b/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
@@ -252,7 +252,7 @@ public class WebSocketConnector implements Connector, WebSocketCreator {
           try {
             f.get(500, TimeUnit.MILLISECONDS);
           } catch (TimeoutException e){
-            log.warning("Sending timed out. Closing connection to " + session.getRemoteAddress());
+            log.fine("Sending timed out. Closing connection to " + session.getRemoteAddress());
             session.disconnect();
           } catch (Exception e){
             log.warning(e.toString());


### PR DESCRIPTION
This log is triggered when the `WebSocketConnector` cannot send a message to a connected fjage.js Gateway within 500ms. 

This tends to happen when a browser initiates a WebSocket connection, but the user is not focused on the browser window that has the connection open. 

Also happens when the connection between the browser and the WebSocketConnector is abruptly broken (like loosing WiFi connection, or unplugging an ethernet cable).

```
1705979634701|WARNING|org.arl.fjage.connectors.WebSocketConnector@27:write|Sending timed out. Closing connection to /192.168.1.106:53581
```

This PR changes that `warning` to a `fine`, since it's not that critical as all `fjåge.js` clients have retries builtin.
