### PR TITLE
Improving fjåge.js timeouts

### DIFF
--- a/docs/jsdoc/index.html
+++ b/docs/jsdoc/index.html
@@ -632,7 +632,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L82-L666'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L84-L676'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -736,7 +736,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
                 <tr>
   <td class='break-word'><span class='code bold'>opts.timeout</span> <code class='quiet'><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>
   
-    (default <code>1000</code>)
+    (default <code>10000</code>)
   </td>
   <td class='break-word'><span>timeout for fjage level messages in ms
 </span></td>
@@ -842,7 +842,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L398-L403'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L404-L409'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -930,7 +930,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L412-L416'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L418-L422'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1018,7 +1018,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L424-L426'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L430-L432'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1097,7 +1097,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L434-L436'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L440-L442'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1176,7 +1176,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L444-L446'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L450-L452'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1255,7 +1255,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L454-L456'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L460-L462'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1334,7 +1334,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L463-L465'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L469-L471'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1400,7 +1400,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L473-L475'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L479-L481'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1480,7 +1480,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L484-L490'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L490-L496'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1569,7 +1569,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L498-L503'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L504-L509'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1649,7 +1649,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L511-L515'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L517-L521'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1718,7 +1718,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>agents()</span>
+            <span class='code strong strong truncate'>agents(timeout)</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -1728,7 +1728,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L521-L526'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L528-L533'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1737,7 +1737,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
 
   <p>Gets a list of all agents in the container.</p>
 
-    <div class='pre p1 fill-light mt0'>agents(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#agentid">AgentID</a>>></div>
+    <div class='pre p1 fill-light mt0'>agents(timeout: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#agentid">AgentID</a>>></div>
   
   
 
@@ -1748,6 +1748,21 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   
   
 
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>timeout</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
+            = <code>opts.timeout</code>)</code>
+	    timeout in milliseconds
+
+          </div>
+          
+        </div>
+      
+    </div>
   
 
   
@@ -1784,7 +1799,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>containsAgent(agentID)</span>
+            <span class='code strong strong truncate'>containsAgent(agentID, timeout)</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -1794,7 +1809,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L534-L542'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L542-L550'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1803,7 +1818,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
 
   <p>Check if an agent with a given name exists in the container.</p>
 
-    <div class='pre p1 fill-light mt0'>containsAgent(agentID: (<a href="#agentid">AgentID</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>></div>
+    <div class='pre p1 fill-light mt0'>containsAgent(agentID: (<a href="#agentid">AgentID</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), timeout: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>></div>
   
   
 
@@ -1822,6 +1837,16 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
           <div>
             <span class='code bold'>agentID</span> <code class='quiet'>((<a href="#agentid">AgentID</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
 	    the agent id to check
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>timeout</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
+            = <code>opts.timeout</code>)</code>
+	    timeout in milliseconds
 
           </div>
           
@@ -1864,7 +1889,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>agentForService(service)</span>
+            <span class='code strong strong truncate'>agentForService(service, timeout)</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -1874,7 +1899,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L551-L559'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L560-L568'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1884,7 +1909,7 @@ It can be used to connect to a fjage master container over WebSockets or TCP.</p
   <p>Finds an agent that provides a named service. If multiple agents are registered
 to provide a given service, any of the agents' id may be returned.</p>
 
-    <div class='pre p1 fill-light mt0'>agentForService(service: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="#agentid">AgentID</a>?></div>
+    <div class='pre p1 fill-light mt0'>agentForService(service: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, timeout: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="#agentid">AgentID</a>?></div>
   
   
 
@@ -1903,6 +1928,16 @@ to provide a given service, any of the agents' id may be returned.</p>
           <div>
             <span class='code bold'>service</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
 	    the named service of interest
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>timeout</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
+            = <code>opts.timeout</code>)</code>
+	    timeout in milliseconds
 
           </div>
           
@@ -1945,7 +1980,7 @@ to provide a given service, any of the agents' id may be returned.</p>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>agentsForService(service)</span>
+            <span class='code strong strong truncate'>agentsForService(service, timeout)</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -1955,7 +1990,7 @@ to provide a given service, any of the agents' id may be returned.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L567-L575'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L577-L585'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -1964,7 +1999,7 @@ to provide a given service, any of the agents' id may be returned.</p>
 
   <p>Finds all agents that provides a named service.</p>
 
-    <div class='pre p1 fill-light mt0'>agentsForService(service: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#agentid">AgentID</a>>></div>
+    <div class='pre p1 fill-light mt0'>agentsForService(service: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, timeout: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#agentid">AgentID</a>>></div>
   
   
 
@@ -1983,6 +2018,16 @@ to provide a given service, any of the agents' id may be returned.</p>
           <div>
             <span class='code bold'>service</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
 	    the named service of interest
+
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>timeout</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
+            = <code>opts.timeout</code>)</code>
+	    timeout in milliseconds
 
           </div>
           
@@ -2035,7 +2080,7 @@ to provide a given service, any of the agents' id may be returned.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L584-L589'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L594-L599'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -2116,7 +2161,7 @@ may be an agent or a topic.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L596-L598'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L606-L608'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -2181,7 +2226,7 @@ may be an agent or a topic.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L608-L611'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L618-L621'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -2218,7 +2263,7 @@ is received or if no response is received after the timeout.</p>
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>timeout</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
-            = <code>1000</code>)</code>
+            = <code>opts.timeout</code>)</code>
 	    timeout in milliseconds
 
           </div>
@@ -2272,7 +2317,7 @@ is received or if no response is received after the timeout.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L622-L654'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L632-L664'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -2362,7 +2407,7 @@ a response is received or if no response is received after the timeout.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/gateway.js#L661-L664'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/gateway.js#L671-L674'>
       <span>gateways/js/src/gateway.js</span>
       </a>
     
@@ -2436,7 +2481,7 @@ this method is called.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/agentid.js#L15-L198'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/agentid.js#L18-L202'>
       <span>gateways/js/src/agentid.js</span>
       </a>
     
@@ -2520,7 +2565,7 @@ on an agent or topic on the fjåge master container.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/agentid.js#L91-L101'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/agentid.js#L95-L105'>
       <span>gateways/js/src/agentid.js</span>
       </a>
     
@@ -2617,7 +2662,7 @@ on an agent or topic on the fjåge master container.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/agentid.js#L28-L30'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/agentid.js#L32-L34'>
       <span>gateways/js/src/agentid.js</span>
       </a>
     
@@ -2683,7 +2728,7 @@ on an agent or topic on the fjåge master container.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/agentid.js#L37-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/agentid.js#L41-L43'>
       <span>gateways/js/src/agentid.js</span>
       </a>
     
@@ -2749,7 +2794,7 @@ on an agent or topic on the fjåge master container.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/agentid.js#L47-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/agentid.js#L51-L55'>
       <span>gateways/js/src/agentid.js</span>
       </a>
     
@@ -2828,7 +2873,7 @@ on an agent or topic on the fjåge master container.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/agentid.js#L60-L64'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/agentid.js#L64-L68'>
       <span>gateways/js/src/agentid.js</span>
       </a>
     
@@ -2864,7 +2909,7 @@ on an agent or topic on the fjåge master container.</p>
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>timeout</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
-            = <code>1000</code>)</code>
+            = <code>owner.timeout</code>)</code>
 	    timeout in milliseconds
 
           </div>
@@ -2918,7 +2963,7 @@ on an agent or topic on the fjåge master container.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/agentid.js#L71-L73'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/agentid.js#L75-L77'>
       <span>gateways/js/src/agentid.js</span>
       </a>
     
@@ -2984,7 +3029,7 @@ on an agent or topic on the fjåge master container.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/agentid.js#L80-L82'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/agentid.js#L84-L86'>
       <span>gateways/js/src/agentid.js</span>
       </a>
     
@@ -3050,7 +3095,7 @@ on an agent or topic on the fjåge master container.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/agentid.js#L112-L151'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/agentid.js#L116-L155'>
       <span>gateways/js/src/agentid.js</span>
       </a>
     
@@ -3105,7 +3150,7 @@ on an agent or topic on the fjåge master container.</p>
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>timeout</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
-            = <code>5000</code>)</code>
+            = <code>owner.timeout</code>)</code>
 	    timeout for the response
 
           </div>
@@ -3159,7 +3204,7 @@ on an agent or topic on the fjåge master container.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/agentid.js#L162-L197'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/agentid.js#L166-L201'>
       <span>gateways/js/src/agentid.js</span>
       </a>
     
@@ -3205,7 +3250,7 @@ on an agent or topic on the fjåge master container.</p>
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>timeout</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
-            = <code>5000</code>)</code>
+            = <code>owner.timeout</code>)</code>
 	    timeout for the response
 
           </div>
@@ -3267,7 +3312,7 @@ on an agent or topic on the fjåge master container.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/services.js#L4-L6'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/services.js#L4-L6'>
       <span>gateways/js/src/services.js</span>
       </a>
     
@@ -3317,7 +3362,7 @@ on an agent or topic on the fjåge master container.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/services.js#L5-L5'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/services.js#L5-L5'>
       <span>gateways/js/src/services.js</span>
       </a>
     
@@ -3384,7 +3429,7 @@ on an agent or topic on the fjåge master container.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L6-L19'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L6-L19'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -3440,7 +3485,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L7-L7'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L7-L7'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -3497,7 +3542,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L8-L8'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L8-L8'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -3554,7 +3599,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L9-L9'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L9-L9'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -3611,7 +3656,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L10-L10'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L10-L10'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -3668,7 +3713,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L11-L11'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L11-L11'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -3725,7 +3770,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L12-L12'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L12-L12'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -3782,7 +3827,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L13-L13'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L13-L13'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -3839,7 +3884,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L14-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L14-L14'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -3896,7 +3941,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L15-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L15-L15'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -3953,7 +3998,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L16-L16'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L16-L16'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -4010,7 +4055,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L17-L17'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L17-L17'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -4067,7 +4112,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/performative.js#L18-L18'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/performative.js#L18-L18'>
       <span>gateways/js/src/performative.js</span>
       </a>
     
@@ -4134,7 +4179,7 @@ FIPA ACL recommendations for interagent communication.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/message.js#L16-L85'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/message.js#L16-L85'>
       <span>gateways/js/src/message.js</span>
       </a>
     
@@ -4253,7 +4298,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/message.js#L67-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/message.js#L67-L84'>
       <span>gateways/js/src/message.js</span>
       </a>
     
@@ -4341,7 +4386,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/message.js#L36-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/message.js#L36-L40'>
       <span>gateways/js/src/message.js</span>
       </a>
     
@@ -4407,7 +4452,7 @@ FIPA ACL recommendations for interagent communication.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/message.js#L49-L57'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/message.js#L49-L57'>
       <span>gateways/js/src/message.js</span>
       </a>
     
@@ -4483,7 +4528,7 @@ we don't know what data type is intended</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/message.js#L111-L133'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/message.js#L111-L133'>
       <span>gateways/js/src/message.js</span>
       </a>
     
@@ -4492,7 +4537,7 @@ we don't know what data type is intended</p>
 
   <p>Creates a unqualified message class based on a fully qualified name.</p>
 
-    <div class='pre p1 fill-light mt0'>new MessageClass(name: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, parent: any?)</div>
+    <div class='pre p1 fill-light mt0'>new MessageClass(name: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, parent: any)</div>
   
   
 
@@ -4518,10 +4563,9 @@ we don't know what data type is intended</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>parent</span> <code class='quiet'>(any?
+            <span class='code bold'>parent</span> <code class='quiet'>(any
             = <code>Message</code>)</code>
-	    class of the parent MessageClass to inherit from
-
+	    
           </div>
           
         </div>
@@ -4568,7 +4612,7 @@ we don't know what data type is intended</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/message.js#L142-L164'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/message.js#L142-L164'>
       <span>gateways/js/src/message.js</span>
       </a>
     
@@ -4678,7 +4722,7 @@ we don't know what data type is intended</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/message.js#L135-L140'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/message.js#L135-L140'>
       <span>gateways/js/src/message.js</span>
       </a>
     
@@ -4755,7 +4799,7 @@ we don't know what data type is intended</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/message.js#L92-L100'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/message.js#L92-L100'>
       <span>gateways/js/src/message.js</span>
       </a>
     
@@ -4816,7 +4860,7 @@ we don't know what data type is intended</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L50-L219'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L50-L219'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5010,7 +5054,7 @@ jsonMsg.<span class="hljs-property">message</span>; <span class="hljs-comment">/
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L91-L100'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L91-L100'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5099,7 +5143,7 @@ jsonMsg.<span class="hljs-property">message</span>; <span class="hljs-comment">/
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L108-L116'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L108-L116'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5179,7 +5223,7 @@ jsonMsg.<span class="hljs-property">message</span>; <span class="hljs-comment">/
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L123-L128'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L123-L128'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5245,7 +5289,7 @@ jsonMsg.<span class="hljs-property">message</span>; <span class="hljs-comment">/
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L136-L145'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L136-L145'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5325,7 +5369,7 @@ jsonMsg.<span class="hljs-property">message</span>; <span class="hljs-comment">/
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L153-L162'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L153-L162'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5405,7 +5449,7 @@ jsonMsg.<span class="hljs-property">message</span>; <span class="hljs-comment">/
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L170-L179'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L170-L179'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5493,7 +5537,7 @@ jsonMsg.<span class="hljs-property">message</span>; <span class="hljs-comment">/
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L188-L214'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L188-L214'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5561,7 +5605,7 @@ AgentID objects, they will be serialized as per the fjåge protocol.</p>
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L216-L218'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L216-L218'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5626,7 +5670,7 @@ AgentID objects, they will be serialized as per the fjåge protocol.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/message.js#L167-L185'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/message.js#L167-L185'>
       <span>gateways/js/src/message.js</span>
       </a>
     
@@ -5736,7 +5780,7 @@ rsp.<span class="hljs-property">readonly</span> <span class="hljs-comment">// = 
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L228-L237'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L228-L237'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5792,7 +5836,7 @@ rsp.<span class="hljs-property">readonly</span> <span class="hljs-comment">// = 
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L229-L229'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L229-L229'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5849,7 +5893,7 @@ rsp.<span class="hljs-property">readonly</span> <span class="hljs-comment">// = 
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L230-L230'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L230-L230'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5906,7 +5950,7 @@ rsp.<span class="hljs-property">readonly</span> <span class="hljs-comment">// = 
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L231-L231'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L231-L231'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -5963,7 +6007,7 @@ rsp.<span class="hljs-property">readonly</span> <span class="hljs-comment">// = 
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L232-L232'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L232-L232'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -6020,7 +6064,7 @@ rsp.<span class="hljs-property">readonly</span> <span class="hljs-comment">// = 
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L233-L233'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L233-L233'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -6077,7 +6121,7 @@ rsp.<span class="hljs-property">readonly</span> <span class="hljs-comment">// = 
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L234-L234'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L234-L234'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -6134,7 +6178,7 @@ rsp.<span class="hljs-property">readonly</span> <span class="hljs-comment">// = 
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L235-L235'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L235-L235'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     
@@ -6191,7 +6235,7 @@ rsp.<span class="hljs-property">readonly</span> <span class="hljs-comment">// = 
   <div class='clearfix'>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/27de4aac41a518c17a139238a4a469468258ad9c/gateways/js/src/jsonmessage.js#L236-L236'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/org-arl/fjage/blob/7e123064f037154408dfbb053b589ab6db972863/gateways/js/src/jsonmessage.js#L236-L236'>
       <span>gateways/js/src/jsonmessage.js</span>
       </a>
     


### PR DESCRIPTION
This pull request improves timeouts available of various Gateway and AgentId methods in fjage.js.

### Gateway Improvements

- Previously the Gateway constructor had an option argument `new Gateway({timeout: 1000})` which set the default timeout for all requests including the fjage container level queries like `agentForService`, `agents`, etc. This is still supported, but we now add the ability to set a timeout for each request individually using an argument to `agentForService`, `agentsForService`, `agents` and `containsAgent` methods. 
- The default timeout remain the same (the default is 8 times the Gateway's timeout, which itself was 1000ms by default).
- With the new argument, you can now specify a different timeout for each request, e.g. `gw.agents(10000)` will set the timeout for that request to 10 seconds instead of the default 8 seconds. You can even set it to -1 to disable the timeout for that request, e.g. `gw.agents(-1)` will wait indefinitely for the response.

### AgentID Improvements

- We also default the timeout for all requests sent to an Agent using the `AgentId` methods (`aid.get()`, `aid.set()`, `aid.request()`, etc.) to default to the Gateway's timeout. Previously, this was set to 1000ms for `request` and 5000ms for `set` and `get`. By copying from the Gateway's timeout and multiplying it accordingly to the previous values, we keep the default behavior consistent.
- We now add the ability to change the default timeout for any requests sent to a specific Agent by adding a `setTimeout` method to the AgentId class. This allows you to set a default timeout for all requests sent to that AgentId.