### PR TITLE
Mark GenericValue as serializable to allow cloning

### DIFF
--- a/src/main/java/org/arl/fjage/GenericValue.java
+++ b/src/main/java/org/arl/fjage/GenericValue.java
@@ -10,8 +10,11 @@ for full license details.
 
 package org.arl.fjage;
 
-final public class GenericValue {
+import java.io.Serializable;
 
+final public class GenericValue implements Serializable {
+
+  private static final long serialVersionUID = 1L;
   final private Object data;
 
   public GenericValue(Object value) {


### PR DESCRIPTION
### Problem

Cloning of messages with `GenericValue` fails.

### Solution

Mark `GenericValue` as serializable, so that the Apache serialization based cloner (which we use as default) can clone it.

### Note

Should be forward-ported to `master` once approved.