### PR TITLE
Make shell messages compliant with JSON

### DIFF
--- a/gateways/c/tests/test_fjage.c
+++ b/gateways/c/tests/test_fjage.c
@@ -231,7 +231,7 @@ int main(int argc, char* argv[]) {
   fjage_msg_destroy(msg);
   msg = fjage_msg_create("org.arl.fjage.shell.ShellExecReq", FJAGE_REQUEST);
   fjage_msg_set_recipient(msg, aid);
-  fjage_msg_add_string(msg, "cmd", "ps");
+  fjage_msg_add_string(msg, "command", "ps");
   msg = fjage_request(gw, msg, 1000);
   test_assert("request", msg != NULL && fjage_msg_get_performative(msg) == FJAGE_AGREE);
   fjage_msg_destroy(msg);

--- a/gateways/js/examples/app.js
+++ b/gateways/js/examples/app.js
@@ -11,7 +11,7 @@ const ShellExecReq = MessageClass('org.arl.fjage.shell.ShellExecReq');
     });
     const req = new ShellExecReq();
     req.recipient = shell;
-    req.cmd = 'a=2; a+2;';
+    req.command = 'a=2; a+2;';
     req.ans = true;
     let rsp = await gw.request(req);
     console.log(rsp);

--- a/gateways/js/examples/example.js
+++ b/gateways/js/examples/example.js
@@ -9,7 +9,7 @@ const ShellExecReq = MessageClass('org.arl.fjage.shell.ShellExecReq');
     });
     const req = new ShellExecReq();
     req.recipient = shell;
-    req.cmd = 'a=2; a+2;';
+    req.command = 'a=2; a+2;';
     req.ans = true;
     let rsp = await gw.request(req);
     console.log(rsp);

--- a/gateways/js/test/spec/fjage.spec.js
+++ b/gateways/js/test/spec/fjage.spec.js
@@ -162,7 +162,7 @@ describe('A Gateway', function () {
     gw.connector.sock.send.calls.reset();
     const req = new ShellExecReq();
     req.recipient = shell;
-    req.cmd = 'boo';
+    req.command = 'boo';
     gw.request(req);
     await delay(300);
     expect(gw.connector.sock.send).toHaveBeenCalled();
@@ -176,7 +176,7 @@ describe('A Gateway', function () {
     gw.connector.sock.send.calls.reset();
     const req = new ShellExecReq();
     req.recipient = shell;
-    req.cmd = 'boo';
+    req.command = 'boo';
     gw.request(req);
     await delay(300);
     expect(gw.connector.sock.send).toHaveBeenCalledWith(fjageMessageChecker());
@@ -190,7 +190,7 @@ describe('A Gateway', function () {
     gw.connector.sock.send.calls.reset();
     const req = new ShellExecReq();
     req.recipient = shell;
-    req.cmd = 'boo';
+    req.command = 'boo';
     gw.request(req);
     await delay(300);
     expect(gw.connector.sock.send).toHaveBeenCalledWith(ShellExecReqChecker());
@@ -557,7 +557,7 @@ describe('Shell GetFile/PutFile', function () {
   it('should be able to send a ShellExecReq', async function () {
     const req = new ShellExecReq();
     req.recipient = shell;
-    req.cmd = 'boo';
+    req.command = 'boo';
     const rsp = await gw.request(req);
     expect(rsp).toBeDefined();
     expect(rsp.perf).toBeDefined();
@@ -579,14 +579,14 @@ describe('Shell GetFile/PutFile', function () {
     var gfr = new GetFileReq();
     gfr.recipient = shell;
     gfr.filename = DIRNAME + '/' + FILENAME;
-    gfr.ofs = 5;
-    gfr.len = 4;
+    gfr.offset = 5;
+    gfr.length = 4;
     const rsp = await gw.request(gfr);
     expect(rsp).toBeTruthy();
     expect(rsp instanceof GetFileRsp).toBeTruthy();
     expect(rsp.contents).not.toBeUndefined();
     expect(rsp.contents.length).toBe(4);
-    expect(rsp.ofs).toBe(5);
+    expect(rsp.offset).toBe(5);
     expect(new TextDecoder('utf-8').decode(new Uint8Array(rsp.contents))).toEqual(TEST_STRING.substr(5, rsp.contents.length));
   });
 
@@ -594,14 +594,14 @@ describe('Shell GetFile/PutFile', function () {
     var gfr = new GetFileReq();
     gfr.recipient = shell;
     gfr.filename = DIRNAME + '/' + FILENAME;
-    gfr.ofs = 9;
-    gfr.len = 0;
+    gfr.offset = 9;
+    gfr.length = 0;
     const rsp = await gw.request(gfr, 3000);
     expect(rsp).toBeTruthy();
     expect(rsp instanceof GetFileRsp).toBeTruthy();
     expect(rsp.contents).not.toBeUndefined();
     expect(rsp.contents.length).toBe(TEST_STRING.length-9);
-    expect(rsp.ofs).toBe(9);
+    expect(rsp.offset).toBe(9);
     expect(new TextDecoder('utf-8').decode(new Uint8Array(rsp.contents))).toEqual(TEST_STRING.substr(9));
   });
 
@@ -609,8 +609,8 @@ describe('Shell GetFile/PutFile', function () {
     var gfr = new GetFileReq();
     gfr.recipient = shell;
     gfr.filename = DIRNAME + '/' + FILENAME;
-    gfr.ofs = 27;
-    gfr.len = 1;
+    gfr.offset = 27;
+    gfr.length = 1;
     const rsp = await gw.request(gfr, 3000);
     expect(rsp).toBeTruthy();
     expect(rsp.perf).toEqual(Performative.REFUSE);
@@ -680,7 +680,7 @@ describe('Shell GetFile/PutFile', function () {
     const pfr = new PutFileReq();
     pfr.recipient = shell;
     pfr.filename = DIRNAME + '/' + FILENAME;
-    pfr.ofs = 10;
+    pfr.offset = 10;
     pfr.contents = Array.from((new TextEncoder('utf-8').encode(TEST_STRING)));
     const rsp = await gw.request(pfr, 3000);
     expect(rsp).toBeTruthy();
@@ -698,7 +698,7 @@ describe('Shell GetFile/PutFile', function () {
     const pfr = new PutFileReq();
     pfr.recipient = shell;
     pfr.filename = DIRNAME + '/' + FILENAME;
-    pfr.ofs = -4;
+    pfr.offset = -4;
     pfr.contents = Array.from((new TextEncoder('utf-8').encode(NEW_STRING)));
     const rsp = await gw.request(pfr, 3000);
     expect(rsp).toBeTruthy();
@@ -751,7 +751,7 @@ describe('Shell GetFile/PutFile', function () {
     const pfr = new PutFileReq();
     pfr.recipient = shell;
     pfr.filename = DIRNAME + '/' + FILENAME;
-    pfr.ofs = 10;
+    pfr.offset = 10;
     pfr.contents = Array.from((new TextEncoder('utf-8').encode(TEST_STRING)));
     const rsp = await gw.request(pfr, 3000);
     expect(rsp).toBeTruthy();
@@ -769,7 +769,7 @@ describe('Shell GetFile/PutFile', function () {
     const pfr = new PutFileReq();
     pfr.recipient = shell;
     pfr.filename = DIRNAME + '/' + FILENAME;
-    pfr.ofs = -4;
+    pfr.offset = -4;
     pfr.contents = Array.from((new TextEncoder('utf-8').encode(NEW_STRING)));
     const rsp = await gw.request(pfr, 3000);
     expect(rsp).toBeTruthy();

--- a/src/main/java/org/arl/fjage/shell/GetFileReq.java
+++ b/src/main/java/org/arl/fjage/shell/GetFileReq.java
@@ -28,8 +28,8 @@ public class GetFileReq extends Message {
   private static final long serialVersionUID = 1L;
 
   private String filename = null;
-  private long ofs = 0;
-  private long len = 0;
+  private long offset = 0;
+  private long length = 0;
 
   /**
    * Create an empty request for file/directory.
@@ -78,8 +78,8 @@ public class GetFileReq extends Message {
   public GetFileReq(String filename, long ofs, long len) {
     super(Performative.REQUEST);
     this.filename = filename;
-    this.ofs = ofs;
-    this.len = len;
+    this.offset = ofs;
+    this.length = len;
   }
 
   /**
@@ -93,8 +93,8 @@ public class GetFileReq extends Message {
   public GetFileReq(AgentID to, String filename, long ofs, long len) {
     super(to, Performative.REQUEST);
     this.filename = filename;
-    this.ofs = ofs;
-    this.len = len;
+    this.offset = ofs;
+    this.length = len;
   }
 
   /**
@@ -121,7 +121,7 @@ public class GetFileReq extends Message {
    * @return start locaion in file (negative for offset relative to end of file).
    */
   public long getOffset() {
-    return ofs;
+    return offset;
   }
 
   /**
@@ -130,7 +130,7 @@ public class GetFileReq extends Message {
    * @param ofs start location in file (negative for offset relative to end of file).
    */
   public void setOffset(long ofs) {
-    this.ofs = ofs;
+    this.offset = ofs;
   }
 
   /**
@@ -139,7 +139,7 @@ public class GetFileReq extends Message {
    * @return number of bytes to read, 0 for no limit.
    */
   public long getLength() {
-    return len;
+    return length;
   }
 
   /**
@@ -148,7 +148,7 @@ public class GetFileReq extends Message {
    * @param len number of bytes to read, 0 for no limit.
    */
   public void setLength(long len) {
-    this.len = len;
+    this.length = len;
   }
 
 }

--- a/src/main/java/org/arl/fjage/shell/GetFileRsp.java
+++ b/src/main/java/org/arl/fjage/shell/GetFileRsp.java
@@ -21,12 +21,19 @@ public class GetFileRsp extends Message {
   private static final long serialVersionUID = 1L;
 
   private String filename;
-  private long ofs = 0;
+  private long offset = 0;
   private byte[] contents;
-  private boolean dir = false;
+  private boolean directory = false;
 
   /**
-   * Create a response to the ShellGetFileReq.
+   * Create an empty response.
+   */
+  public GetFileRsp() {
+    super(Performative.INFORM);
+  }
+
+    /**
+   * Create a response to the GetFileReq.
    *
    * @param inReplyTo message to which this is a response.
    */
@@ -80,7 +87,16 @@ public class GetFileRsp extends Message {
    * @return true for directory, false for ordinary file.
    */
   public boolean isDirectory() {
-    return dir;
+    return directory;
+  }
+
+  /**
+   * Checks if the file being returned is a directory.
+   *
+   * @return true for directory, false for ordinary file.
+   */
+  public boolean getDirectory() {
+    return directory;
   }
 
   /**
@@ -89,7 +105,7 @@ public class GetFileRsp extends Message {
    * @param dir true for directory, false for ordinary file.
    */
   public void setDirectory(boolean dir) {
-    this.dir = dir;
+    this.directory = dir;
   }
 
   /**
@@ -98,7 +114,7 @@ public class GetFileRsp extends Message {
    * @return start locaion in file.
    */
   public long getOffset() {
-    return ofs;
+    return offset;
   }
 
   /**
@@ -107,7 +123,7 @@ public class GetFileRsp extends Message {
    * @param ofs start location in file.
    */
   public void setOffset(long ofs) {
-    this.ofs = ofs;
+    this.offset = ofs;
   }
 
 }

--- a/src/main/java/org/arl/fjage/shell/PutFileReq.java
+++ b/src/main/java/org/arl/fjage/shell/PutFileReq.java
@@ -23,7 +23,7 @@ public class PutFileReq extends Message {
 
   private String filename = null;
   private byte[] contents = null;
-  private long ofs = 0;
+  private long offset = 0;
 
   /**
    * Create an empty request for file write.
@@ -62,7 +62,7 @@ public class PutFileReq extends Message {
     super(Performative.REQUEST);
     this.filename = filename;
     this.contents = contents;
-    this.ofs = ofs;
+    this.offset = ofs;
   }
 
   /**
@@ -88,7 +88,7 @@ public class PutFileReq extends Message {
     super(to, Performative.REQUEST);
     this.filename = filename;
     this.contents = contents;
-    this.ofs = ofs;
+    this.offset = ofs;
   }
 
   /**
@@ -133,7 +133,7 @@ public class PutFileReq extends Message {
    * @return start locaion in file (negative for offset relative to end of file).
    */
   public long getOffset() {
-    return ofs;
+    return offset;
   }
 
   /**
@@ -142,7 +142,7 @@ public class PutFileReq extends Message {
    * @param ofs start location in file (negative for offset relative to end of file).
    */
   public void setOffset(long ofs) {
-    this.ofs = ofs;
+    this.offset = ofs;
   }
 
 }

--- a/src/main/java/org/arl/fjage/shell/ShellExecReq.java
+++ b/src/main/java/org/arl/fjage/shell/ShellExecReq.java
@@ -24,9 +24,9 @@ public class ShellExecReq extends Message {
 
   private static final long serialVersionUID = 1L;
 
-  private String cmd = null;
+  private String command = null;
   private File script = null;
-  private List<String> args = null;
+  private List<String> scriptArgs = null;
   private boolean ans = false;
 
   /**
@@ -52,7 +52,7 @@ public class ShellExecReq extends Message {
    */
   public ShellExecReq(String cmd) {
     super(Performative.REQUEST);
-    this.cmd = cmd;
+    this.command = cmd;
   }
 
   /**
@@ -63,7 +63,7 @@ public class ShellExecReq extends Message {
    */
   public ShellExecReq(AgentID to, String cmd) {
     super(to, Performative.REQUEST);
-    this.cmd = cmd;
+    this.command = cmd;
   }
 
   /**
@@ -96,7 +96,7 @@ public class ShellExecReq extends Message {
   public ShellExecReq(File script, List<String> args) {
     super(Performative.REQUEST);
     this.script = script;
-    this.args = args;
+    this.scriptArgs = args;
   }
 
   /**
@@ -109,7 +109,7 @@ public class ShellExecReq extends Message {
   public ShellExecReq(AgentID to, File script, List<String> args) {
     super(to, Performative.REQUEST);
     this.script = script;
-    this.args = args;
+    this.scriptArgs = args;
   }
 
   /**
@@ -119,7 +119,7 @@ public class ShellExecReq extends Message {
    */
   public void setCommand(String cmd) {
     if (cmd != null && script != null) throw new UnsupportedOperationException("ShellExecReq can either have a command or script, but not both");
-    this.cmd = cmd;
+    this.command = cmd;
   }
 
   /**
@@ -128,7 +128,7 @@ public class ShellExecReq extends Message {
    * @return command to execute, null if none.
    */
   public String getCommand() {
-    return cmd;
+    return command;
   }
 
   /**
@@ -137,7 +137,7 @@ public class ShellExecReq extends Message {
    * @param script script file to execute.
    */
   public void setScript(File script) {
-    if (script != null && cmd != null) throw new UnsupportedOperationException("ShellExecReq can either have a command or script, but not both");
+    if (script != null && command != null) throw new UnsupportedOperationException("ShellExecReq can either have a command or script, but not both");
     this.script = script;
   }
 
@@ -148,9 +148,9 @@ public class ShellExecReq extends Message {
    * @param args arguments to pass to script.
    */
   public void setScript(File script, List<String> args) {
-    if (script != null && cmd != null) throw new UnsupportedOperationException("ShellExecReq can either have a command or script, but not both");
+    if (script != null && command != null) throw new UnsupportedOperationException("ShellExecReq can either have a command or script, but not both");
     this.script = script;
-    this.args = args;
+    this.scriptArgs = args;
   }
 
   /**
@@ -168,7 +168,7 @@ public class ShellExecReq extends Message {
    * @return script arguments, null if none.
    */
   public List<String> getScriptArgs() {
-    return args;
+    return scriptArgs;
   }
 
   /**


### PR DESCRIPTION
Shell messages (`ShellExecReq`, `GetFileReq`, `PutFileReq` and `GetFileRsp`) used private field names that did not agree with Javabean property names. This made the JSON fields be different from the Javabean properties. To avoid confusion with this, this PR unifies both. This is the convention we now follow with all messages.

Since this PR only modified internal field names, this is technically non-breaking. However, JS and C gateways/tests refer to private field names and so also had to be updated.