### PR TITLE
Shell scrollbar style

### DIFF
--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -53,6 +53,19 @@
       padding: 0;
       margin: 0;
     }
+    *::-webkit-scrollbar {
+      width: 8px;
+    }
+
+    *::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    *::-webkit-scrollbar-thumb {
+      background-color: rgba(134, 134, 134, 0.46);
+      border-radius: 20px;
+      border: 4px solid transparent;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
Scrollbar style updated.

The original ones looked like this.

<img width="1512" alt="Screenshot 2024-03-15 at 2 57 48 PM" src="https://github.com/org-arl/fjage/assets/553140/3a35e750-cc43-4e2d-a4ba-07f1b8f5005b">
<img width="1506" alt="Screenshot 2024-03-15 at 2 57 55 PM" src="https://github.com/org-arl/fjage/assets/553140/64c5a146-72e4-45a7-af2b-f113419f221e">
