### PR TITLE
Pin xterm height and width to 160x50 to align with the shell

### DIFF
--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -172,7 +172,10 @@
       const darkmodeBtn = document.getElementById('darkmode-tgl');
       let userTheme = false;
 
-      const term = new Terminal();
+      const term = new Terminal({
+        cols: 160,
+        rows: 50
+      });
       fitAddon = new FitAddon.FitAddon();
       term.loadAddon(fitAddon);
       term.loadAddon(new WebLinksAddon.WebLinksAddon());


### PR DESCRIPTION
This would reduce a lot of issues with doing multiline commands on the shell.