### PR TITLE
Allow the WebShell dark mode toggle to be disabled

### DIFF
--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -176,7 +176,7 @@
       if (hideModeToggle){
         darkmodeBtn.parentElement.style.display = 'none';
         window.addEventListener('message', evt => {
-          if (evt.data && evt.data.theme){q
+          if (evt.data && evt.data.theme){
             setTheme(term, evt.data.theme);
           }
         });

--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -73,18 +73,6 @@
     let delta = 200;
     let fitAddon;
     let currentTheme = null;
-    let hideModeToggle = false;
-    let parentTheme = null;
-    if (window.parent.document.documentElement.classList.contains('dark')){
-      parentTheme = 'dark';
-      currentTheme = parentTheme;
-      hideModeToggle = true;
-    }else if (window.parent.document.documentElement.classList.contains('light')){
-      parentTheme = 'light';
-      currentTheme = parentTheme;
-      hideModeToggle = true;
-    }
-    hideModeToggle = hideModeToggle || window.parent.hideModeToggle;
     window.shellready = false;
     function connectSocket(term, url, path){
       const ws = new WebSocket('ws://' + url + path);
@@ -159,6 +147,15 @@
       }
     }
     window.addEventListener('load', () => {
+      let hideModeToggle = false;
+      if (window.parent.document.documentElement.classList.contains('dark')){
+        currentTheme = 'dark';
+        hideModeToggle = true;
+      }else if (window.parent.document.documentElement.classList.contains('light')){
+        currentTheme = 'light';
+        hideModeToggle = true;
+      }
+      hideModeToggle = hideModeToggle || window.parent.hideModeToggle;
       const darkmodeBtn = document.getElementById('darkmode-tgl');
       let userTheme = false;
 

--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -1,3 +1,12 @@
+<!-- fjåge Web Shell
+
+# API
+
+- shellready : will be true when the shell is ready to accept input
+- hideModeToggle : if set to true, the darkmode toggle will be hidden
+- window.postMessage({theme: 'dark'}) : to set the theme to 'dark' mode
+
+-->
 <html>
 <head>
   <title>fjåge shell</title>
@@ -109,15 +118,16 @@
   </div>
   <script>
     const ignoreKeys = ['Meta-R', 'Meta-Shift-R'];
-    var defaultCursorWidth;
-    var rtime = 0;
-    var resizing = false;
-    var delta = 200;
-    var fitAddon;
+    let defaultCursorWidth;
+    let rtime = 0;
+    let resizing = false;
+    let delta = 200;
+    let fitAddon;
+    let hideModeToggle = !window.hideModeToggle;
     window.shellready = false;
     function connectSocket(term, url, path){
       const ws = new WebSocket('ws://' + url + path);
-      var attachAddon;
+      let attachAddon;
       window.ws = ws;
       ws.onerror = () => reconnectSocket(term, attachAddon, url, path, ws)
       ws.onclose = () => reconnectSocket(term, attachAddon, url, path, ws)
@@ -183,8 +193,8 @@
     }
     window.addEventListener('load', () => {
       const darkmodeBtn = document.getElementById('darkmode-tgl');
-      var lightmode = false;
-      var userTheme = false;
+      let lightmode = false;
+      let userTheme = false;
 
       const term = new Terminal();
       fitAddon = new FitAddon.FitAddon();
@@ -195,21 +205,30 @@
       fitAddon.fit();
       defaultCursorWidth = term.getOption("cursorWidth");
 
-      if (window.matchMedia){
-        lightmode = !window.matchMedia('(prefers-color-scheme: dark)').matches;
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
-          if (userTheme) return;
-          const newColorScheme = e.matches ? "dark" : "light";
-          darkmodeBtn.checked = !!e.matches;
-          setTheme(term, newColorScheme);
+      if (hideModeToggle){
+        darkmodeBtn.parentElement.style.display = 'none';
+        window.addEventListener('message', evt => {
+          if (evt.data && evt.data.theme){
+            setTheme(term, evt.data.theme);
+          }
         });
+      }else {
+        if (window.matchMedia){
+          lightmode = !window.matchMedia('(prefers-color-scheme: dark)').matches;
+          window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+            if (userTheme) return;
+            const newColorScheme = e.matches ? "dark" : "light";
+            darkmodeBtn.checked = !!e.matches;
+            setTheme(term, newColorScheme);
+          });
+        }
+        darkmodeBtn.checked = !lightmode;
+        setTheme(term, lightmode ? 'light' : 'dark');
+        darkmodeBtn.addEventListener('change', evt => {
+            setTheme(term, evt.target.checked ? 'dark' : 'light');
+            userTheme = true;
+        })
       }
-      darkmodeBtn.checked = !lightmode;
-      setTheme(term, lightmode ? 'light' : 'dark');
-      darkmodeBtn.addEventListener('change', evt => {
-          setTheme(term, evt.target.checked ? 'dark' : 'light');
-          userTheme = true;
-      })
 
       const urlParams = new URLSearchParams(window.location.search);
       const url = urlParams.get('url') || window.location.hostname + ':' + window.location.port;;

--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -45,66 +45,13 @@
       right: 20px;
       z-index: 100;
     }
-    .tgl {
-      display: none;
-    }
-    .tgl, .tgl:after, .tgl:before, .tgl *, .tgl *:after, .tgl *:before, .tgl + .tgl-btn {
-      box-sizing: border-box;
-    }
-    .tgl::-moz-selection, .tgl:after::-moz-selection, .tgl:before::-moz-selection, .tgl *::-moz-selection, .tgl *:after::-moz-selection, .tgl *:before::-moz-selection, .tgl + .tgl-btn::-moz-selection {
-      background: none;
-    }
-    .tgl::selection, .tgl:after::selection, .tgl:before::selection, .tgl *::selection, .tgl *:after::selection, .tgl *:before::selection, .tgl + .tgl-btn::selection {
-      background: none;
-    }
-    .tgl + .tgl-btn {
-      outline: 0;
-      display: block;
-      width: 3.2em;
-      height: 1.5em;
-      position: relative;
-      cursor: pointer;
-      -webkit-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
-      user-select: none;
-    }
-    .tgl + .tgl-btn:after, .tgl + .tgl-btn:before {
-      position: relative;
-      display: block;
-      content: "";
-      width: 40%;
-      height: 100%;
-    }
-    .tgl + .tgl-btn:after {
-      left: 0;
-    }
-    .tgl + .tgl-btn:before {
-      display: none;
-    }
-    .tgl:checked + .tgl-btn:after {
-      left: 60%;
-    }
 
-    .tgl-flat + .tgl-btn {
-      padding: 2px;
-      transition: all 0.2s ease;
-      background: #fff;
-      border: 4px solid #dfdfdf;
-      border-radius: 2em;
-    }
-    .tgl-flat + .tgl-btn:after {
-      transition: all 0.2s ease;
-      background: #dfdfdf;
-      content: "";
-      border-radius: 1em;
-    }
-    .tgl-flat:checked + .tgl-btn {
-      border: 4px solid #8d8d8d;
-    }
-    .tgl-flat:checked + .tgl-btn:after {
-      left: 60%;
-      background: #8d8d8d;
+    button.modeToggle {
+      background-color: transparent;
+      border: none;
+      cursor: pointer;
+      padding: 0;
+      margin: 0;
     }
   </style>
 </head>
@@ -112,8 +59,10 @@
   <div class="container">
     <div id='terminal'></div>
     <div class="btn-container" title="Toggle Light/Dark ColorMode">
-      <input class="tgl tgl-flat" id="darkmode-tgl" type="checkbox" checked/>
-      <label class="tgl-btn" for="darkmode-tgl"></label>
+      <button class="modeToggle" id="darkmode-tgl">
+        <svg id="darkmode-dark" data-v-bd832875="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="icon" width="24px" height="24px" viewBox="0 0 24 24"><path fill="white" d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12S6.477 2 12 2h.1A6.98 6.98 0 0 0 10 7m-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938A7.999 7.999 0 0 0 4 12"></path></svg>
+        <svg id="darkmode-light" style="display: none;" data-v-bd832875="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="icon" width="24px" height="24px" viewBox="0 0 24 24"><path fill="currentColor" d="M12 18a6 6 0 1 1 0-12a6 6 0 0 1 0 12m0-2a4 4 0 1 0 0-8a4 4 0 0 0 0 8M11 1h2v3h-2zm0 19h2v3h-2zM3.515 4.929l1.414-1.414L7.05 5.636L5.636 7.05zM16.95 18.364l1.414-1.414l2.121 2.121l-1.414 1.414zm2.121-14.85l1.414 1.415l-2.121 2.121l-1.414-1.414zM5.636 16.95l1.414 1.414l-2.121 2.121l-1.414-1.414zM23 11v2h-3v-2zM4 11v2H1v-2z"></path></svg>
+      </button>
     </div>
   </div>
   <script>
@@ -123,7 +72,9 @@
     let resizing = false;
     let delta = 200;
     let fitAddon;
-    let hideModeToggle = !window.hideModeToggle;
+    let currentTheme = 'dark';
+    // let hideModeToggle = !window.hideModeToggle;
+    let hideModeToggle = false;
     window.shellready = false;
     function connectSocket(term, url, path){
       const ws = new WebSocket('ws://' + url + path);
@@ -170,6 +121,9 @@
           cursor: '#586e75',
           selection: '#d3c494'
         });
+        document.getElementById('darkmode-dark').style.display = 'none';
+        document.getElementById('darkmode-light').style.display = 'block';
+        currentTheme = theme;
       }else if (theme == 'dark'){
         term.setOption('theme', {
           background: '#000000',
@@ -181,6 +135,9 @@
           red: '#cc0000',
           cursor: '#ff6e75'
         });
+        document.getElementById('darkmode-dark').style.display = 'block';
+        document.getElementById('darkmode-light').style.display = 'none';
+        currentTheme = theme;
       }
     };
     function resizeend() {
@@ -218,14 +175,13 @@
           window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
             if (userTheme) return;
             const newColorScheme = e.matches ? "dark" : "light";
-            darkmodeBtn.checked = !!e.matches;
             setTheme(term, newColorScheme);
           });
         }
         darkmodeBtn.checked = !lightmode;
         setTheme(term, lightmode ? 'light' : 'dark');
-        darkmodeBtn.addEventListener('change', evt => {
-            setTheme(term, evt.target.checked ? 'dark' : 'light');
+        darkmodeBtn.addEventListener('click', evt => {
+            setTheme(term, currentTheme == 'dark' ? 'light' : 'dark');
             userTheme = true;
         })
       }

--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -73,8 +73,12 @@
     let delta = 200;
     let fitAddon;
     let currentTheme = 'dark';
-    // let hideModeToggle = !window.hideModeToggle;
     let hideModeToggle = false;
+    let parentTheme = window.parent.document.documentElement.className;
+    if (parentTheme == 'light' || parentTheme == 'dark'){
+      currentTheme = parentTheme;
+      hideModeToggle = true;
+    }
     window.shellready = false;
     function connectSocket(term, url, path){
       const ws = new WebSocket('ws://' + url + path);

--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -3,6 +3,7 @@
 # API
 
 - shellready : will be true when the shell is ready to accept input
+- hideModeToggle : if true, the mode toggle button will be hidden
 - window.postMessage({theme: 'dark'}) : to set the theme to 'dark' mode
 
 -->
@@ -73,11 +74,17 @@
     let fitAddon;
     let currentTheme = null;
     let hideModeToggle = false;
-    let parentTheme = window.parent.document.documentElement.className;
-    if (parentTheme == 'light' || parentTheme == 'dark'){
+    let parentTheme = null;
+    if (window.parent.document.documentElement.classList.contains('dark')){
+      parentTheme = 'dark';
+      currentTheme = parentTheme;
+      hideModeToggle = true;
+    }else if (window.parent.document.documentElement.classList.contains('light')){
+      parentTheme = 'light';
       currentTheme = parentTheme;
       hideModeToggle = true;
     }
+    hideModeToggle = hideModeToggle || window.parent.hideModeToggle;
     window.shellready = false;
     function connectSocket(term, url, path){
       const ws = new WebSocket('ws://' + url + path);
@@ -169,7 +176,7 @@
       if (hideModeToggle){
         darkmodeBtn.parentElement.style.display = 'none';
         window.addEventListener('message', evt => {
-          if (evt.data && evt.data.theme){
+          if (evt.data && evt.data.theme){q
             setTheme(term, evt.data.theme);
           }
         });
@@ -186,7 +193,7 @@
             userTheme = true;
         })
       }
-      setTheme(term, currentTheme ? 'light' : 'dark');
+      setTheme(term, currentTheme);
 
       const urlParams = new URLSearchParams(window.location.search);
       const url = urlParams.get('url') || window.location.hostname + ':' + window.location.port;;

--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -71,7 +71,7 @@
     let resizing = false;
     let delta = 200;
     let fitAddon;
-    let currentTheme = 'dark';
+    let currentTheme = null;
     let hideModeToggle = false;
     let parentTheme = window.parent.document.documentElement.className;
     if (parentTheme == 'light' || parentTheme == 'dark'){
@@ -163,6 +163,8 @@
       term.open(document.getElementById('terminal'));
       fitAddon.fit();
       defaultCursorWidth = term.getOption("cursorWidth");
+
+      if (currentTheme == null && window.matchMedia) currentTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
       if (hideModeToggle){
         darkmodeBtn.parentElement.style.display = 'none';

--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -3,7 +3,6 @@
 # API
 
 - shellready : will be true when the shell is ready to accept input
-- hideModeToggle : if set to true, the darkmode toggle will be hidden
 - window.postMessage({theme: 'dark'}) : to set the theme to 'dark' mode
 
 -->
@@ -60,7 +59,7 @@
     <div id='terminal'></div>
     <div class="btn-container" title="Toggle Light/Dark ColorMode">
       <button class="modeToggle" id="darkmode-tgl">
-        <svg id="darkmode-dark" data-v-bd832875="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="icon" width="24px" height="24px" viewBox="0 0 24 24"><path fill="white" d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12S6.477 2 12 2h.1A6.98 6.98 0 0 0 10 7m-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938A7.999 7.999 0 0 0 4 12"></path></svg>
+        <svg id="darkmode-dark" style="display: none;" data-v-bd832875="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="icon" width="24px" height="24px" viewBox="0 0 24 24"><path fill="white" d="M10 7a7 7 0 0 0 12 4.9v.1c0 5.523-4.477 10-10 10S2 17.523 2 12S6.477 2 12 2h.1A6.98 6.98 0 0 0 10 7m-6 5a8 8 0 0 0 15.062 3.762A9 9 0 0 1 8.238 4.938A7.999 7.999 0 0 0 4 12"></path></svg>
         <svg id="darkmode-light" style="display: none;" data-v-bd832875="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="icon" width="24px" height="24px" viewBox="0 0 24 24"><path fill="currentColor" d="M12 18a6 6 0 1 1 0-12a6 6 0 0 1 0 12m0-2a4 4 0 1 0 0-8a4 4 0 0 0 0 8M11 1h2v3h-2zm0 19h2v3h-2zM3.515 4.929l1.414-1.414L7.05 5.636L5.636 7.05zM16.95 18.364l1.414-1.414l2.121 2.121l-1.414 1.414zm2.121-14.85l1.414 1.415l-2.121 2.121l-1.414-1.414zM5.636 16.95l1.414 1.414l-2.121 2.121l-1.414-1.414zM23 11v2h-3v-2zM4 11v2H1v-2z"></path></svg>
       </button>
     </div>
@@ -154,7 +153,6 @@
     }
     window.addEventListener('load', () => {
       const darkmodeBtn = document.getElementById('darkmode-tgl');
-      let lightmode = false;
       let userTheme = false;
 
       const term = new Terminal();
@@ -175,20 +173,18 @@
         });
       }else {
         if (window.matchMedia){
-          lightmode = !window.matchMedia('(prefers-color-scheme: dark)').matches;
           window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
             if (userTheme) return;
             const newColorScheme = e.matches ? "dark" : "light";
             setTheme(term, newColorScheme);
           });
         }
-        darkmodeBtn.checked = !lightmode;
-        setTheme(term, lightmode ? 'light' : 'dark');
         darkmodeBtn.addEventListener('click', evt => {
             setTheme(term, currentTheme == 'dark' ? 'light' : 'dark');
             userTheme = true;
         })
       }
+      setTheme(term, currentTheme ? 'light' : 'dark');
 
       const urlParams = new URLSearchParams(window.location.search);
       const url = urlParams.get('url') || window.location.hostname + ':' + window.location.port;;


### PR DESCRIPTION
We added a toggle button for Light/Dark mode on the fjåge Web Shell. However, many modern web frameworks support dark mode, and it's common to embed the WebShell as an iframe inside web apps made from such a framework.

So we add two features to WebShell.

- WebShell now looks at the `class` attribute on the parent `HTML` element and if it finds a `light` or `dark` class attribute uses that as a hint to hide its toggle button and use the parent element's mode (light/dark) as it's own mode.
- WebShell also looks at an attribute on the `iframe` called `hideModeToggle` If that's set to true, then it also hides its toggle button.
- The WebShell accepts a message sent using the `window.postMessage` API with a `theme` property which defines the theme to be either `light` or `dark`. This allows the container web app to update the WebShell that the theme has changed.

Finally, we updated the button style for the toggle button.
