### PR TITLE
Addin type annotations to fjage.js

### DIFF
--- a/docs/jsdoc/index.html
+++ b/docs/jsdoc/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset='utf-8'>
-  <title>fjage 1.12.0 | Documentation</title>
+  <title>fjage 1.13.0 | Documentation</title>
   <meta name='description' content='JS Gateway for fjåge'>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' rel='stylesheet'>
@@ -15,7 +15,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>fjage</h3>
-          <div class='mb1'><code>1.12.0</code></div>
+          <div class='mb1'><code>1.13.0</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -409,6 +409,26 @@
                 
                 </li>
               
+                
+                <li><a
+                  href='#parameterreqentry'
+                  class="">
+                  ParameterReq.Entry
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#parameterreq'
+                  class="">
+                  ParameterReq
+                  
+                </a>
+                
+                </li>
+              
             </ul>
           </div>
           <div class='mt1 h6 quiet'>
@@ -429,7 +449,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L9-L13'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L9-L13'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -485,7 +505,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L15-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L15-L15'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -542,7 +562,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L16-L16'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L16-L16'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -599,7 +619,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L17-L17'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L17-L17'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -656,7 +676,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L18-L18'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L18-L18'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -713,7 +733,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L19-L19'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L19-L19'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -770,7 +790,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L20-L20'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L20-L20'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -827,7 +847,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L21-L21'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L21-L21'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -884,7 +904,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L22-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L22-L22'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -941,7 +961,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L23-L23'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L23-L23'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -998,7 +1018,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L24-L24'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L24-L24'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1055,7 +1075,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L25-L25'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L25-L25'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1112,7 +1132,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L26-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L26-L26'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1179,7 +1199,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L36-L197'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L36-L199'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1188,7 +1208,7 @@ FIPA ACL recommendations for interagent communication.</p>
 
   <p>An identifier for an agent or a topic.</p>
 
-    <div class='pre p1 fill-light mt0'>new AgentID(name: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, topic: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>, owner: <a href="#gateway">Gateway</a>)</div>
+    <div class='pre p1 fill-light mt0'>new AgentID(name: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, topic: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>, owner: <a href="#gateway">Gateway</a>?)</div>
   
   
 
@@ -1214,7 +1234,8 @@ FIPA ACL recommendations for interagent communication.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>topic</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</code>
+            <span class='code bold'>topic</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>
+            = <code>false</code>)</code>
 	    name of topic
 
           </div>
@@ -1223,7 +1244,7 @@ FIPA ACL recommendations for interagent communication.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>owner</span> <code class='quiet'>(<a href="#gateway">Gateway</a>)</code>
+            <span class='code bold'>owner</span> <code class='quiet'>(<a href="#gateway">Gateway</a>?)</code>
 	    Gateway owner for this AgentID
 
           </div>
@@ -1263,7 +1284,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L50-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L50-L52'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1329,7 +1350,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L59-L61'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L59-L61'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1395,7 +1416,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L69-L72'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L69-L73'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1404,7 +1425,7 @@ FIPA ACL recommendations for interagent communication.</p>
 
   <p>Sends a message to the agent represented by this id.</p>
 
-    <div class='pre p1 fill-light mt0'>send(msg: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): void</div>
+    <div class='pre p1 fill-light mt0'>send(msg: <a href="#message">Message</a>): void</div>
   
   
 
@@ -1421,7 +1442,7 @@ FIPA ACL recommendations for interagent communication.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>msg</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+            <span class='code bold'>msg</span> <code class='quiet'>(<a href="#message">Message</a>)</code>
 	    message to send
 
           </div>
@@ -1474,7 +1495,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L81-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L82-L86'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1564,7 +1585,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L91-L93'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L93-L95'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1630,7 +1651,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L100-L102'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L102-L104'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1696,7 +1717,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L113-L150'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L115-L152'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1805,7 +1826,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L161-L196'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L163-L198'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1904,7 +1925,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L205-L287'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L207-L294'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1913,7 +1934,7 @@ FIPA ACL recommendations for interagent communication.</p>
 
   <p>Base class for messages transmitted by one agent to another. Creates an empty message.</p>
 
-    <div class='pre p1 fill-light mt0'>new Message(inReplyTo: <a href="#message">Message</a>, perf: any, null-null: <a href="#performative">Performative</a>)</div>
+    <div class='pre p1 fill-light mt0'>new Message(inReplyTo: <a href="#message">Message</a>?, perf: <a href="#performative">Performative</a>)</div>
   
   
 
@@ -1930,7 +1951,7 @@ FIPA ACL recommendations for interagent communication.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>inReplyTo</span> <code class='quiet'>(<a href="#message">Message</a>
+            <span class='code bold'>inReplyTo</span> <code class='quiet'>(<a href="#message">Message</a>?
             = <code>{msgID:null,sender:null}</code>)</code>
 	    message to which this response corresponds to
 
@@ -1940,16 +1961,8 @@ FIPA ACL recommendations for interagent communication.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>perf</span> <code class='quiet'>(any
-            = <code>&#39;&#39;</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>null-null</span> <code class='quiet'>(<a href="#performative">Performative</a>)</code>
+            <span class='code bold'>perf</span> <code class='quiet'>(<a href="#performative">Performative</a>
+            = <code>Performative.INFORM</code>)</code>
 	    performative
 
           </div>
@@ -1989,7 +2002,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L221-L243'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L223-L245'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2063,7 +2076,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L294-L302'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L301-L309'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2124,7 +2137,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L323-L850'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L326-L909'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2134,7 +2147,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <p>A gateway for connecting to a fjage master container. The new version of the constructor
 uses an options object instead of individual parameters. The old version with</p>
 
-    <div class='pre p1 fill-light mt0'>new Gateway(opts: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, port: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?, pathname: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, timeout: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, hostname: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</div>
+    <div class='pre p1 fill-light mt0'>new Gateway(opts: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</div>
   
   
 
@@ -2251,45 +2264,6 @@ uses an options object instead of individual parameters. The old version with</p
           
         </div>
       
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>port</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</code>
-	    Deprecated : port number of the master container to connect to
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>pathname</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
-            = <code>=&quot;/ws/&quot;</code>)</code>
-	    Deprecated : path of the master container to connect to (for WebSockets)
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>timeout</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
-            = <code>1000</code>)</code>
-	    Deprecated : timeout for fjage level messages in ms
-
-          </div>
-          
-        </div>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>hostname</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
-            = <code>&quot;localhost&quot;</code>)</code>
-	    Deprecated : hostname/ip address of the master container to connect to
-
-          </div>
-          
-        </div>
-      
     </div>
   
 
@@ -2323,7 +2297,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L579-L584'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L636-L641'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2411,7 +2385,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L593-L597'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L650-L654'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2499,7 +2473,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L605-L607'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L662-L664'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2578,7 +2552,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L615-L617'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L672-L674'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2657,7 +2631,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L625-L627'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L682-L684'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2736,7 +2710,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L635-L637'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L692-L694'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2815,7 +2789,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L644-L646'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L701-L703'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2824,7 +2798,7 @@ uses an options object instead of individual parameters. The old version with</p
 
   <p>Gets the agent ID associated with the gateway.</p>
 
-    <div class='pre p1 fill-light mt0'>getAgentID(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
+    <div class='pre p1 fill-light mt0'>getAgentID(): <a href="#agentid">AgentID</a></div>
   
   
 
@@ -2842,7 +2816,7 @@ uses an options object instead of individual parameters. The old version with</p
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>:
+      <code><a href="#agentid">AgentID</a></code>:
         agent ID
 
       
@@ -2881,7 +2855,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L654-L656'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L711-L713'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2961,7 +2935,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L665-L671'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L722-L728'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3050,7 +3024,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L679-L683'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L736-L741'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3130,7 +3104,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L691-L695'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L749-L753'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3209,7 +3183,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L701-L706'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L759-L764'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3275,7 +3249,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L714-L719'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L772-L777'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3355,7 +3329,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L728-L737'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L786-L795'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3436,7 +3410,7 @@ to provide a given service, any of the agents' id may be returned.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L745-L757'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L803-L815'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3508,7 +3482,7 @@ to provide a given service, any of the agents' id may be returned.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L766-L776'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L824-L835'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3589,7 +3563,7 @@ may be an agent or a topic.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L783-L785'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L842-L844'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3654,7 +3628,7 @@ may be an agent or a topic.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L795-L798'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L854-L857'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3664,7 +3638,7 @@ may be an agent or a topic.</p>
   <p>Sends a request and waits for a response. This method returns a {Promise} which resolves when a response
 is received or if no response is received after the timeout.</p>
 
-    <div class='pre p1 fill-light mt0'>request(msg: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, timeout: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="#message">Message</a>?></div>
+    <div class='pre p1 fill-light mt0'>request(msg: <a href="#message">Message</a>, timeout: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="#message">Message</a> | void)></div>
   
   
 
@@ -3681,7 +3655,7 @@ is received or if no response is received after the timeout.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>msg</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+            <span class='code bold'>msg</span> <code class='quiet'>(<a href="#message">Message</a>)</code>
 	    message to send
 
           </div>
@@ -3706,7 +3680,7 @@ is received or if no response is received after the timeout.</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="#message">Message</a>?></code>:
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="#message">Message</a> | void)></code>:
         a promise which resolves with the received response message, null on timeout
 
       
@@ -3735,7 +3709,7 @@ is received or if no response is received after the timeout.</p>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>receive(filter?, timeout)</span>
+            <span class='code strong strong truncate'>receive(filter, timeout)</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -3745,7 +3719,7 @@ is received or if no response is received after the timeout.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L809-L838'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L868-L897'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3755,7 +3729,7 @@ is received or if no response is received after the timeout.</p>
   <p>Returns a response message received by the gateway. This method returns a {Promise} which resolves when
 a response is received or if no response is received after the timeout.</p>
 
-    <div class='pre p1 fill-light mt0'>receive(filter: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">function</a>?, timeout: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="#message">Message</a>?></div>
+    <div class='pre p1 fill-light mt0'>receive(filter: any, timeout: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="#message">Message</a> | void)></div>
   
   
 
@@ -3772,10 +3746,8 @@ a response is received or if no response is received after the timeout.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>filter</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">function</a>?)</code>
-	    original message to which a response is expected, or a MessageClass of the type
-of message to match, or a closure to use to match against the message
-
+            <span class='code bold'>filter</span> <code class='quiet'>(any)</code>
+	    
           </div>
           
         </div>
@@ -3798,7 +3770,7 @@ of message to match, or a closure to use to match against the message
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="#message">Message</a>?></code>:
+      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;(<a href="#message">Message</a> | void)></code>:
         received response message, null on timeout
 
       
@@ -3837,7 +3809,7 @@ of message to match, or a closure to use to match against the message
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L845-L848'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L904-L907'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3911,7 +3883,7 @@ this method is called.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L855-L857'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L914-L916'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3961,7 +3933,7 @@ this method is called.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L856-L856'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L915-L915'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -4028,7 +4000,7 @@ this method is called.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/0db20ae97f8f1f61e3d813f1d90e9a242bc1538b/gateways/js/src/fjage.js#L868-L886'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L927-L948'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -4037,7 +4009,7 @@ this method is called.</p>
 
   <p>Creates a unqualified message class based on a fully qualified name.</p>
 
-    <div class='pre p1 fill-light mt0'>new MessageClass(name: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, parent: class): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">function</a></div>
+    <div class='pre p1 fill-light mt0'>new MessageClass(name: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, parent: any)</div>
   
   
 
@@ -4063,10 +4035,9 @@ this method is called.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>parent</span> <code class='quiet'>(class
+            <span class='code bold'>parent</span> <code class='quiet'>(any
             = <code>Message</code>)</code>
-	    class of the parent MessageClass to inherit from
-
+	    
           </div>
           
         </div>
@@ -4076,14 +4047,6 @@ this method is called.</p>
 
   
 
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function">function</a></code>:
-        constructor for the unqualified message class
-
-      
-    
   
 
   
@@ -4097,6 +4060,175 @@ this method is called.</p>
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">const</span> <span class="hljs-title class_">ParameterReq</span> = <span class="hljs-title class_">MessageClass</span>(<span class="hljs-string">&#x27;org.arl.fjage.param.ParameterReq&#x27;</span>);
 <span class="hljs-keyword">let</span> pReq = <span class="hljs-keyword">new</span> <span class="hljs-title class_">ParameterReq</span>()</pre>
     
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='parameterreqentry'>
+      ParameterReq.Entry
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L1058-L1063'>
+      <span>gateways/js/src/fjage.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+    <div class='pre p1 fill-light mt0'>ParameterReq.Entry</div>
+  
+    <p>
+      Type:
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>param</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          : parameter name
+
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>value</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+          : parameter value
+
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='parameterreq'>
+      ParameterReq
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/c35b36d55999c0edb08b83c6a154030db92a8995/gateways/js/src/fjage.js#L1066-L1074'>
+      <span>gateways/js/src/fjage.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>A message that requests one or more parameters of an agent.</p>
+
+    <div class='pre p1 fill-light mt0'>ParameterReq</div>
+  
+    <p>
+      Type:
+      <a href="#message">Message</a>
+    </p>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>param</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          : parameters name to be get/set if only a single parameter is to be get/set
+
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>value</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+          : parameters value to be set if only a single parameter is to be set
+
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>requests</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#parameterreqentry">ParameterReq.Entry</a>>)</code>
+          : a list of multiple parameters to be get/set
+
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>index</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</code>
+          : index of parameter(s) to be set
+
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
   
 
   

--- a/gateways/js/dist/esm/fjage.js
+++ b/gateways/js/dist/esm/fjage.js
@@ -37,29 +37,31 @@ var createConnection;
  * @class
  * @ignore
  */
-class TCPconnector {
+class TCPConnector {
 
   /**
     * Create an TCPConnector to connect to a fjage master over TCP
    * @param {Object} opts
-   * @param {string} opts.hostname - hostname/ip address of the master container to connect to
-   * @param {string} opts.port - port number of the master container to connect to
-   * @param {boolean} opts.keepAlive - try to reconnect if the connection is lost
+   * @param {string} [opts.hostname='localhost'] - hostname/ip address of the master container to connect to
+   * @param {number} [opts.port=1100] - port number of the master container to connect to
+   * @param {boolean} [opts.keepAlive=true] - try to reconnect if the connection is lost
+   * @param {boolean} [opts.debug=false] - debug info to be logged to console?
    * @param {number} [opts.reconnectTime=5000] - time before reconnection is attempted after an error
     */
   constructor(opts = {}) {
-    let host = opts.hostname;
-    let port = opts.port;
+    let host = opts.hostname || 'localhost';
+    let port = opts.port || 1100;
     this._keepAlive = opts.keepAlive;
     this._reconnectTime = opts.reconnectTime || DEFAULT_RECONNECT_TIME$1;
     this.url = new URL('tcp://localhost');
     this.url.hostname = host;
-    this.url.port = port;
+    this.url.port = port.toString();
     this._buf = '';
     this._firstConn = true;               // if the Gateway has managed to connect to a server before
     this._firstReConn = true;             // if the Gateway has attempted to reconnect to a server before
     this.pendingOnOpen = [];              // list of callbacks make as soon as gateway is open
     this.connListeners = [];              // external listeners wanting to listen connection events
+    this.debug = false;
     this._sockInit(host, port);
   }
 
@@ -73,6 +75,7 @@ class TCPconnector {
   _sockInit(host, port){
     if (!createConnection){
       try {
+        // @ts-ignore
         import('net').then(module => {
           createConnection = module.createConnection;
           this._sockSetup(host, port);
@@ -157,18 +160,18 @@ class TCPconnector {
   }
 
   /**
+   * @callback TCPConnectorReadCallback
+   * @ignore
+   * @param {string} s - incoming message string
+   */
+
+  /**
    * Set a callback for receiving incoming strings from the connector
-   * @param {TCPConnector~ReadCallback} cb - callback that is called when the connector gets a string
+   * @param {TCPConnectorReadCallback} cb - callback that is called when the connector gets a string
    */
   setReadCallback(cb){
     if (cb && {}.toString.call(cb) === '[object Function]') this._onSockRx = cb;
   }
-
-  /**
-   * @callback TCPConnector~ReadCallback
-   * @ignore
-   * @param {string} s - incoming message string
-   */
 
   /**
    * Add listener for connection events
@@ -226,17 +229,20 @@ class WSConnector {
   /**
    * Create an WSConnector to connect to a fjage master over WebSockets
    * @param {Object} opts
-   * @param {string} opts.hostname - hostname/ip address of the master container to connect to
-   * @param {string} opts.port - port number of the master container to connect to
-   * @param {string} opts.pathname - path of the master container to connect to
-   * @param {boolean} opts.keepAlive - try to reconnect if the connection is lost
+   * @param {string} [opts.hostname='localhost'] - hostname/ip address of the master container to connect to
+   * @param {number} [opts.port=80] - port number of the master container to connect to
+   * @param {string} [opts.pathname="/"] - path of the master container to connect to
+   * @param {boolean} [opts.keepAlive=true] - try to reconnect if the connection is lost
+   * @param {boolean} [opts.debug=false] - debug info to be logged to console?
    * @param {number} [opts.reconnectTime=5000] - time before reconnection is attempted after an error
    */
   constructor(opts = {}) {
+    let host = opts.hostname || 'localhost';
+    let port = opts.port || 80;
     this.url = new URL('ws://localhost');
-    this.url.hostname = opts.hostname;
-    this.url.port = opts.port;
-    this.url.pathname = opts.pathname;
+    this.url.hostname = host;
+    this.url.port = port.toString();
+    this.url.pathname = opts.pathname || '/';
     this._keepAlive = opts.keepAlive;
     this._reconnectTime = opts.reconnectTime || DEFAULT_RECONNECT_TIME;
     this.debug = opts.debug || false;      // debug info to be logged to console?
@@ -311,19 +317,19 @@ class WSConnector {
   }
 
   /**
+   * @callback WSConnectorReadCallback
+   * @ignore
+   * @param {string} s - incoming message string
+   */
+
+  /**
    * Set a callback for receiving incoming strings from the connector
-   * @param {WSConnector~ReadCallback} cb - callback that is called when the connector gets a string
+   * @param {WSConnectorReadCallback} cb - callback that is called when the connector gets a string
    * @ignore
    */
   setReadCallback(cb){
     if (cb && {}.toString.call(cb) === '[object Function]') this._onWebsockRx = cb;
   }
-
-  /**
-   * @callback WSConnector~ReadCallback
-   * @ignore
-   * @param {string} s - incoming message string
-   */
 
   /**
    * Add listener for connection events
@@ -395,13 +401,13 @@ const Performative = {
  * An identifier for an agent or a topic.
  * @class
  * @param {string} name - name of the agent
- * @param {boolean} topic - name of topic
- * @param {Gateway} owner - Gateway owner for this AgentID
+ * @param {boolean} [topic=false] - name of topic
+ * @param {Gateway} [owner] - Gateway owner for this AgentID
  */
 class AgentID {
 
 
-  constructor(name, topic, owner) {
+  constructor(name, topic=false, owner) {
     this.name = name;
     this.topic = topic;
     this.owner = owner;
@@ -428,12 +434,13 @@ class AgentID {
   /**
    * Sends a message to the agent represented by this id.
    *
-   * @param {string} msg - message to send
+   * @param {Message} msg - message to send
    * @returns {void}
    */
   send(msg) {
     msg.recipient = this.toJSON();
-    this.owner.send(msg);
+    if (this.owner) this.owner.send(msg);
+    else throw new Error('Unowned AgentID cannot send messages');
   }
 
   /**
@@ -445,7 +452,8 @@ class AgentID {
    */
   async request(msg, timeout=1000) {
     msg.recipient = this.toJSON();
-    return this.owner.request(msg, timeout);
+    if (this.owner) return this.owner.request(msg, timeout);
+    else throw new Error('Unowned AgentID cannot send messages');
   }
 
   /**
@@ -564,12 +572,12 @@ class AgentID {
 /**
  * Base class for messages transmitted by one agent to another. Creates an empty message.
  * @class
- * @param {Message} inReplyTo - message to which this response corresponds to
- * @param {Performative} - performative
+ * @param {Message} [inReplyTo] - message to which this response corresponds to
+ * @param {Performative} [perf=Performative.INFORM] - performative
  */
 class Message {
 
-  constructor(inReplyTo={msgID:null, sender:null}, perf='') {
+  constructor(inReplyTo={msgID:null, sender:null}, perf=Performative.INFORM) {
     this.__clazz__ = 'org.arl.fjage.Message';
     this.msgID = _guid(8);
     this.sender = null;
@@ -610,7 +618,11 @@ class Message {
   // convert a message into a JSON string
   // NOTE: we don't do any base64 encoding for TX as
   //       we don't know what data type is intended
-  /** @private */
+  /**
+   * @private
+   *
+   * @return {string} - JSON string representation of the message
+   */
   _serialize() {
     let clazz = this.__clazz__ || 'org.arl.fjage.Message';
     let data = JSON.stringify(this, (k,v) => {
@@ -628,26 +640,27 @@ class Message {
   }
 
   // convert a dictionary (usually from decoding JSON) into a message
-  /** @private */
-  static _deserialize(obj) {
-    if (typeof obj == 'string' || obj instanceof String) {
+  /**
+   * @private
+   *
+   * @param {(string|Object)} json - JSON string or object to be converted to a message
+   * @returns {Message} - message created from the JSON string or object
+   * */
+  static _deserialize(json) {
+    let obj = null;
+    if (typeof json == 'string') {
       try {
-        obj = JSON.parse(obj);
+        obj = JSON.parse(json);
       }catch(e){
         return null;
       }
-    }
-    try {
-      let qclazz = obj.clazz;
-      let clazz = qclazz.replace(/^.*\./, '');
-      let rv = MessageClass[clazz] ? new MessageClass[clazz] : new Message();
-      rv.__clazz__ = qclazz;
-      rv._inflate(obj.data);
-      return rv;
-    } catch (err) {
-      console.warn('Error trying to deserialize JSON object : ', obj, err);
-      return null;
-    }
+    } else obj = json;
+    let qclazz = obj.clazz;
+    let clazz = qclazz.replace(/^.*\./, '');
+    let rv = MessageClass[clazz] ? new MessageClass[clazz] : new Message();
+    rv.__clazz__ = qclazz;
+    rv._inflate(obj.data);
+    return rv;
   }
 }
 
@@ -673,36 +686,18 @@ class GenericMessage extends Message {
  *
  * @class
  * @param {Object} opts
- * @param {string}  [opts.hostname="localhost"] - hostname/ip address of the master container to connect to
- * @param {string}  [opts.port='1100']        - port number of the master container to connect to
- * @param {string}  [opts.pathname=""]        - path of the master container to connect to (for WebSockets)
- * @param {boolean} [opts.keepAlive=true]     - try to reconnect if the connection is lost
- * @param {number}  [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
- * @param {number}  [opts.timeout=1000]       - timeout for fjage level messages in ms
+ * @param {string} [opts.hostname="localhost"] - hostname/ip address of the master container to connect to
+ * @param {number} [opts.port=1100]          - port number of the master container to connect to
+ * @param {string} [opts.pathname=""]        - path of the master container to connect to (for WebSockets)
+ * @param {string} [opts.keepAlive=true]     - try to reconnect if the connection is lost
+ * @param {number} [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
+ * @param {number} [opts.timeout=1000]       - timeout for fjage level messages in ms
  * @param {boolean} [opts.returnNullOnFailedResponse=true] - return null instead of throwing an error when a parameter is not found
- * @param {string}  [hostname="localhost"]    - <strike>Deprecated : hostname/ip address of the master container to connect to</strike>
- * @param {number}  [port=]                   - <strike>Deprecated : port number of the master container to connect to</strike>
- * @param {string}  [pathname=="/ws/"]        - <strike>Deprecated : path of the master container to connect to (for WebSockets)</strike>
- * @param {number}  [timeout=1000]            - <strike>Deprecated : timeout for fjage level messages in ms</strike>
  */
 class Gateway {
 
-  constructor(opts = {}, port, pathname='/ws/', timeout=1000) {
-    // Support for deprecated constructor
-    if (typeof opts === 'string' || opts instanceof String){
-      opts = {
-        'hostname': opts,
-        'port' : port,
-        'pathname' : pathname,
-        'timeout' : timeout
-      };
-      console.warn('Deprecated use of Gateway constructor');
-    }
-
-    // Set defaults
-    for (var key in GATEWAY_DEFAULTS){
-      if (opts[key] == undefined || opts[key] === '') opts[key] = GATEWAY_DEFAULTS[key];
-    }
+  constructor(opts = {}) {
+    opts = Object.assign({}, GATEWAY_DEFAULTS, opts);
     var url = DEFAULT_URL;
     url.hostname = opts.hostname;
     url.port = opts.port;
@@ -725,7 +720,12 @@ class Gateway {
     this._addGWCache(this);
   }
 
-  /** @private */
+  /**
+   * Sends an event to all registered listeners of the given type.
+   * @private
+   * @param {string} type - type of event
+   * @param {Object|Message|string} val - value to be sent to the listeners
+   */
   _sendEvent(type, val) {
     if (Array.isArray(this.eventListeners[type])) {
       this.eventListeners[type].forEach(l => {
@@ -740,7 +740,11 @@ class Gateway {
     }
   }
 
-  /** @private */
+  /**
+   * @private
+   * @param {string} data - stringfied JSON data received from the master container to be processed
+   * @returns {void}
+   */
   _onMsgRx(data) {
     var obj;
     if (this.debug) console.log('< '+data);
@@ -757,6 +761,7 @@ class Gateway {
       delete this.pending[obj.id];
     } else if (obj.action == 'send') {
       // incoming message from master
+      // @ts-ignore
       let msg = Message._deserialize(obj.message);
       if (!msg) return;
       this._sendEvent('rxmsg', msg);
@@ -817,7 +822,12 @@ class Gateway {
     }
   }
 
-  /** @private */
+  /**
+   * Sends a message out to the master container.
+   * @private
+   * @param {string|Object} s - JSON object (either stringified or not) to be sent to the master container
+   * @returns {boolean} - true if the message was sent successfully
+   */
   _msgTx(s) {
     if (typeof s != 'string' && !(s instanceof String)) s = JSON.stringify(s);
     if(this.debug) console.log('> '+s);
@@ -825,7 +835,11 @@ class Gateway {
     return this.connector.write(s);
   }
 
-  /** @private */
+  /**
+   * @private
+   * @param {Object} rq - request to be sent to the master container as a JSON object
+   * @returns {Promise<Object>} - a promise which returns the response from the master container
+   */
   _msgTxRx(rq) {
     rq.id = _guid(8);
     return new Promise(resolve => {
@@ -847,21 +861,27 @@ class Gateway {
     });
   }
 
-  /** @private */
+  /**
+   * @private
+   * @param {URL} url - URL object of the master container to connect to
+   * @returns {TCPConnector|WSConnector} - connector object to connect to the master container
+   */
   _createConnector(url){
     let conn;
     if (url.protocol.startsWith('ws')){
       conn =  new WSConnector({
         'hostname':url.hostname,
-        'port':url.port,
+        'port':parseInt(url.port),
         'pathname':url.pathname,
-        'keepAlive': this._keepAlive
+        'keepAlive': this._keepAlive,
+        'debug': this.debug
       });
     }else if (url.protocol.startsWith('tcp')){
-      conn = new TCPconnector({
+      conn = new TCPConnector({
         'hostname':url.hostname,
-        'port':url.port,
-        'keepAlive': this._keepAlive
+        'port':parseInt(url.port),
+        'keepAlive': this._keepAlive,
+        'debug': this.debug
       });
     } else return null;
     conn.setReadCallback(this._onMsgRx.bind(this));
@@ -877,7 +897,13 @@ class Gateway {
     return conn;
   }
 
-  /** @private */
+  /**
+   * Checks if the object is a constructor.
+   *
+   * @private
+   * @param {Object} value - an object to be checked if it is a constructor
+   * @returns {boolean} - if the object is a constructor
+   */
   _isConstructor(value) {
     try {
       new new Proxy(value, {construct() { return {}; }});
@@ -887,7 +913,13 @@ class Gateway {
     }
   }
 
-  /** @private */
+  /**
+   * Matches a message with a filter.
+   * @private
+   * @param {string|Object|function} filter - filter to be matched
+   * @param {Message} msg - message to be matched to the filter
+   * @returns {boolean} - true if the message matches the filter
+   */
   _matchMessage(filter, msg){
     if (typeof filter == 'string' || filter instanceof String) {
       return 'inReplyTo' in msg && msg.inReplyTo == filter;
@@ -907,18 +939,25 @@ class Gateway {
     }
   }
 
-  /** @private */
+  /**
+   * Gets the next message from the queue that matches the filter.
+   * @private
+   * @param {string|Object|function} filter - filter to be matched
+   */
   _getMessageFromQueue(filter) {
     if (!this.queue.length) return;
     if (!filter) return this.queue.shift();
-
     let matchedMsg = this.queue.find( msg => this._matchMessage(filter, msg));
     if (matchedMsg) this.queue.splice(this.queue.indexOf(matchedMsg), 1);
-
     return matchedMsg;
   }
 
-  /** @private */
+  /**
+   * Gets a cached gateway object for the given URL (if it exists).
+   * @private
+   * @param {URL} url - URL object of the master container to connect to
+   * @returns {Gateway|void} - gateway object for the given URL
+   */
   _getGWCache(url){
     if (!gObj.fjage || !gObj.fjage.gateways) return null;
     var f = gObj.fjage.gateways.filter(g => g.connector.url.toString() == url.toString());
@@ -926,13 +965,21 @@ class Gateway {
     return null;
   }
 
-  /** @private */
+  /**
+   * Adds a gateway object to the cache if it doesn't already exist.
+   * @private
+   * @param {Gateway} gw - gateway object to be added to the cache
+   */
   _addGWCache(gw){
     if (!gObj.fjage || !gObj.fjage.gateways) return;
     gObj.fjage.gateways.push(gw);
   }
 
-  /** @private */
+  /**
+   * Removes a gateway object from the cache if it exists.
+   * @private
+   * @param {Gateway} gw - gateway object to be removed from the cache
+   */
   _removeGWCache(gw){
     if (!gObj.fjage || !gObj.fjage.gateways) return;
     var index = gObj.fjage.gateways.indexOf(gw);
@@ -1020,7 +1067,7 @@ class Gateway {
   /**
    * Gets the agent ID associated with the gateway.
    *
-   * @returns {string} - agent ID
+   * @returns {AgentID} - agent ID
    */
   getAgentID() {
     return this.aid;
@@ -1061,6 +1108,7 @@ class Gateway {
     if (!topic.isTopic()) topic = new AgentID(topic.getName() + '__ntf', true, this);
     this.subscriptions[topic.toJSON()] = true;
     this._update_watch();
+    return true;
   }
 
   /**
@@ -1152,6 +1200,7 @@ class Gateway {
     }
     this._sendEvent('txmsg', msg);
     let rq = JSON.stringify({ action: 'send', relay: true, message: '###MSG###' });
+    // @ts-ignore
     rq = rq.replace('"###MSG###"', msg._serialize());
     return !!this._msgTx(rq);
   }
@@ -1169,9 +1218,9 @@ class Gateway {
    * Sends a request and waits for a response. This method returns a {Promise} which resolves when a response
    * is received or if no response is received after the timeout.
    *
-   * @param {string} msg - message to send
+   * @param {Message} msg - message to send
    * @param {number} [timeout=1000] - timeout in milliseconds
-   * @returns {Promise<?Message>} - a promise which resolves with the received response message, null on timeout
+   * @returns {Promise<Message|void>} - a promise which resolves with the received response message, null on timeout
    */
   async request(msg, timeout=1000) {
     this.send(msg);
@@ -1182,10 +1231,10 @@ class Gateway {
    * Returns a response message received by the gateway. This method returns a {Promise} which resolves when
    * a response is received or if no response is received after the timeout.
    *
-   * @param {function} [filter=] - original message to which a response is expected, or a MessageClass of the type
+   * @param {function|Message|typeof Message} filter - original message to which a response is expected, or a MessageClass of the type
    * of message to match, or a closure to use to match against the message
    * @param {number} [timeout=0] - timeout in milliseconds
-   * @returns {Promise<?Message>} - received response message, null on timeout
+   * @returns {Promise<Message|void>} - received response message, null on timeout
    */
   async receive(filter, timeout=0) {
     return new Promise(resolve => {
@@ -1240,8 +1289,8 @@ const Services = {
 /**
  * Creates a unqualified message class based on a fully qualified name.
  * @param {string} name - fully qualified name of the message class to be created
- * @param {class} [parent=Message] - class of the parent MessageClass to inherit from
- * @returns {function} - constructor for the unqualified message class
+ * @param {typeof Message} [parent] - class of the parent MessageClass to inherit from
+ * @constructs Message
  * @example
  * const ParameterReq = MessageClass('org.arl.fjage.param.ParameterReq');
  * let pReq = new ParameterReq()
@@ -1250,6 +1299,9 @@ function MessageClass(name, parent=Message) {
   let sname = name.replace(/^.*\./, '');
   if (MessageClass[sname]) return MessageClass[sname];
   let cls = class extends parent {
+    /**
+     * @param {{ [x: string]: any; }} params
+     */
     constructor(params) {
       super();
       this.__clazz__ = name;
@@ -1305,7 +1357,7 @@ function _b64toArray(base64, dtype, littleEndian=true) {
     break;
   case '[J': // long array
     for (i = 0; i < len; i+=8)
-      rv.push(view.getInt64(i, littleEndian));
+      rv.push(view.getBigInt64(i, littleEndian));
     break;
   case '[F': // float array
     for (i = 0; i < len; i+=4)
@@ -1340,6 +1392,8 @@ function _decodeBase64(k, d) {
 ////// global
 
 const GATEWAY_DEFAULTS = {};
+
+/** @type {Window & globalThis & Object} */
 let gObj = {};
 let DEFAULT_URL;
 if (isBrowser || isWebWorker){
@@ -1356,7 +1410,7 @@ if (isBrowser || isWebWorker){
   DEFAULT_URL = new URL('ws://localhost');
   // Enable caching of Gateways
   if (typeof gObj.fjage === 'undefined') gObj.fjage = {};
-  if (typeof gObj.fjage.gateways == 'undefined')gObj.fjage.gateways = [];
+  if (typeof gObj.fjage.gateways == 'undefined') gObj.fjage.gateways = [];
 } else if (isJsDom || isNode){
   gObj = global;
   Object.assign(GATEWAY_DEFAULTS, {
@@ -1372,6 +1426,23 @@ if (isBrowser || isWebWorker){
   gObj.atob = a => Buffer.from(a, 'base64').toString('binary');
 }
 
+/**
+ * @typedef {Object} ParameterReq.Entry
+ * @property {string} param - parameter name
+ * @property {Object} value - parameter value
+ * @exports ParameterReq.Entry
+ */
+
+
+/**
+ * A message that requests one or more parameters of an agent.
+ * @typedef {Message} ParameterReq
+ * @property {string} param - parameters name to be get/set if only a single parameter is to be get/set
+ * @property {Object} value - parameters value to be set if only a single parameter is to be set
+ * @property {Array<ParameterReq.Entry>} requests - a list of multiple parameters to be get/set
+ * @property {number} [index=-1] - index of parameter(s) to be set
+ * @exports ParameterReq
+ */
 const ParameterReq = MessageClass('org.arl.fjage.param.ParameterReq');
 
-export { AgentID, Gateway, GenericMessage, Message, MessageClass, Performative, Services };
+export { AgentID, Gateway, GenericMessage, Message, MessageClass, ParameterReq, Performative, Services };

--- a/gateways/js/dist/fjage.js
+++ b/gateways/js/dist/fjage.js
@@ -43,29 +43,31 @@
    * @class
    * @ignore
    */
-  class TCPconnector {
+  class TCPConnector {
 
     /**
       * Create an TCPConnector to connect to a fjage master over TCP
      * @param {Object} opts
-     * @param {string} opts.hostname - hostname/ip address of the master container to connect to
-     * @param {string} opts.port - port number of the master container to connect to
-     * @param {boolean} opts.keepAlive - try to reconnect if the connection is lost
+     * @param {string} [opts.hostname='localhost'] - hostname/ip address of the master container to connect to
+     * @param {number} [opts.port=1100] - port number of the master container to connect to
+     * @param {boolean} [opts.keepAlive=true] - try to reconnect if the connection is lost
+     * @param {boolean} [opts.debug=false] - debug info to be logged to console?
      * @param {number} [opts.reconnectTime=5000] - time before reconnection is attempted after an error
       */
     constructor(opts = {}) {
-      let host = opts.hostname;
-      let port = opts.port;
+      let host = opts.hostname || 'localhost';
+      let port = opts.port || 1100;
       this._keepAlive = opts.keepAlive;
       this._reconnectTime = opts.reconnectTime || DEFAULT_RECONNECT_TIME$1;
       this.url = new URL('tcp://localhost');
       this.url.hostname = host;
-      this.url.port = port;
+      this.url.port = port.toString();
       this._buf = '';
       this._firstConn = true;               // if the Gateway has managed to connect to a server before
       this._firstReConn = true;             // if the Gateway has attempted to reconnect to a server before
       this.pendingOnOpen = [];              // list of callbacks make as soon as gateway is open
       this.connListeners = [];              // external listeners wanting to listen connection events
+      this.debug = false;
       this._sockInit(host, port);
     }
 
@@ -79,6 +81,7 @@
     _sockInit(host, port){
       if (!createConnection){
         try {
+          // @ts-ignore
           import('net').then(module => {
             createConnection = module.createConnection;
             this._sockSetup(host, port);
@@ -163,18 +166,18 @@
     }
 
     /**
+     * @callback TCPConnectorReadCallback
+     * @ignore
+     * @param {string} s - incoming message string
+     */
+
+    /**
      * Set a callback for receiving incoming strings from the connector
-     * @param {TCPConnector~ReadCallback} cb - callback that is called when the connector gets a string
+     * @param {TCPConnectorReadCallback} cb - callback that is called when the connector gets a string
      */
     setReadCallback(cb){
       if (cb && {}.toString.call(cb) === '[object Function]') this._onSockRx = cb;
     }
-
-    /**
-     * @callback TCPConnector~ReadCallback
-     * @ignore
-     * @param {string} s - incoming message string
-     */
 
     /**
      * Add listener for connection events
@@ -232,17 +235,20 @@
     /**
      * Create an WSConnector to connect to a fjage master over WebSockets
      * @param {Object} opts
-     * @param {string} opts.hostname - hostname/ip address of the master container to connect to
-     * @param {string} opts.port - port number of the master container to connect to
-     * @param {string} opts.pathname - path of the master container to connect to
-     * @param {boolean} opts.keepAlive - try to reconnect if the connection is lost
+     * @param {string} [opts.hostname='localhost'] - hostname/ip address of the master container to connect to
+     * @param {number} [opts.port=80] - port number of the master container to connect to
+     * @param {string} [opts.pathname="/"] - path of the master container to connect to
+     * @param {boolean} [opts.keepAlive=true] - try to reconnect if the connection is lost
+     * @param {boolean} [opts.debug=false] - debug info to be logged to console?
      * @param {number} [opts.reconnectTime=5000] - time before reconnection is attempted after an error
      */
     constructor(opts = {}) {
+      let host = opts.hostname || 'localhost';
+      let port = opts.port || 80;
       this.url = new URL('ws://localhost');
-      this.url.hostname = opts.hostname;
-      this.url.port = opts.port;
-      this.url.pathname = opts.pathname;
+      this.url.hostname = host;
+      this.url.port = port.toString();
+      this.url.pathname = opts.pathname || '/';
       this._keepAlive = opts.keepAlive;
       this._reconnectTime = opts.reconnectTime || DEFAULT_RECONNECT_TIME;
       this.debug = opts.debug || false;      // debug info to be logged to console?
@@ -317,19 +323,19 @@
     }
 
     /**
+     * @callback WSConnectorReadCallback
+     * @ignore
+     * @param {string} s - incoming message string
+     */
+
+    /**
      * Set a callback for receiving incoming strings from the connector
-     * @param {WSConnector~ReadCallback} cb - callback that is called when the connector gets a string
+     * @param {WSConnectorReadCallback} cb - callback that is called when the connector gets a string
      * @ignore
      */
     setReadCallback(cb){
       if (cb && {}.toString.call(cb) === '[object Function]') this._onWebsockRx = cb;
     }
-
-    /**
-     * @callback WSConnector~ReadCallback
-     * @ignore
-     * @param {string} s - incoming message string
-     */
 
     /**
      * Add listener for connection events
@@ -401,13 +407,13 @@
    * An identifier for an agent or a topic.
    * @class
    * @param {string} name - name of the agent
-   * @param {boolean} topic - name of topic
-   * @param {Gateway} owner - Gateway owner for this AgentID
+   * @param {boolean} [topic=false] - name of topic
+   * @param {Gateway} [owner] - Gateway owner for this AgentID
    */
   class AgentID {
 
 
-    constructor(name, topic, owner) {
+    constructor(name, topic=false, owner) {
       this.name = name;
       this.topic = topic;
       this.owner = owner;
@@ -434,12 +440,13 @@
     /**
      * Sends a message to the agent represented by this id.
      *
-     * @param {string} msg - message to send
+     * @param {Message} msg - message to send
      * @returns {void}
      */
     send(msg) {
       msg.recipient = this.toJSON();
-      this.owner.send(msg);
+      if (this.owner) this.owner.send(msg);
+      else throw new Error('Unowned AgentID cannot send messages');
     }
 
     /**
@@ -451,7 +458,8 @@
      */
     async request(msg, timeout=1000) {
       msg.recipient = this.toJSON();
-      return this.owner.request(msg, timeout);
+      if (this.owner) return this.owner.request(msg, timeout);
+      else throw new Error('Unowned AgentID cannot send messages');
     }
 
     /**
@@ -570,12 +578,12 @@
   /**
    * Base class for messages transmitted by one agent to another. Creates an empty message.
    * @class
-   * @param {Message} inReplyTo - message to which this response corresponds to
-   * @param {Performative} - performative
+   * @param {Message} [inReplyTo] - message to which this response corresponds to
+   * @param {Performative} [perf=Performative.INFORM] - performative
    */
   class Message {
 
-    constructor(inReplyTo={msgID:null, sender:null}, perf='') {
+    constructor(inReplyTo={msgID:null, sender:null}, perf=Performative.INFORM) {
       this.__clazz__ = 'org.arl.fjage.Message';
       this.msgID = _guid(8);
       this.sender = null;
@@ -616,7 +624,11 @@
     // convert a message into a JSON string
     // NOTE: we don't do any base64 encoding for TX as
     //       we don't know what data type is intended
-    /** @private */
+    /**
+     * @private
+     *
+     * @return {string} - JSON string representation of the message
+     */
     _serialize() {
       let clazz = this.__clazz__ || 'org.arl.fjage.Message';
       let data = JSON.stringify(this, (k,v) => {
@@ -634,26 +646,27 @@
     }
 
     // convert a dictionary (usually from decoding JSON) into a message
-    /** @private */
-    static _deserialize(obj) {
-      if (typeof obj == 'string' || obj instanceof String) {
+    /**
+     * @private
+     *
+     * @param {(string|Object)} json - JSON string or object to be converted to a message
+     * @returns {Message} - message created from the JSON string or object
+     * */
+    static _deserialize(json) {
+      let obj = null;
+      if (typeof json == 'string') {
         try {
-          obj = JSON.parse(obj);
+          obj = JSON.parse(json);
         }catch(e){
           return null;
         }
-      }
-      try {
-        let qclazz = obj.clazz;
-        let clazz = qclazz.replace(/^.*\./, '');
-        let rv = MessageClass[clazz] ? new MessageClass[clazz] : new Message();
-        rv.__clazz__ = qclazz;
-        rv._inflate(obj.data);
-        return rv;
-      } catch (err) {
-        console.warn('Error trying to deserialize JSON object : ', obj, err);
-        return null;
-      }
+      } else obj = json;
+      let qclazz = obj.clazz;
+      let clazz = qclazz.replace(/^.*\./, '');
+      let rv = MessageClass[clazz] ? new MessageClass[clazz] : new Message();
+      rv.__clazz__ = qclazz;
+      rv._inflate(obj.data);
+      return rv;
     }
   }
 
@@ -679,36 +692,18 @@
    *
    * @class
    * @param {Object} opts
-   * @param {string}  [opts.hostname="localhost"] - hostname/ip address of the master container to connect to
-   * @param {string}  [opts.port='1100']        - port number of the master container to connect to
-   * @param {string}  [opts.pathname=""]        - path of the master container to connect to (for WebSockets)
-   * @param {boolean} [opts.keepAlive=true]     - try to reconnect if the connection is lost
-   * @param {number}  [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
-   * @param {number}  [opts.timeout=1000]       - timeout for fjage level messages in ms
+   * @param {string} [opts.hostname="localhost"] - hostname/ip address of the master container to connect to
+   * @param {number} [opts.port=1100]          - port number of the master container to connect to
+   * @param {string} [opts.pathname=""]        - path of the master container to connect to (for WebSockets)
+   * @param {string} [opts.keepAlive=true]     - try to reconnect if the connection is lost
+   * @param {number} [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
+   * @param {number} [opts.timeout=1000]       - timeout for fjage level messages in ms
    * @param {boolean} [opts.returnNullOnFailedResponse=true] - return null instead of throwing an error when a parameter is not found
-   * @param {string}  [hostname="localhost"]    - <strike>Deprecated : hostname/ip address of the master container to connect to</strike>
-   * @param {number}  [port=]                   - <strike>Deprecated : port number of the master container to connect to</strike>
-   * @param {string}  [pathname=="/ws/"]        - <strike>Deprecated : path of the master container to connect to (for WebSockets)</strike>
-   * @param {number}  [timeout=1000]            - <strike>Deprecated : timeout for fjage level messages in ms</strike>
    */
   class Gateway {
 
-    constructor(opts = {}, port, pathname='/ws/', timeout=1000) {
-      // Support for deprecated constructor
-      if (typeof opts === 'string' || opts instanceof String){
-        opts = {
-          'hostname': opts,
-          'port' : port,
-          'pathname' : pathname,
-          'timeout' : timeout
-        };
-        console.warn('Deprecated use of Gateway constructor');
-      }
-
-      // Set defaults
-      for (var key in GATEWAY_DEFAULTS){
-        if (opts[key] == undefined || opts[key] === '') opts[key] = GATEWAY_DEFAULTS[key];
-      }
+    constructor(opts = {}) {
+      opts = Object.assign({}, GATEWAY_DEFAULTS, opts);
       var url = DEFAULT_URL;
       url.hostname = opts.hostname;
       url.port = opts.port;
@@ -731,7 +726,12 @@
       this._addGWCache(this);
     }
 
-    /** @private */
+    /**
+     * Sends an event to all registered listeners of the given type.
+     * @private
+     * @param {string} type - type of event
+     * @param {Object|Message|string} val - value to be sent to the listeners
+     */
     _sendEvent(type, val) {
       if (Array.isArray(this.eventListeners[type])) {
         this.eventListeners[type].forEach(l => {
@@ -746,7 +746,11 @@
       }
     }
 
-    /** @private */
+    /**
+     * @private
+     * @param {string} data - stringfied JSON data received from the master container to be processed
+     * @returns {void}
+     */
     _onMsgRx(data) {
       var obj;
       if (this.debug) console.log('< '+data);
@@ -763,6 +767,7 @@
         delete this.pending[obj.id];
       } else if (obj.action == 'send') {
         // incoming message from master
+        // @ts-ignore
         let msg = Message._deserialize(obj.message);
         if (!msg) return;
         this._sendEvent('rxmsg', msg);
@@ -823,7 +828,12 @@
       }
     }
 
-    /** @private */
+    /**
+     * Sends a message out to the master container.
+     * @private
+     * @param {string|Object} s - JSON object (either stringified or not) to be sent to the master container
+     * @returns {boolean} - true if the message was sent successfully
+     */
     _msgTx(s) {
       if (typeof s != 'string' && !(s instanceof String)) s = JSON.stringify(s);
       if(this.debug) console.log('> '+s);
@@ -831,7 +841,11 @@
       return this.connector.write(s);
     }
 
-    /** @private */
+    /**
+     * @private
+     * @param {Object} rq - request to be sent to the master container as a JSON object
+     * @returns {Promise<Object>} - a promise which returns the response from the master container
+     */
     _msgTxRx(rq) {
       rq.id = _guid(8);
       return new Promise(resolve => {
@@ -853,21 +867,27 @@
       });
     }
 
-    /** @private */
+    /**
+     * @private
+     * @param {URL} url - URL object of the master container to connect to
+     * @returns {TCPConnector|WSConnector} - connector object to connect to the master container
+     */
     _createConnector(url){
       let conn;
       if (url.protocol.startsWith('ws')){
         conn =  new WSConnector({
           'hostname':url.hostname,
-          'port':url.port,
+          'port':parseInt(url.port),
           'pathname':url.pathname,
-          'keepAlive': this._keepAlive
+          'keepAlive': this._keepAlive,
+          'debug': this.debug
         });
       }else if (url.protocol.startsWith('tcp')){
-        conn = new TCPconnector({
+        conn = new TCPConnector({
           'hostname':url.hostname,
-          'port':url.port,
-          'keepAlive': this._keepAlive
+          'port':parseInt(url.port),
+          'keepAlive': this._keepAlive,
+          'debug': this.debug
         });
       } else return null;
       conn.setReadCallback(this._onMsgRx.bind(this));
@@ -883,7 +903,13 @@
       return conn;
     }
 
-    /** @private */
+    /**
+     * Checks if the object is a constructor.
+     *
+     * @private
+     * @param {Object} value - an object to be checked if it is a constructor
+     * @returns {boolean} - if the object is a constructor
+     */
     _isConstructor(value) {
       try {
         new new Proxy(value, {construct() { return {}; }});
@@ -893,7 +919,13 @@
       }
     }
 
-    /** @private */
+    /**
+     * Matches a message with a filter.
+     * @private
+     * @param {string|Object|function} filter - filter to be matched
+     * @param {Message} msg - message to be matched to the filter
+     * @returns {boolean} - true if the message matches the filter
+     */
     _matchMessage(filter, msg){
       if (typeof filter == 'string' || filter instanceof String) {
         return 'inReplyTo' in msg && msg.inReplyTo == filter;
@@ -913,18 +945,25 @@
       }
     }
 
-    /** @private */
+    /**
+     * Gets the next message from the queue that matches the filter.
+     * @private
+     * @param {string|Object|function} filter - filter to be matched
+     */
     _getMessageFromQueue(filter) {
       if (!this.queue.length) return;
       if (!filter) return this.queue.shift();
-
       let matchedMsg = this.queue.find( msg => this._matchMessage(filter, msg));
       if (matchedMsg) this.queue.splice(this.queue.indexOf(matchedMsg), 1);
-
       return matchedMsg;
     }
 
-    /** @private */
+    /**
+     * Gets a cached gateway object for the given URL (if it exists).
+     * @private
+     * @param {URL} url - URL object of the master container to connect to
+     * @returns {Gateway|void} - gateway object for the given URL
+     */
     _getGWCache(url){
       if (!gObj.fjage || !gObj.fjage.gateways) return null;
       var f = gObj.fjage.gateways.filter(g => g.connector.url.toString() == url.toString());
@@ -932,13 +971,21 @@
       return null;
     }
 
-    /** @private */
+    /**
+     * Adds a gateway object to the cache if it doesn't already exist.
+     * @private
+     * @param {Gateway} gw - gateway object to be added to the cache
+     */
     _addGWCache(gw){
       if (!gObj.fjage || !gObj.fjage.gateways) return;
       gObj.fjage.gateways.push(gw);
     }
 
-    /** @private */
+    /**
+     * Removes a gateway object from the cache if it exists.
+     * @private
+     * @param {Gateway} gw - gateway object to be removed from the cache
+     */
     _removeGWCache(gw){
       if (!gObj.fjage || !gObj.fjage.gateways) return;
       var index = gObj.fjage.gateways.indexOf(gw);
@@ -1026,7 +1073,7 @@
     /**
      * Gets the agent ID associated with the gateway.
      *
-     * @returns {string} - agent ID
+     * @returns {AgentID} - agent ID
      */
     getAgentID() {
       return this.aid;
@@ -1067,6 +1114,7 @@
       if (!topic.isTopic()) topic = new AgentID(topic.getName() + '__ntf', true, this);
       this.subscriptions[topic.toJSON()] = true;
       this._update_watch();
+      return true;
     }
 
     /**
@@ -1158,6 +1206,7 @@
       }
       this._sendEvent('txmsg', msg);
       let rq = JSON.stringify({ action: 'send', relay: true, message: '###MSG###' });
+      // @ts-ignore
       rq = rq.replace('"###MSG###"', msg._serialize());
       return !!this._msgTx(rq);
     }
@@ -1175,9 +1224,9 @@
      * Sends a request and waits for a response. This method returns a {Promise} which resolves when a response
      * is received or if no response is received after the timeout.
      *
-     * @param {string} msg - message to send
+     * @param {Message} msg - message to send
      * @param {number} [timeout=1000] - timeout in milliseconds
-     * @returns {Promise<?Message>} - a promise which resolves with the received response message, null on timeout
+     * @returns {Promise<Message|void>} - a promise which resolves with the received response message, null on timeout
      */
     async request(msg, timeout=1000) {
       this.send(msg);
@@ -1188,10 +1237,10 @@
      * Returns a response message received by the gateway. This method returns a {Promise} which resolves when
      * a response is received or if no response is received after the timeout.
      *
-     * @param {function} [filter=] - original message to which a response is expected, or a MessageClass of the type
+     * @param {function|Message|typeof Message} filter - original message to which a response is expected, or a MessageClass of the type
      * of message to match, or a closure to use to match against the message
      * @param {number} [timeout=0] - timeout in milliseconds
-     * @returns {Promise<?Message>} - received response message, null on timeout
+     * @returns {Promise<Message|void>} - received response message, null on timeout
      */
     async receive(filter, timeout=0) {
       return new Promise(resolve => {
@@ -1246,8 +1295,8 @@
   /**
    * Creates a unqualified message class based on a fully qualified name.
    * @param {string} name - fully qualified name of the message class to be created
-   * @param {class} [parent=Message] - class of the parent MessageClass to inherit from
-   * @returns {function} - constructor for the unqualified message class
+   * @param {typeof Message} [parent] - class of the parent MessageClass to inherit from
+   * @constructs Message
    * @example
    * const ParameterReq = MessageClass('org.arl.fjage.param.ParameterReq');
    * let pReq = new ParameterReq()
@@ -1256,6 +1305,9 @@
     let sname = name.replace(/^.*\./, '');
     if (MessageClass[sname]) return MessageClass[sname];
     let cls = class extends parent {
+      /**
+       * @param {{ [x: string]: any; }} params
+       */
       constructor(params) {
         super();
         this.__clazz__ = name;
@@ -1311,7 +1363,7 @@
       break;
     case '[J': // long array
       for (i = 0; i < len; i+=8)
-        rv.push(view.getInt64(i, littleEndian));
+        rv.push(view.getBigInt64(i, littleEndian));
       break;
     case '[F': // float array
       for (i = 0; i < len; i+=4)
@@ -1346,6 +1398,8 @@
   ////// global
 
   const GATEWAY_DEFAULTS = {};
+
+  /** @type {Window & globalThis & Object} */
   let gObj = {};
   let DEFAULT_URL;
   if (isBrowser || isWebWorker){
@@ -1362,7 +1416,7 @@
     DEFAULT_URL = new URL('ws://localhost');
     // Enable caching of Gateways
     if (typeof gObj.fjage === 'undefined') gObj.fjage = {};
-    if (typeof gObj.fjage.gateways == 'undefined')gObj.fjage.gateways = [];
+    if (typeof gObj.fjage.gateways == 'undefined') gObj.fjage.gateways = [];
   } else if (isJsDom || isNode){
     gObj = global;
     Object.assign(GATEWAY_DEFAULTS, {
@@ -1378,6 +1432,23 @@
     gObj.atob = a => Buffer.from(a, 'base64').toString('binary');
   }
 
+  /**
+   * @typedef {Object} ParameterReq.Entry
+   * @property {string} param - parameter name
+   * @property {Object} value - parameter value
+   * @exports ParameterReq.Entry
+   */
+
+
+  /**
+   * A message that requests one or more parameters of an agent.
+   * @typedef {Message} ParameterReq
+   * @property {string} param - parameters name to be get/set if only a single parameter is to be get/set
+   * @property {Object} value - parameters value to be set if only a single parameter is to be set
+   * @property {Array<ParameterReq.Entry>} requests - a list of multiple parameters to be get/set
+   * @property {number} [index=-1] - index of parameter(s) to be set
+   * @exports ParameterReq
+   */
   const ParameterReq = MessageClass('org.arl.fjage.param.ParameterReq');
 
   exports.AgentID = AgentID;
@@ -1385,6 +1456,7 @@
   exports.GenericMessage = GenericMessage;
   exports.Message = Message;
   exports.MessageClass = MessageClass;
+  exports.ParameterReq = ParameterReq;
   exports.Performative = Performative;
   exports.Services = Services;
 

--- a/gateways/js/eslint.config.js
+++ b/gateways/js/eslint.config.js
@@ -15,7 +15,7 @@ export default [
       'quotes': [
         'error',
         'single'
-      ]
+      ],
     }
   }
 ];

--- a/gateways/js/package-lock.json
+++ b/gateways/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fjage",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fjage",
-      "version": "1.12.2",
+      "version": "1.13.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "browser-or-node": "^2.1.1"
@@ -16,12 +16,14 @@
         "@playwright/test": "^1.41.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
+        "@types/node": "^22.7.5",
         "documentation": "^14.0.2",
         "eslint": "^8.55.0",
         "globals": "^13.24.0",
         "jasmine": "^5.1.0",
         "node-static": "^0.7.11",
-        "rollup": "^4.8.0"
+        "rollup": "^4.8.0",
+        "typescript": "^5.6.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -956,6 +958,16 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -5151,6 +5163,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
@@ -5159,6 +5185,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "10.1.2",

--- a/gateways/js/package.json
+++ b/gateways/js/package.json
@@ -12,11 +12,11 @@
     "dist/**"
   ],
   "scripts": {
-    "build": "npx rimraf -rf dist/ && eslint src/*.js && rollup --silent -c rollup.config.js",
-    "pretest": "npx playwright install --with-deps && node test/spec/create-spec.cjs",
+    "build": "eslint src/*.js && tsc && rollup --silent -c rollup.config.js",
+    "pretest": "playwright install --with-deps && node test/spec/create-spec.cjs",
     "test": "node test/run-tests.cjs",
     "docs": "documentation build src/fjage.js -f html --github --document-exported -o ../../docs/jsdoc",
-    "clean": "npx rimraf -rf dist/"
+    "clean": "rimraf -rf dist/"
   },
   "repository": {
     "type": "git",
@@ -36,12 +36,14 @@
     "@playwright/test": "^1.41.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
+    "@types/node": "^22.7.5",
     "documentation": "^14.0.2",
     "eslint": "^8.55.0",
     "globals": "^13.24.0",
     "jasmine": "^5.1.0",
     "node-static": "^0.7.11",
-    "rollup": "^4.8.0"
+    "rollup": "^4.8.0",
+    "typescript": "^5.6.3"
   },
   "dependencies": {
     "browser-or-node": "^2.1.1"

--- a/gateways/js/src/TCPConnector.js
+++ b/gateways/js/src/TCPConnector.js
@@ -8,7 +8,7 @@ var createConnection;
  * @class
  * @ignore
  */
-export default class TCPconnector {
+export default class TCPConnector {
 
   /**
     * Create an TCPConnector to connect to a fjage master over TCP
@@ -16,6 +16,7 @@ export default class TCPconnector {
    * @param {string} [opts.hostname='localhost'] - hostname/ip address of the master container to connect to
    * @param {number} [opts.port=1100] - port number of the master container to connect to
    * @param {boolean} [opts.keepAlive=true] - try to reconnect if the connection is lost
+   * @param {boolean} [opts.debug=false] - debug info to be logged to console?
    * @param {number} [opts.reconnectTime=5000] - time before reconnection is attempted after an error
     */
   constructor(opts = {}) {
@@ -31,6 +32,7 @@ export default class TCPconnector {
     this._firstReConn = true;             // if the Gateway has attempted to reconnect to a server before
     this.pendingOnOpen = [];              // list of callbacks make as soon as gateway is open
     this.connListeners = [];              // external listeners wanting to listen connection events
+    this.debug = false;
     this._sockInit(host, port);
   }
 
@@ -44,6 +46,7 @@ export default class TCPconnector {
   _sockInit(host, port){
     if (!createConnection){
       try {
+        // @ts-ignore
         import('net').then(module => {
           createConnection = module.createConnection;
           this._sockSetup(host, port);

--- a/gateways/js/src/TCPConnector.js
+++ b/gateways/js/src/TCPConnector.js
@@ -8,7 +8,7 @@ var createConnection;
  * @class
  * @ignore
  */
-export default class TCPConnector {
+class TCPConnector {
 
   /**
     * Create an TCPConnector to connect to a fjage master over TCP
@@ -131,18 +131,18 @@ export default class TCPConnector {
   }
 
   /**
+   * @callback TCPConnectorReadCallback
+   * @ignore
+   * @param {string} s - incoming message string
+   */
+
+  /**
    * Set a callback for receiving incoming strings from the connector
-   * @param {TCPConnector~ReadCallback} cb - callback that is called when the connector gets a string
+   * @param {TCPConnectorReadCallback} cb - callback that is called when the connector gets a string
    */
   setReadCallback(cb){
     if (cb && {}.toString.call(cb) === '[object Function]') this._onSockRx = cb;
   }
-
-  /**
-   * @callback TCPConnector~ReadCallback
-   * @ignore
-   * @param {string} s - incoming message string
-   */
 
   /**
    * Add listener for connection events
@@ -188,3 +188,5 @@ export default class TCPConnector {
     }
   }
 }
+
+export default TCPConnector;

--- a/gateways/js/src/TCPConnector.js
+++ b/gateways/js/src/TCPConnector.js
@@ -13,19 +13,19 @@ export default class TCPconnector {
   /**
     * Create an TCPConnector to connect to a fjage master over TCP
    * @param {Object} opts
-   * @param {string} opts.hostname - hostname/ip address of the master container to connect to
-   * @param {string} opts.port - port number of the master container to connect to
-   * @param {boolean} opts.keepAlive - try to reconnect if the connection is lost
+   * @param {string} [opts.hostname='localhost'] - hostname/ip address of the master container to connect to
+   * @param {number} [opts.port=1100] - port number of the master container to connect to
+   * @param {boolean} [opts.keepAlive=true] - try to reconnect if the connection is lost
    * @param {number} [opts.reconnectTime=5000] - time before reconnection is attempted after an error
     */
   constructor(opts = {}) {
-    let host = opts.hostname;
-    let port = opts.port;
+    let host = opts.hostname || 'localhost';
+    let port = opts.port || 1100;
     this._keepAlive = opts.keepAlive;
     this._reconnectTime = opts.reconnectTime || DEFAULT_RECONNECT_TIME;
     this.url = new URL('tcp://localhost');
     this.url.hostname = host;
-    this.url.port = port;
+    this.url.port = port.toString();
     this._buf = '';
     this._firstConn = true;               // if the Gateway has managed to connect to a server before
     this._firstReConn = true;             // if the Gateway has attempted to reconnect to a server before

--- a/gateways/js/src/WSConnector.js
+++ b/gateways/js/src/WSConnector.js
@@ -9,18 +9,20 @@ export default class WSConnector {
   /**
    * Create an WSConnector to connect to a fjage master over WebSockets
    * @param {Object} opts
-   * @param {string} opts.hostname - hostname/ip address of the master container to connect to
-   * @param {string} opts.port - port number of the master container to connect to
-   * @param {string} opts.pathname - path of the master container to connect to
-   * @param {boolean} opts.keepAlive - try to reconnect if the connection is lost
+   * @param {string} [opts.hostname='localhost'] - hostname/ip address of the master container to connect to
+   * @param {number} [opts.port=80] - port number of the master container to connect to
+   * @param {string} [opts.pathname="/"] - path of the master container to connect to
+   * @param {boolean} [opts.keepAlive=true] - try to reconnect if the connection is lost
+   * @param {boolean} [opts.debug=false] - debug info to be logged to console?
    * @param {number} [opts.reconnectTime=5000] - time before reconnection is attempted after an error
    */
   constructor(opts = {}) {
+    let host = opts.hostname || 'localhost';
+    let port = opts.port || 80;
     this.url = new URL('ws://localhost');
-    this.url.hostname = opts.hostname;
-    this.url.port = opts.port;
-    this.url.pathname = opts.pathname;
-    this._keepAlive = opts.keepAlive;
+    this.url.hostname = host;
+    this.url.port = port.toString();
+    this.url.pathname = opts.pathname || '/';
     this._reconnectTime = opts.reconnectTime || DEFAULT_RECONNECT_TIME;
     this.debug = opts.debug || false;      // debug info to be logged to console?
     this._firstConn = true;               // if the Gateway has managed to connect to a server before

--- a/gateways/js/src/WSConnector.js
+++ b/gateways/js/src/WSConnector.js
@@ -4,7 +4,7 @@ const DEFAULT_RECONNECT_TIME = 5000;       // ms, delay between retries to conne
  * @class
  * @ignore
  */
-export default class WSConnector {
+class WSConnector {
 
   /**
    * Create an WSConnector to connect to a fjage master over WebSockets
@@ -23,6 +23,7 @@ export default class WSConnector {
     this.url.hostname = host;
     this.url.port = port.toString();
     this.url.pathname = opts.pathname || '/';
+    this._keepAlive = opts.keepAlive;
     this._reconnectTime = opts.reconnectTime || DEFAULT_RECONNECT_TIME;
     this.debug = opts.debug || false;      // debug info to be logged to console?
     this._firstConn = true;               // if the Gateway has managed to connect to a server before
@@ -96,19 +97,19 @@ export default class WSConnector {
   }
 
   /**
+   * @callback WSConnectorReadCallback
+   * @ignore
+   * @param {string} s - incoming message string
+   */
+
+  /**
    * Set a callback for receiving incoming strings from the connector
-   * @param {WSConnector~ReadCallback} cb - callback that is called when the connector gets a string
+   * @param {WSConnectorReadCallback} cb - callback that is called when the connector gets a string
    * @ignore
    */
   setReadCallback(cb){
     if (cb && {}.toString.call(cb) === '[object Function]') this._onWebsockRx = cb;
   }
-
-  /**
-   * @callback WSConnector~ReadCallback
-   * @ignore
-   * @param {string} s - incoming message string
-   */
 
   /**
    * Add listener for connection events
@@ -150,3 +151,5 @@ export default class WSConnector {
     }
   }
 }
+
+export default WSConnector;

--- a/gateways/js/tsconfig.json
+++ b/gateways/js/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compileOnSave": false,
+    "compilerOptions": {
+        "noEmit": true,
+        "allowJs": true,
+        "checkJs": true,
+        "target": "es6",
+        "resolveJsonModule": true,
+        "moduleResolution": "node"
+    },
+    "include": ["./src"]
+}

--- a/gateways/js/tsconfig.json
+++ b/gateways/js/tsconfig.json
@@ -1,12 +1,16 @@
 {
     "compileOnSave": false,
     "compilerOptions": {
-        "noEmit": true,
+        // "noEmit": true,
         "allowJs": true,
         "checkJs": true,
-        "target": "es6",
+        "declaration": true,
+        "target": "es2020",
         "resolveJsonModule": true,
-        "moduleResolution": "node"
+        "moduleResolution": "node",
+        "emitDeclarationOnly": true,
+        "outDir": "dist/",
+        "declarationMap": true
     },
-    "include": ["./src"]
+    "include": ["./src/*.js"]
 }


### PR DESCRIPTION
`fjage.js` Gateway is written in JavaScript but with modern [ES6 style classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) and other modern JavaScript syntax.

Instead of moving the entire implementation to TypeScript a majority of the benefits of TypeScript can be had by adding type annotations to a JavaScript library. This would allow consumer TypeScript libraries to use the types and IDE like VSCode to infer types of code that use `fjage.js`.

Since we already had type information JSDocs comments for documentation, we can extend that to automatically generate the `*.d.ts` files with the type annotation information and publish them along with the other `*.js` files.

This PR
- cleans up JSDoc comments to make TypeScript compiler generate the type files
- fixes some code which might have been unclear about types (relies on implicit coercion)
- adds the tools to automatically generate the generate the type files on build