### PR TITLE
Allow the _to_json of AgentID to be used to generate the JSON for AgentIDs

### DIFF
--- a/gateways/python/fjagepy/__init__.py
+++ b/gateways/python/fjagepy/__init__.py
@@ -287,8 +287,6 @@ class Message(object):
             if not k.startswith('_') and k.endswith('_'):
                 k = k[:-1]
             self.__dict__[k] = v
-            if isinstance(v, AgentID):
-                self.__dict__[k] = v.name
 
     def __getattribute__(self, name):
         if name == 'performative':
@@ -407,8 +405,6 @@ def MessageClass(name, parent=Message, perf=None):
             if not k.startswith('_') and k.endswith('_'):
                 k = k[:-1]
             self.__dict__[k] = v
-            if isinstance(v, AgentID):
-                self.__dict__[k] = v.name
 
     sname = name.split('.')[-1]
     class_ = type(sname, (parent,), {"__init__": setclazz})
@@ -532,8 +528,6 @@ class GenericMessage(Message):
             if not k.startswith('_') and k.endswith('_'):
                 k = k[:-1]
             self.__dict__[k] = v
-            if isinstance(v, AgentID):
-                self.__dict__[k] = v.name
 
 
 class Gateway:


### PR DESCRIPTION
In `Message` constructors of fjage.py we were forcing all the `AgentID` types to be converted to `v.name` before setting their values on the message objects. This looses information about if a `AgentID` is a `Topic` etc.

So instead, we let the `_to_json` method of `AgentID` do the proper stringification when the Message is converted to JSON.