### PR TITLE
Increasing the timeout for messages to 2s

### DIFF
--- a/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
+++ b/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
@@ -250,7 +250,7 @@ public class WebSocketConnector implements Connector, WebSocketCreator {
         if (session != null && session.isOpen()) {
           Future<Void> f = session.getRemote().sendStringByFuture(s);
           try {
-            f.get(500, TimeUnit.MILLISECONDS);
+            f.get(2, TimeUnit.SECONDS);
           } catch (TimeoutException e){
             log.fine("Sending timed out. Closing connection to " + session.getRemoteAddress());
             session.disconnect();


### PR DESCRIPTION
We noticed the original 500ms timeout was causing many large messages to fail when the client was connected over a slower conenction.