### PR TITLE
Fixing dispatching of indexed parameter req

### DIFF
--- a/src/main/java/org/arl/fjage/param/ParameterMessageBehavior.java
+++ b/src/main/java/org/arl/fjage/param/ParameterMessageBehavior.java
@@ -380,13 +380,18 @@ public class ParameterMessageBehavior extends MessageBehavior {
     try {
       return MethodUtils.invokeMethod(agent, name, ndx, value);
     } catch (NoSuchMethodException ignored) {
+      // If MethodUtils.invokeMethod fails, we will try to invoke the method by
+      // getting the method and invoking it directly
+      Class<?>[] parameterTypes = new Class<?>[2];
+      parameterTypes[0] = Integer.TYPE;
+      parameterTypes[1] = value.getClass();
       try {
-        return MethodUtils.invokeMethod(agent, name, Integer.valueOf(ndx), value);
+        Method m = agent.getClass().getMethod(name, parameterTypes);
+        return m.invoke(agent, ndx, value);
       } catch (NoSuchMethodException ex) {
         nsme = ex;
       }
     }
-
     if (value instanceof Number) {
       Number nvalue = (Number) value;
       try {

--- a/src/main/java/org/arl/fjage/param/ParameterMessageBehavior.java
+++ b/src/main/java/org/arl/fjage/param/ParameterMessageBehavior.java
@@ -379,9 +379,14 @@ public class ParameterMessageBehavior extends MessageBehavior {
     NoSuchMethodException nsme = null;
     try {
       return MethodUtils.invokeMethod(agent, name, ndx, value);
-    } catch (NoSuchMethodException ex) {
-      nsme = ex;
+    } catch (NoSuchMethodException ignored) {
+      try {
+        return MethodUtils.invokeMethod(agent, name, Integer.valueOf(ndx), value);
+      } catch (NoSuchMethodException ex) {
+        nsme = ex;
+      }
     }
+
     if (value instanceof Number) {
       Number nvalue = (Number) value;
       try {


### PR DESCRIPTION
This is a fix for `ParameterMessageBehavior` when setting indexed parameters. When an Agent has a defined setter method `setMyParam(int ndx, Object value)`, the `ParameterMessageBehavior` can't find the method.

I traced this down to Apache Commons Lang. `ParameterMessageBehavior` calls `invokeCompatibleSetter` which then calls `MethodUtils.invokeMethod(agent, name, ndx, value)`, where `name` is the method name (`setMyParam` in our example), `ndx` is the parameter index and `value` is the value to be set.

While doing the reflection MethodUtils does a `ClassUtils.toClass(args)` on the list of all args. That converts the `int ndx` into a boxed `Integer`. Because of this, looks ups of indexed setters can fail since they're commonly defined with the index being an `int`.

This fix tries to detect that and tries to use the standard Java reflection API (`Class.getMethod`) to find an appropriate method to dispatch to.