### PR TITLE
Update fjage_quickstart.sh for GSON 2.10.1

### DIFF
--- a/src/sphinx/fjage_quickstart.sh
+++ b/src/sphinx/fjage_quickstart.sh
@@ -12,7 +12,7 @@ curl -O https://repo1.maven.org/maven2/com/github/org-arl/fjage/$VERSION/fjage-$
 curl -O https://repo1.maven.org/maven2/org/codehaus/groovy/groovy/2.5.9/groovy-2.5.9.jar
 curl -O https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar
 curl -O https://repo1.maven.org/maven2/org/jline/jline/3.12.1/jline-3.12.1.jar
-curl -O https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.5/gson-2.8.5.jar
+curl -O https://repo1.maven.org/maven2/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar
 curl -O https://repo1.maven.org/maven2/org/eclipse/jetty/websocket/websocket-servlet/9.4.26.v20200117/websocket-servlet-9.4.26.v20200117.jar
 cd ../..
 


### PR DESCRIPTION
This pull request aims to fix an issue I have been experiencing with running Fjåge using the quickstart script. 

Here is the full text of the original error:
```
/fjage # cat logs/log-0.txt 
1719945928582|INFO|org.arl.fjage.shell.GroovyBoot@1:main|fjage Build: fjage-1.12.3/64d610f7/17-03-2024_22:38:15
1719945928805|INFO|org.arl.fjage.shell.GroovyBoot@1:main|Running etc/initrc.groovy
1719945928887|INFO|org.arl.fjage.remote.MasterContainer@1:openTcpServer|Listening on port 5081
1719945928889|INFO|org.arl.fjage.connectors.TcpServer@20:run|Listening on port 5081
1719945928982|WARNING|org.arl.fjage.shell.GroovyScriptEngine@1:error|Groovy execution failed

java.lang.NoClassDefFoundError: com/google/gson/ToNumberStrategy
Stack trace:
   org.arl.fjage.remote.MasterContainer.isDuplicate(MasterContainer.java:199)
   org.arl.fjage.Container.add(Container.java:204)
   org.arl.fjage.Container$add.call(Unknown Source) ...
   initrc.run(initrc.groovy:34) ...
   org.arl.fjage.shell.GroovyScriptEngine.exec(GroovyScriptEngine.java:215)
   org.arl.fjage.shell.GroovyBoot.main(GroovyBoot.java:95)
```

I found that this error appeared on both Alpine Linux and Ubuntu Linux docker containers (--platform=linux/amd64 and linux/arm64)

I was able to resolve this issue in my testing by switching out GSON 2.8.5 for 2.10.1.

Here's a Dockerfile to demonstrate GSON 2.8.5 vs 2.10.1:
```
# docker build . -t fjage-rs:testcontainer && docker run -p 5081:5081 --rm -it fjage-rs:testcontainer
FROM alpine:latest

# Dependencies
RUN mkdir fjage
RUN apk add curl openjdk8-jre bash

# Quickstart
WORKDIR /fjage

#github org-arl/fjage
#RUN curl -O https://raw.githubusercontent.com/org-arl/fjage/master/src/sphinx/fjage_quickstart.sh

#github brodiealexander/fjage
RUN curl -O https://raw.githubusercontent.com/brodiealexander/fjage/master/src/sphinx/fjage_quickstart.sh
RUN bash fjage_quickstart.sh

# To see error upon failure
ENTRYPOINT /fjage/fjage.sh || true && cat /fjage/logs/log-0.txt
```

Thanks!
BA