### PR TITLE
fix(Behavior): Use atomic lookup instead of `synchronized` in `restart()`

### DIFF
--- a/src/main/java/org/arl/fjage/Behavior.java
+++ b/src/main/java/org/arl/fjage/Behavior.java
@@ -149,9 +149,13 @@ public class Behavior implements Comparable<Behavior> {
    *
    * @see #block()
    */
-  public synchronized void restart() {
+  public void restart() {
     blocked = false;
-    if (agent != null) agent.wake();
+    // Use local variable to ensure that the `!= null` and `.wake()` run on the
+    // same value. Don't use `synchronized` block as that may deadlock with the
+    // `agent` lock required for `wake()`.
+    Agent tmp = agent;
+    if (tmp != null) tmp.wake();
   }
 
   /**
@@ -249,4 +253,3 @@ public class Behavior implements Comparable<Behavior> {
   }
 
 }
-

--- a/src/main/java/org/arl/fjage/FSMBehavior.java
+++ b/src/main/java/org/arl/fjage/FSMBehavior.java
@@ -162,6 +162,7 @@ public class FSMBehavior extends Behavior {
   public void setNextState(Object name) {
     State state = (name instanceof State) ? (State)name : states.get(name);
     if (state == null) throw new FjageException("Unknown state: "+name);
+    if (next == FINAL) return;
     next = state;
     restart();
   }
@@ -171,6 +172,7 @@ public class FSMBehavior extends Behavior {
    * to be exited, and re-entered.
    */
   public void reenterState() {
+    if (next == FINAL) return;
     next = REENTER;
     restart();
   }


### PR DESCRIPTION
Fixes a potential deadlock between the `Agent` and `Behavior` locks. X-ref https://github.com/org-arl/unet/issues/2057

Currently marked as "Draft" since we are still testing this. Will mark as ready and ask for review once the test was successful. 

Should be ported to `master` once merged. 