### PR TITLE
Adding functionality to serve an agent's store directory

### DIFF
--- a/src/main/java/org/arl/fjage/Agent.java
+++ b/src/main/java/org/arl/fjage/Agent.java
@@ -703,16 +703,32 @@ public class Agent implements Runnable, TimestampProvider, Messenger {
   /**
    * Serve the Agent's store over HTTP.
    *
-   * @param enable true to enable, false to disable
+   * @param directoryListing true to enable directory listing, false otherwise
    * @return true if successful, false otherwise
    */
-  public boolean serveStore(boolean enable){
+  public boolean enableServeStore(boolean directoryListing){
     WebServer webServer = getWebServer();
     if (webServer != null) {
       String path = "store/" + this.getClass().getCanonicalName().replace(".", "/");
-      if (webServer.hasContext(path) == enable) return true;
-      if (enable) webServer.add("/"+path, new File(path+"/"));
-      else webServer.remove("/"+path);
+      if (webServer.hasContext(path)) return false;
+      webServer.add("/"+path, new File(path+"/"), new WebServer.WebServerOptions().directoryListed(directoryListing));
+      return true;
+    }
+    log.warning("No web server found");
+    return false;
+  }
+
+  /**
+   * Stop serving the Agent's store over HTTP.
+   *
+   * @return true if successful, false otherwise
+   */
+  public boolean disableServeStore(){
+    WebServer webServer = getWebServer();
+    if (webServer != null) {
+      String path = "store/" + this.getClass().getCanonicalName().replace(".", "/");
+      if (!webServer.hasContext(path)) return false;
+      webServer.remove("/"+path);
       return true;
     }
     log.warning("No web server found");


### PR DESCRIPTION
Adds a new API `Agent.enableServeStore` and `Agent.disableServeStore` which allow the agent to request a WebServer connected to the `container` (if any) to serve its default store directory (for e.g. `$UNET_HOME/store/org/arl/fjage/shell/ShellAgent`) over HTTP.

Pending https://github.com/org-arl/fjage/pull/329 for review.

