### PR TITLE
Overwrite empty Gateway options argument with defaults

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,7 +23,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/gateways/js/src/fjage.js
+++ b/gateways/js/src/fjage.js
@@ -338,7 +338,10 @@ export class GenericMessage extends Message {
 export class Gateway {
 
   constructor(opts = {}) {
-    opts = Object.assign({}, GATEWAY_DEFAULTS, opts);
+    // Similar to Object.assign but also overwrites `undefined` and empty strings with defaults
+    for (var key in GATEWAY_DEFAULTS){
+      if (opts[key] == undefined || opts[key] === '') opts[key] = GATEWAY_DEFAULTS[key];
+    }
     var url = DEFAULT_URL;
     url.hostname = opts.hostname;
     url.port = opts.port;


### PR DESCRIPTION
[Fjage.js cleanup](https://github.com/org-arl/fjage/pull/331) caused support for `undefined` host/port in `Gateway` constructor to stop working. 

Prior to the cleanup, constructing `Gateway` using `const gw = new Gateway({host:undefined, port:undefined})` would default to the fjage.js code automatically using the default Gateway host/port, which would be based on the web page's origin.

Moving to `Object.assign` removed that feature, since it treats `undefined` as valid values and hence `opt` overwrites the `DEFAULT` values.. This PR revert to the old code and adds a comment to explain why were not using `Object.assign`.