### PR TITLE
Add `cancelPendingOnDisconnect` constructor option on Gateway to cancel all pending requests

### DIFF
--- a/docs/jsdoc/index.html
+++ b/docs/jsdoc/index.html
@@ -449,7 +449,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L14-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L14-L27'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -505,7 +505,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L15-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L15-L15'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -562,7 +562,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L16-L16'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L16-L16'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -619,7 +619,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L17-L17'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L17-L17'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -676,7 +676,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L18-L18'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L18-L18'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -733,7 +733,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L19-L19'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L19-L19'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -790,7 +790,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L20-L20'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L20-L20'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -847,7 +847,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L21-L21'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L21-L21'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -904,7 +904,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L22-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L22-L22'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -961,7 +961,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L23-L23'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L23-L23'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1018,7 +1018,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L24-L24'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L24-L24'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1075,7 +1075,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L25-L25'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L25-L25'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1132,7 +1132,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L26-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L26-L26'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1199,7 +1199,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L36-L201'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L36-L201'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1284,7 +1284,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L50-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L50-L52'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1350,7 +1350,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L59-L61'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L59-L61'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1416,7 +1416,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L69-L73'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L69-L73'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1495,7 +1495,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L82-L86'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L82-L86'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1585,7 +1585,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L93-L95'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L93-L95'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1651,7 +1651,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L102-L104'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L102-L104'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1717,7 +1717,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L115-L153'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L115-L153'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1826,7 +1826,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L164-L200'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L164-L200'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1925,7 +1925,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L221-L308'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L221-L308'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2038,7 +2038,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L237-L259'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L237-L259'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2112,7 +2112,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L315-L323'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L315-L323'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2173,7 +2173,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L341-L929'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L341-L929'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2298,7 +2298,7 @@ uses an options object instead of individual parameters. The old version with</p
                 <tr>
   <td class='break-word'><span class='code bold'>opts.cancelPendingOnDisconnect</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code>
   
-    (default <code>true</code>)
+    (default <code>false</code>)
   </td>
   <td class='break-word'><span>cancel pending requests on disconnect
 </span></td>
@@ -2344,7 +2344,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L653-L658'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L653-L658'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2432,7 +2432,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L667-L671'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L667-L671'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2520,7 +2520,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L679-L681'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L679-L681'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2599,7 +2599,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L689-L691'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L689-L691'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2678,7 +2678,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L699-L701'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L699-L701'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2757,7 +2757,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L709-L711'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L709-L711'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2836,7 +2836,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L718-L720'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L718-L720'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2902,7 +2902,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L728-L730'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L728-L730'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2982,7 +2982,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L739-L745'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L739-L745'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3071,7 +3071,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L753-L758'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L753-L758'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3151,7 +3151,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L766-L770'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L766-L770'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3230,7 +3230,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L776-L781'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L776-L781'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3296,7 +3296,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L789-L794'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L789-L794'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3376,7 +3376,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L803-L812'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L803-L812'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3457,7 +3457,7 @@ to provide a given service, any of the agents' id may be returned.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L820-L832'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L820-L832'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3529,7 +3529,7 @@ to provide a given service, any of the agents' id may be returned.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L841-L852'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L841-L852'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3610,7 +3610,7 @@ may be an agent or a topic.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L859-L861'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L859-L861'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3675,7 +3675,7 @@ may be an agent or a topic.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L871-L874'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L871-L874'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3766,7 +3766,7 @@ is received or if no response is received after the timeout.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L885-L917'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L885-L917'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3856,7 +3856,7 @@ a response is received or if no response is received after the timeout.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L924-L927'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L924-L927'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3930,7 +3930,7 @@ this method is called.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L934-L936'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L934-L936'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3980,7 +3980,7 @@ this method is called.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L935-L935'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L935-L935'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -4047,7 +4047,7 @@ this method is called.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L947-L969'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L947-L969'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -4131,7 +4131,7 @@ this method is called.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L1081-L1086'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L1081-L1086'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -4208,7 +4208,7 @@ this method is called.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L1089-L1097'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/31a0ed15b82bf37c0516d99512d1d7fb57c227d8/gateways/js/src/fjage.js#L1089-L1097'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     

--- a/docs/jsdoc/index.html
+++ b/docs/jsdoc/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset='utf-8'>
-  <title>fjage 1.13.5 | Documentation</title>
+  <title>fjage 2.1.0 | Documentation</title>
   <meta name='description' content='JS Gateway for fjåge'>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' rel='stylesheet'>
@@ -15,7 +15,7 @@
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>fjage</h3>
-          <div class='mb1'><code>1.13.5</code></div>
+          <div class='mb1'><code>2.1.0</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -449,7 +449,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L14-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L14-L27'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -505,7 +505,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L15-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L15-L15'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -562,7 +562,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L16-L16'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L16-L16'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -619,7 +619,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L17-L17'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L17-L17'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -676,7 +676,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L18-L18'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L18-L18'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -733,7 +733,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L19-L19'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L19-L19'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -790,7 +790,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L20-L20'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L20-L20'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -847,7 +847,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L21-L21'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L21-L21'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -904,7 +904,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L22-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L22-L22'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -961,7 +961,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L23-L23'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L23-L23'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1018,7 +1018,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L24-L24'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L24-L24'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1075,7 +1075,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L25-L25'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L25-L25'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1132,7 +1132,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L26-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L26-L26'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1199,7 +1199,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L36-L199'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L36-L201'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1284,7 +1284,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L50-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L50-L52'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1350,7 +1350,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L59-L61'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L59-L61'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1416,7 +1416,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L69-L73'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L69-L73'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1495,7 +1495,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L82-L86'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L82-L86'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1585,7 +1585,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L93-L95'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L93-L95'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1651,7 +1651,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L102-L104'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L102-L104'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1717,7 +1717,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L115-L152'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L115-L153'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1826,7 +1826,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L163-L198'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L164-L200'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1925,7 +1925,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L207-L294'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L221-L308'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -1934,7 +1934,7 @@ FIPA ACL recommendations for interagent communication.</p>
 
   <p>Base class for messages transmitted by one agent to another. Creates an empty message.</p>
 
-    <div class='pre p1 fill-light mt0'>new Message(inReplyTo: <a href="#message">Message</a>?, perf: <a href="#performative">Performative</a>)</div>
+    <div class='pre p1 fill-light mt0'>new Message(inReplyTo: <a href="#message">Message</a>?, perf: <a href="#performative">Performative</a>, msgID: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, recipient: <a href="#agentid">AgentID</a>?, sender: <a href="#agentid">AgentID</a>?, sentAt: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</div>
   
   
 
@@ -1964,6 +1964,42 @@ FIPA ACL recommendations for interagent communication.</p>
             <span class='code bold'>perf</span> <code class='quiet'>(<a href="#performative">Performative</a>
             = <code>Performative.INFORM</code>)</code>
 	    performative
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>msgID</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
+	    unique identifier for the message
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>recipient</span> <code class='quiet'>(<a href="#agentid">AgentID</a>?)</code>
+	    recipient of the message
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>sender</span> <code class='quiet'>(<a href="#agentid">AgentID</a>?)</code>
+	    sender of the message
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>sentAt</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</code>
+	    time at which the message was sent
 
           </div>
           
@@ -2002,7 +2038,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L223-L245'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L237-L259'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2076,7 +2112,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L301-L309'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L315-L323'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2137,7 +2173,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L326-L909'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L341-L929'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2259,6 +2295,17 @@ uses an options object instead of individual parameters. The old version with</p
 
 
               
+                <tr>
+  <td class='break-word'><span class='code bold'>opts.cancelPendingOnDisconnect</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code>
+  
+    (default <code>true</code>)
+  </td>
+  <td class='break-word'><span>cancel pending requests on disconnect
+</span></td>
+</tr>
+
+
+              
             </tbody>
           </table>
           
@@ -2297,7 +2344,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L636-L641'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L653-L658'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2385,7 +2432,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L650-L654'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L667-L671'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2473,7 +2520,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L662-L664'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L679-L681'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2552,7 +2599,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L672-L674'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L689-L691'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2631,7 +2678,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L682-L684'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L699-L701'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2710,7 +2757,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L692-L694'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L709-L711'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2789,7 +2836,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L701-L703'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L718-L720'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2855,7 +2902,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L711-L713'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L728-L730'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2925,7 +2972,7 @@ uses an options object instead of individual parameters. The old version with</p
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>topic(topic, topic2)</span>
+            <span class='code strong strong truncate'>topic(topic, topic2?)</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -2935,7 +2982,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L722-L728'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L739-L745'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -2944,7 +2991,7 @@ uses an options object instead of individual parameters. The old version with</p
 
   <p>Returns an object representing the named topic.</p>
 
-    <div class='pre p1 fill-light mt0'>topic(topic: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="#agentid">AgentID</a>), topic2: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="#agentid">AgentID</a></div>
+    <div class='pre p1 fill-light mt0'>topic(topic: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="#agentid">AgentID</a>), topic2: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?): <a href="#agentid">AgentID</a></div>
   
   
 
@@ -2970,7 +3017,7 @@ uses an options object instead of individual parameters. The old version with</p
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>topic2</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+            <span class='code bold'>topic2</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
 	    name of the topic if the topic param is an AgentID
 
           </div>
@@ -3024,7 +3071,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L736-L741'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L753-L758'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3104,7 +3151,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L749-L753'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L766-L770'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3183,7 +3230,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L759-L764'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L776-L781'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3249,7 +3296,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L772-L777'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L789-L794'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3329,7 +3376,7 @@ uses an options object instead of individual parameters. The old version with</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L786-L795'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L803-L812'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3410,7 +3457,7 @@ to provide a given service, any of the agents' id may be returned.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L803-L815'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L820-L832'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3482,7 +3529,7 @@ to provide a given service, any of the agents' id may be returned.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L824-L835'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L841-L852'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3563,7 +3610,7 @@ may be an agent or a topic.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L842-L844'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L859-L861'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3628,7 +3675,7 @@ may be an agent or a topic.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L854-L857'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L871-L874'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3719,7 +3766,7 @@ is received or if no response is received after the timeout.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L868-L897'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L885-L917'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3809,7 +3856,7 @@ a response is received or if no response is received after the timeout.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L904-L907'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L924-L927'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3883,7 +3930,7 @@ this method is called.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L914-L916'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L934-L936'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -3933,7 +3980,7 @@ this method is called.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L915-L915'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L935-L935'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -4000,7 +4047,7 @@ this method is called.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L927-L948'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L947-L969'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -4084,7 +4131,7 @@ this method is called.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L1058-L1063'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L1081-L1086'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     
@@ -4161,7 +4208,7 @@ this method is called.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/8ef1244fbb43ddddf8fce14713d04a9fa00b72c0/gateways/js/src/fjage.js#L1066-L1074'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/644d2eb68a3e1f6b6b5ea57ca4ebdbbaf697b2e7/gateways/js/src/fjage.js#L1089-L1097'>
       <span>gateways/js/src/fjage.js</span>
       </a>
     

--- a/gateways/Gateways.md
+++ b/gateways/Gateways.md
@@ -98,6 +98,10 @@ All gateway agents should use names prefixed with `gateway-`.
 
 - Flushes the incoming queue in the `Gateway`.
 
+### `cancellAll()` :: Void -> Void
+
+- Immediately cancells all pending receives on a `Gateway`.
+
 ## AgentID Class
 
 ### `AgentID()` :: String name, (Boolean isTopic) -> AgentID

--- a/gateways/Gateways.md
+++ b/gateways/Gateways.md
@@ -98,10 +98,6 @@ All gateway agents should use names prefixed with `gateway-`.
 
 - Flushes the incoming queue in the `Gateway`.
 
-### `cancellAll()` :: Void -> Void
-
-- Immediately cancells all pending receives on a `Gateway`.
-
 ## AgentID Class
 
 ### `AgentID()` :: String name, (Boolean isTopic) -> AgentID

--- a/gateways/js/dist/esm/fjage.js
+++ b/gateways/js/dist/esm/fjage.js
@@ -1,4 +1,4 @@
-/* fjage.js v2.0.0 */
+/* fjage.js v2.1.0 */
 
 const isBrowser =
   typeof window !== "undefined" && typeof window.document !== "undefined";
@@ -725,7 +725,7 @@ class Gateway {
     this._returnNullOnFailedResponse = opts.returnNullOnFailedResponse; // null or error
     this.pending = {};                    // msgid to callback mapping for pending requests to server
     this.subscriptions = {};              // hashset for all topics that are subscribed
-    this.listener = {};                   // set of callbacks that want to listen to incoming messages
+    this.listeners = {};                  // list of callbacks that want to listen to incoming messages
     this.eventListeners = {};             // external listeners wanting to listen internal events
     this.queue = [];                      // incoming message queue
     this.connected = false;               // connection status
@@ -742,18 +742,36 @@ class Gateway {
    * @param {Object|Message|string} val - value to be sent to the listeners
    */
   _sendEvent(type, val) {
-    if (Array.isArray(this.eventListeners[type])) {
-      this.eventListeners[type].forEach(l => {
-        if (l && {}.toString.call(l) === '[object Function]'){
-          try {
-            l(val);
-          } catch (error) {
-            console.warn('Error in event listener : ' + error);
-          }
+    if (!Array.isArray(this.eventListeners[type])) return;
+    this.eventListeners[type].forEach(l => {
+      if (l && {}.toString.call(l) === '[object Function]'){
+        try {
+          l(val);
+        } catch (error) {
+          console.warn('Error in event listener : ' + error);
         }
-      });
-    }
+      }
+    });
   }
+
+  /**
+   * Sends the message to all registered receivers.
+   *
+   * @private
+   * @param {Message} msg
+   * @returns {boolean} - true if the message was consumed by any listener
+   */
+  _sendReceivers(msg) {
+    for (var lid in this.listeners){
+      try {
+        if (this.listeners[lid] && this.listeners[lid](msg)) return true;
+      } catch (error) {
+        console.warn('Error in listener : ' + error);
+      }
+    }
+    return false;
+  }
+
 
   /**
    * @private
@@ -781,32 +799,10 @@ class Gateway {
       if (!msg) return;
       this._sendEvent('rxmsg', msg);
       if ((msg.recipient == this.aid.toJSON() )|| this.subscriptions[msg.recipient]) {
-        var consumed = false;
-        if (Array.isArray(this.eventListeners['message'])){
-          for (var i = 0; i < this.eventListeners['message'].length; i++) {
-            try {
-              if (this.eventListeners['message'][i](msg)) {
-                consumed = true;
-                break;
-              }
-            } catch (error) {
-              console.warn('Error in message listener : ' + error);
-            }
-          }
-        }
-        // iterate over internal callbacks, until one consumes the message
-        for (var key in this.listener){
-          // callback returns true if it has consumed the message
-          try {
-            if (this.listener[key](msg)) {
-              consumed = true;
-              break;
-            }
-          } catch (error) {
-            console.warn('Error in listener : ' + error);
-          }
-        }
-        if(!consumed) {
+        // send to any "message" listeners
+        this._sendEvent('message', msg);
+        // send message to receivers, if not consumed, add to queue
+        if(!this._sendReceivers(msg)) {
           if (this.queue.length >= this._queueSize) this.queue.shift();
           this.queue.push(msg);
         }
@@ -1227,6 +1223,17 @@ class Gateway {
   }
 
   /**
+   * Cancels all pending receive requests. The listener callbacks are called with `null` as the argument and
+   * then removed from the listener list.
+   *
+   * @returns {void}
+   */
+  cancelAll() {
+    this._sendReceivers(null);
+  }
+
+
+  /**
    * Sends a request and waits for a response. This method returns a {Promise} which resolves when a response
    * is received or if no response is received after the timeout.
    *
@@ -1264,15 +1271,18 @@ class Gateway {
       let timer;
       if (timeout > 0){
         timer = setTimeout(() => {
-          this.listener[lid] && delete this.listener[lid];
+          this.listeners[lid] && delete this.listeners[lid];
           if (this.debug) console.log('Receive Timeout : ' + filter);
           resolve();
         }, timeout);
       }
-      this.listener[lid] = msg => {
-        if (!this._matchMessage(filter, msg)) return false;
+      // listener for each pending receive
+      this.listeners[lid] = msg => {
+        // skip if the message does not match the filter
+        if (msg && !this._matchMessage(filter, msg)) return false;
         if(timer) clearTimeout(timer);
-        this.listener[lid] && delete this.listener[lid];
+        // if the message matches the filter or is null, delete listener clear timer and resolve
+        this.listeners[lid] && delete this.listeners[lid];
         resolve(msg);
         return true;
       };

--- a/gateways/js/dist/esm/fjage.js
+++ b/gateways/js/dist/esm/fjage.js
@@ -705,6 +705,7 @@ class GenericMessage extends Message {
  * @param {number} [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
  * @param {number} [opts.timeout=1000]       - timeout for fjage level messages in ms
  * @param {boolean} [opts.returnNullOnFailedResponse=true] - return null instead of throwing an error when a parameter is not found
+ * @param {boolean} [opts.cancellPendingOnDisconnect=true] - cancel pending requests on disconnect
  */
 class Gateway {
 
@@ -723,6 +724,7 @@ class Gateway {
     this._keepAlive = opts.keepAlive;     // reconnect if connection gets closed/errored
     this._queueSize = opts.queueSize;     // size of queue
     this._returnNullOnFailedResponse = opts.returnNullOnFailedResponse; // null or error
+    this._cancellPendingOnDisconnect = opts.cancellPendingOnDisconnect; // cancel pending requests on disconnect
     this.pending = {};                    // msgid to callback mapping for pending requests to server
     this.subscriptions = {};              // hashset for all topics that are subscribed
     this.listeners = {};                  // list of callbacks that want to listen to incoming messages
@@ -856,7 +858,7 @@ class Gateway {
     return new Promise(resolve => {
       let timer = setTimeout(() => {
         delete this.pending[rq.id];
-        if (this.debug) console.log('Receive Timeout : ' + rq);
+        if (this.debug) console.log('Receive Timeout : ' + JSON.stringify(rq));
         resolve();
       }, 8*this._timeout);
       this.pending[rq.id] = rsp => {
@@ -866,7 +868,7 @@ class Gateway {
       if (!this._msgTx.call(this,rq)) {
         clearTimeout(timer);
         delete this.pending[rq.id];
-        if (this.debug) console.log('Transmit Timeout : ' + rq);
+        if (this.debug) console.log('Transmit Timeout : ' +  JSON.stringify(rq));
         resolve();
       }
     });
@@ -902,6 +904,11 @@ class Gateway {
         this.flush();
         this.connector.write('{"alive": true}');
         this._update_watch();
+      } else {
+        if (this._cancellPendingOnDisconnect) {
+          this._sendReceivers(null);
+          this.flush();
+        }
       }
       this._sendEvent('conn', state);
     });
@@ -1223,17 +1230,6 @@ class Gateway {
   }
 
   /**
-   * Cancels all pending receive requests. The listener callbacks are called with `null` as the argument and
-   * then removed from the listener list.
-   *
-   * @returns {void}
-   */
-  cancelAll() {
-    this._sendReceivers(null);
-  }
-
-
-  /**
    * Sends a request and waits for a response. This method returns a {Promise} which resolves when a response
    * is received or if no response is received after the timeout.
    *
@@ -1428,7 +1424,8 @@ if (isBrowser || isWebWorker){
     'timeout': 1000,
     'keepAlive' : true,
     'queueSize': DEFAULT_QUEUE_SIZE,
-    'returnNullOnFailedResponse': true
+    'returnNullOnFailedResponse': true,
+    'cancellPendingOnDisconnect': false
   });
   DEFAULT_URL = new URL('ws://localhost');
   // Enable caching of Gateways
@@ -1443,7 +1440,8 @@ if (isBrowser || isWebWorker){
     'timeout': 1000,
     'keepAlive' : true,
     'queueSize': DEFAULT_QUEUE_SIZE,
-    'returnNullOnFailedResponse': true
+    'returnNullOnFailedResponse': true,
+    'cancellPendingOnDisconnect': false
   });
   DEFAULT_URL = new URL('tcp://localhost');
   gObj.atob = a => Buffer.from(a, 'base64').toString('binary');

--- a/gateways/js/dist/esm/fjage.js
+++ b/gateways/js/dist/esm/fjage.js
@@ -705,7 +705,7 @@ class GenericMessage extends Message {
  * @param {number} [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
  * @param {number} [opts.timeout=1000]       - timeout for fjage level messages in ms
  * @param {boolean} [opts.returnNullOnFailedResponse=true] - return null instead of throwing an error when a parameter is not found
- * @param {boolean} [opts.cancellPendingOnDisconnect=true] - cancel pending requests on disconnect
+ * @param {boolean} [opts.cancelPendingOnDisconnect=false] - cancel pending requests on disconnect
  */
 class Gateway {
 
@@ -724,7 +724,7 @@ class Gateway {
     this._keepAlive = opts.keepAlive;     // reconnect if connection gets closed/errored
     this._queueSize = opts.queueSize;     // size of queue
     this._returnNullOnFailedResponse = opts.returnNullOnFailedResponse; // null or error
-    this._cancellPendingOnDisconnect = opts.cancellPendingOnDisconnect; // cancel pending requests on disconnect
+    this._cancelPendingOnDisconnect = opts.cancelPendingOnDisconnect; // cancel pending requests on disconnect
     this.pending = {};                    // msgid to callback mapping for pending requests to server
     this.subscriptions = {};              // hashset for all topics that are subscribed
     this.listeners = {};                  // list of callbacks that want to listen to incoming messages
@@ -905,7 +905,7 @@ class Gateway {
         this.connector.write('{"alive": true}');
         this._update_watch();
       } else {
-        if (this._cancellPendingOnDisconnect) {
+        if (this._cancelPendingOnDisconnect) {
           this._sendReceivers(null);
           this.flush();
         }
@@ -1425,7 +1425,7 @@ if (isBrowser || isWebWorker){
     'keepAlive' : true,
     'queueSize': DEFAULT_QUEUE_SIZE,
     'returnNullOnFailedResponse': true,
-    'cancellPendingOnDisconnect': false
+    'cancelPendingOnDisconnect': false
   });
   DEFAULT_URL = new URL('ws://localhost');
   // Enable caching of Gateways
@@ -1441,7 +1441,7 @@ if (isBrowser || isWebWorker){
     'keepAlive' : true,
     'queueSize': DEFAULT_QUEUE_SIZE,
     'returnNullOnFailedResponse': true,
-    'cancellPendingOnDisconnect': false
+    'cancelPendingOnDisconnect': false
   });
   DEFAULT_URL = new URL('tcp://localhost');
   gObj.atob = a => Buffer.from(a, 'base64').toString('binary');

--- a/gateways/js/dist/fjage.js
+++ b/gateways/js/dist/fjage.js
@@ -711,7 +711,7 @@
    * @param {number} [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
    * @param {number} [opts.timeout=1000]       - timeout for fjage level messages in ms
    * @param {boolean} [opts.returnNullOnFailedResponse=true] - return null instead of throwing an error when a parameter is not found
-   * @param {boolean} [opts.cancellPendingOnDisconnect=true] - cancel pending requests on disconnect
+   * @param {boolean} [opts.cancelPendingOnDisconnect=false] - cancel pending requests on disconnect
    */
   class Gateway {
 
@@ -730,7 +730,7 @@
       this._keepAlive = opts.keepAlive;     // reconnect if connection gets closed/errored
       this._queueSize = opts.queueSize;     // size of queue
       this._returnNullOnFailedResponse = opts.returnNullOnFailedResponse; // null or error
-      this._cancellPendingOnDisconnect = opts.cancellPendingOnDisconnect; // cancel pending requests on disconnect
+      this._cancelPendingOnDisconnect = opts.cancelPendingOnDisconnect; // cancel pending requests on disconnect
       this.pending = {};                    // msgid to callback mapping for pending requests to server
       this.subscriptions = {};              // hashset for all topics that are subscribed
       this.listeners = {};                  // list of callbacks that want to listen to incoming messages
@@ -911,7 +911,7 @@
           this.connector.write('{"alive": true}');
           this._update_watch();
         } else {
-          if (this._cancellPendingOnDisconnect) {
+          if (this._cancelPendingOnDisconnect) {
             this._sendReceivers(null);
             this.flush();
           }
@@ -1431,7 +1431,7 @@
       'keepAlive' : true,
       'queueSize': DEFAULT_QUEUE_SIZE,
       'returnNullOnFailedResponse': true,
-      'cancellPendingOnDisconnect': false
+      'cancelPendingOnDisconnect': false
     });
     DEFAULT_URL = new URL('ws://localhost');
     // Enable caching of Gateways
@@ -1447,7 +1447,7 @@
       'keepAlive' : true,
       'queueSize': DEFAULT_QUEUE_SIZE,
       'returnNullOnFailedResponse': true,
-      'cancellPendingOnDisconnect': false
+      'cancelPendingOnDisconnect': false
     });
     DEFAULT_URL = new URL('tcp://localhost');
     gObj.atob = a => Buffer.from(a, 'base64').toString('binary');

--- a/gateways/js/package-lock.json
+++ b/gateways/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fjage",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fjage",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "browser-or-node": "2.0.0"

--- a/gateways/js/package.json
+++ b/gateways/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fjage",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "JS Gateway for fjåge",
   "main": "./dist/cjs/fjage.cjs",
   "exports": {

--- a/gateways/js/src/fjage.js
+++ b/gateways/js/src/fjage.js
@@ -533,8 +533,6 @@ export class Gateway {
         this.flush();
         this.connector.write('{"alive": true}');
         this._update_watch();
-      }else{
-        // TODO: remove all pending messages
       }
       this._sendEvent('conn', state);
     });

--- a/gateways/js/src/fjage.js
+++ b/gateways/js/src/fjage.js
@@ -336,7 +336,7 @@ export class GenericMessage extends Message {
  * @param {number} [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
  * @param {number} [opts.timeout=1000]       - timeout for fjage level messages in ms
  * @param {boolean} [opts.returnNullOnFailedResponse=true] - return null instead of throwing an error when a parameter is not found
- * @param {boolean} [opts.cancellPendingOnDisconnect=true] - cancel pending requests on disconnect
+ * @param {boolean} [opts.cancelPendingOnDisconnect=true] - cancel pending requests on disconnect
  */
 export class Gateway {
 
@@ -355,7 +355,7 @@ export class Gateway {
     this._keepAlive = opts.keepAlive;     // reconnect if connection gets closed/errored
     this._queueSize = opts.queueSize;     // size of queue
     this._returnNullOnFailedResponse = opts.returnNullOnFailedResponse; // null or error
-    this._cancellPendingOnDisconnect = opts.cancellPendingOnDisconnect; // cancel pending requests on disconnect
+    this._cancelPendingOnDisconnect = opts.cancelPendingOnDisconnect; // cancel pending requests on disconnect
     this.pending = {};                    // msgid to callback mapping for pending requests to server
     this.subscriptions = {};              // hashset for all topics that are subscribed
     this.listeners = {};                  // list of callbacks that want to listen to incoming messages
@@ -536,7 +536,7 @@ export class Gateway {
         this.connector.write('{"alive": true}');
         this._update_watch();
       } else{
-        if (this._cancellPendingOnDisconnect) {
+        if (this._cancelPendingOnDisconnect) {
           this._sendReceivers(null);
           this.flush();
         }
@@ -1056,7 +1056,7 @@ if (isBrowser || isWebWorker){
     'keepAlive' : true,
     'queueSize': DEFAULT_QUEUE_SIZE,
     'returnNullOnFailedResponse': true,
-    'cancellPendingOnDisconnect': false
+    'cancelPendingOnDisconnect': false
   });
   DEFAULT_URL = new URL('ws://localhost');
   // Enable caching of Gateways
@@ -1072,7 +1072,7 @@ if (isBrowser || isWebWorker){
     'keepAlive' : true,
     'queueSize': DEFAULT_QUEUE_SIZE,
     'returnNullOnFailedResponse': true,
-    'cancellPendingOnDisconnect': false
+    'cancelPendingOnDisconnect': false
   });
   DEFAULT_URL = new URL('tcp://localhost');
   gObj.atob = a => Buffer.from(a, 'base64').toString('binary');

--- a/gateways/js/src/fjage.js
+++ b/gateways/js/src/fjage.js
@@ -336,6 +336,7 @@ export class GenericMessage extends Message {
  * @param {number} [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
  * @param {number} [opts.timeout=1000]       - timeout for fjage level messages in ms
  * @param {boolean} [opts.returnNullOnFailedResponse=true] - return null instead of throwing an error when a parameter is not found
+ * @param {boolean} [opts.cancellPendingOnDisconnect=true] - cancel pending requests on disconnect
  */
 export class Gateway {
 
@@ -354,6 +355,7 @@ export class Gateway {
     this._keepAlive = opts.keepAlive;     // reconnect if connection gets closed/errored
     this._queueSize = opts.queueSize;     // size of queue
     this._returnNullOnFailedResponse = opts.returnNullOnFailedResponse; // null or error
+    this._cancellPendingOnDisconnect = opts.cancellPendingOnDisconnect; // cancel pending requests on disconnect
     this.pending = {};                    // msgid to callback mapping for pending requests to server
     this.subscriptions = {};              // hashset for all topics that are subscribed
     this.listeners = {};                  // list of callbacks that want to listen to incoming messages
@@ -533,6 +535,11 @@ export class Gateway {
         this.flush();
         this.connector.write('{"alive": true}');
         this._update_watch();
+      } else{
+        if (this._cancellPendingOnDisconnect) {
+          this._sendReceivers(null);
+          this.flush();
+        }
       }
       this._sendEvent('conn', state);
     });
@@ -854,17 +861,6 @@ export class Gateway {
   }
 
   /**
-   * Cancels all pending receive requests. The listener callbacks are called with `null` as the argument and
-   * then removed from the listener list.
-   *
-   * @returns {void}
-   */
-  cancelAll() {
-    this._sendReceivers(null);
-  }
-
-
-  /**
    * Sends a request and waits for a response. This method returns a {Promise} which resolves when a response
    * is received or if no response is received after the timeout.
    *
@@ -1059,7 +1055,8 @@ if (isBrowser || isWebWorker){
     'timeout': 1000,
     'keepAlive' : true,
     'queueSize': DEFAULT_QUEUE_SIZE,
-    'returnNullOnFailedResponse': true
+    'returnNullOnFailedResponse': true,
+    'cancellPendingOnDisconnect': false
   });
   DEFAULT_URL = new URL('ws://localhost');
   // Enable caching of Gateways
@@ -1074,7 +1071,8 @@ if (isBrowser || isWebWorker){
     'timeout': 1000,
     'keepAlive' : true,
     'queueSize': DEFAULT_QUEUE_SIZE,
-    'returnNullOnFailedResponse': true
+    'returnNullOnFailedResponse': true,
+    'cancellPendingOnDisconnect': false
   });
   DEFAULT_URL = new URL('tcp://localhost');
   gObj.atob = a => Buffer.from(a, 'base64').toString('binary');

--- a/gateways/js/src/fjage.js
+++ b/gateways/js/src/fjage.js
@@ -487,7 +487,7 @@ export class Gateway {
     return new Promise(resolve => {
       let timer = setTimeout(() => {
         delete this.pending[rq.id];
-        if (this.debug) console.log('Receive Timeout : ' + rq);
+        if (this.debug) console.log('Receive Timeout : ' + JSON.stringify(rq));
         resolve();
       }, 8*this._timeout);
       this.pending[rq.id] = rsp => {
@@ -497,7 +497,7 @@ export class Gateway {
       if (!this._msgTx.call(this,rq)) {
         clearTimeout(timer);
         delete this.pending[rq.id];
-        if (this.debug) console.log('Transmit Timeout : ' + rq);
+        if (this.debug) console.log('Transmit Timeout : ' +  JSON.stringify(rq));
         resolve();
       }
     });

--- a/gateways/js/src/fjage.js
+++ b/gateways/js/src/fjage.js
@@ -336,7 +336,7 @@ export class GenericMessage extends Message {
  * @param {number} [opts.queueSize=128]      - size of the queue of received messages that haven't been consumed yet
  * @param {number} [opts.timeout=1000]       - timeout for fjage level messages in ms
  * @param {boolean} [opts.returnNullOnFailedResponse=true] - return null instead of throwing an error when a parameter is not found
- * @param {boolean} [opts.cancelPendingOnDisconnect=true] - cancel pending requests on disconnect
+ * @param {boolean} [opts.cancelPendingOnDisconnect=false] - cancel pending requests on disconnect
  */
 export class Gateway {
 

--- a/gateways/js/test/spec/fjage.spec.js
+++ b/gateways/js/test/spec/fjage.spec.js
@@ -327,12 +327,13 @@ describe('A Gateway', function () {
     gw.close();
   });
 
-  it('should be able to cancel all requests', async function() {
-    const gw = new Gateway(Object.assign({}, gwOpts, {returnNullOnFailedResponse: false}));
+  it('should cancel requests when disconnected', async function() {
+    const gw = new Gateway(Object.assign({}, gwOpts, {returnNullOnFailedResponse: false, cancellPendingOnDisconnect: true}));
     const shell = gw.agent('shell');
     expectAsync(shell.get('language'))
     .toBeRejectedWithError();
-    gw.cancelAll();
+    if (isBrowser) gw.connector.sock.close();
+    else gw.connector.sock.destroy();
     await delay(100);
     gw.close();
   });

--- a/gateways/js/test/spec/fjage.spec.js
+++ b/gateways/js/test/spec/fjage.spec.js
@@ -326,6 +326,17 @@ describe('A Gateway', function () {
     pub.set('tick', false);
     gw.close();
   });
+
+  it('should be able to cancel all requests', async function() {
+    const gw = new Gateway(Object.assign({}, gwOpts, {returnNullOnFailedResponse: false}));
+    const shell = gw.agent('shell');
+    expectAsync(shell.get('language'))
+    .toBeRejectedWithError();
+    gw.cancelAll();
+    await delay(100);
+    gw.close();
+  });
+
 });
 
 describe('An AgentID', function () {

--- a/gateways/js/test/spec/fjage.spec.js
+++ b/gateways/js/test/spec/fjage.spec.js
@@ -328,7 +328,7 @@ describe('A Gateway', function () {
   });
 
   it('should cancel requests when disconnected', async function() {
-    const gw = new Gateway(Object.assign({}, gwOpts, {returnNullOnFailedResponse: false, cancellPendingOnDisconnect: true}));
+    const gw = new Gateway(Object.assign({}, gwOpts, {returnNullOnFailedResponse: false, cancelPendingOnDisconnect: true}));
     const shell = gw.agent('shell');
     expectAsync(shell.get('language'))
     .toBeRejectedWithError();


### PR DESCRIPTION
The current Gateway API doesn't have a mechanism to cancel all pending `receive` (or indirectly `request`) calls. This can be handy when trying to clean up or just abort any ongoing operations.

## Feature
- Added `cancelPendingOnDisconnect` to option to fjage.js Gateway. This defaults to `false`, to keep the previous behaviour. This will cause the Gateway to `resolve` all pending `receive` with a `null`.
- Add test to verify the behaviour of `cancelPendingOnDisconnect`

## Cleanup
- Renamed internal `this.listener = []` => `this.listeners = []`
- `Gateway.addMessageListener` don't consume messages any more, they're just mere listeners as per the name.
