### PR TITLE
fix(FSMBehavior): Prevent state changes out of FINAL state

### DIFF
--- a/src/main/java/org/arl/fjage/FSMBehavior.java
+++ b/src/main/java/org/arl/fjage/FSMBehavior.java
@@ -162,6 +162,7 @@ public class FSMBehavior extends Behavior {
   public void setNextState(Object name) {
     State state = (name instanceof State) ? (State)name : states.get(name);
     if (state == null) throw new FjageException("Unknown state: "+name);
+    if (next == FINAL) return;
     next = state;
     restart();
   }
@@ -171,6 +172,7 @@ public class FSMBehavior extends Behavior {
    * to be exited, and re-entered.
    */
   public void reenterState() {
+    if (next == FINAL) return;
     next = REENTER;
     restart();
   }


### PR DESCRIPTION
Fixes https://github.com/org-arl/fjage/issues/324 by blocking state changes out of the `FINAL` state. 

To be ported to `master` once finalised.