### PR TITLE
fix(JSON): JSONify Java maps as JSON dicts

### DIFF
--- a/src/main/java/org/arl/fjage/remote/GenericValueAdapterFactory.java
+++ b/src/main/java/org/arl/fjage/remote/GenericValueAdapterFactory.java
@@ -22,6 +22,7 @@ import org.arl.fjage.GenericValue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Handles conversion of various data types to JSON.
@@ -49,7 +50,11 @@ class GenericValueAdapterFactory implements TypeAdapterFactory {
         if (Number.class.isAssignableFrom(type)) out.value((Number)((GenericValue)value).getValue());
         else if (type.equals(String.class)) out.value((String)((GenericValue)value).getValue());
         else if (type.equals(Boolean.class)) out.value((Boolean)((GenericValue)value).getValue());
-        else if (List.class.isAssignableFrom(type) || (type.isArray() && type.getComponentType().isPrimitive())) {
+        else if (
+          List.class.isAssignableFrom(type)
+          || (type.isArray() && type.getComponentType().isPrimitive())
+          || Map.class.isAssignableFrom(type)
+        ) {
           TypeAdapter delegate = gson.getAdapter(TypeToken.get(type));
           Object v = ((GenericValue)value).getValue();
           delegate.write(out, v);


### PR DESCRIPTION
Currently, `GenericValue`s that happen to be Java `Map`s are JSONified as generic objects, not JSON maps. This is inconsistent with how Java `Map`s are serialized elsewhere (e.g. in `ParamChangeNtf`), leading to much confusion. This PR changes the `GenericValue` serialization code so Java maps are JSONified as JSON maps, with imho is the correct behavior. Unfortunately, this change may break code that relied on the old behavior. 