### PR TITLE
Add support for nested Maps/Arrays inside GenericValue JSON

### DIFF
--- a/src/main/java/org/arl/fjage/remote/GenericValueAdapterFactory.java
+++ b/src/main/java/org/arl/fjage/remote/GenericValueAdapterFactory.java
@@ -123,8 +123,16 @@ class GenericValueAdapterFactory implements TypeAdapterFactory {
                   // ignore
                 }
               }
-              else if (tok == JsonToken.STRING) map.put(name, in.nextString());
-              else if (tok == JsonToken.BOOLEAN) map.put(name, in.nextBoolean());
+              else if (tok2 == JsonToken.STRING) map.put(name, in.nextString());
+              else if (tok2 == JsonToken.BOOLEAN) map.put(name, in.nextBoolean());
+              else if (tok2 == JsonToken.BEGIN_OBJECT) {
+                TypeAdapter delegate = gson.getAdapter(TypeToken.get(Map.class));
+                map.put(name, delegate.read(in));
+              }
+              else if (tok2 == JsonToken.BEGIN_ARRAY) {
+                TypeAdapter delegate = gson.getAdapter(TypeToken.get(List.class));
+                map.put(name, delegate.read(in));
+              }
               else in.skipValue();
             }
           }


### PR DESCRIPTION
> We may wish to support simple JSON map as a special case on the Java side, where not specifying a clazz defaults to using a HashMap.
 
from https://github.com/org-arl/fjage/pull/309

We already had some support for this, albeit it was broken (`tok` vs `tok2`). This PR fixes that and also adds support for nested Maps and Lists.

So for example, a Agent parameter with the value `device.netIf = {"eth0" : {"up": true, "ips":["1982.168.2.1", "10.30.0.1"]}` will get deserialized correctly into a GenericValue as an Map with values that can be Null/Boolean/Number/String/(simple)Map/(simple)List

This won't support having GenericValues as values inside the nested Map or List. But I think we can live with that.