### PR TITLE
Fix the broken build

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,11 @@ Try to stick to the coding style already in use in the repository. Additionally,
 Building:
 
 * `gradle` to build the jars including resources (webshell, fjage.js, etc.)
-* `gradle lite` to build only the jars
 * `gradle test` to run all regression tests (automated through Github actions CI)
 * `gradle publish` to upload jars to Maven staging (requires credentials)
 * `make html` to build developer's documentation (automated through ReadTheDocs)
 * `gradle javadoc` to build the Java API documentation
-* `npm run docs` to build the Javascript API documentation
+* `gradle jsdoc` to build the Javascript API documentation
 
 License
 -------

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
   id 'signing'
 }
 
-defaultTasks 'jars'
+defaultTasks 'jar'
 
 archivesBaseName = 'fjage'
 group = 'com.github.org-arl'
@@ -28,7 +28,7 @@ try {
   def npmproc = "$npmcmd -v".execute()
   npmproc.waitForOrKill(3000)
   npmExists = npmproc.exitValue() == 0
-} catch (IOException ex){}
+} catch (IOException ignored){}
 
 targetCompatibility = 1.8
 sourceCompatibility = 1.8
@@ -68,45 +68,9 @@ compileGroovy {
   options.compilerArgs << "-Xlint:-options"
 }
 
-test {
-  systemProperties project.properties.subMap(["manualJSTest"])
-  systemProperties project.properties.subMap(["manualPyTest"])
-  systemProperties project.properties.subMap(["manualCTest"])
-}
-
-tasks.withType(Javadoc) {
-  options.addStringOption('Xdoclint:none', '-quiet')
-}
-
-jar {
-  manifest {
-    attributes (
-      "Build-Owner": System.getenv().USER ?: "fjage",
-      "Build-Timestamp": new Date().format('d-MM-yyyy_HH:mm:ss'),
-      "Build-Version": "${project.version}/${commit}")
-  }
-}
-
-processResources {
-  exclude '**/readme.md'
-}
-
-test {
-  testLogging {
-    events "passed", "skipped", "failed"
-    exceptionFormat "full"
-  }
-}
-
-task lite(dependsOn: jar, type: Copy) {
-  into "$buildDir/libs"
-  from configurations.runtimeClasspath
-}
-
-task buildjs {
+tasks.register('buildjs') {
   inputs.files fileTree('gateways/js/src').include('**/*.js'), "gateways/js/package.json"
   outputs.dir "gateways/js/dist"
-
   doLast {
     if (npmExists) {
       exec {
@@ -121,37 +85,35 @@ task buildjs {
         executable npmcmd
         args 'run', 'build'
       }
-    } else{
-      project.logger.lifecycle('npm not found. Using cached fjage.js build')
+    } else if (file('gateways/js/dist/fjage.js').exists()) {
+      if (!gradle.taskGraph.hasTask(":javadoc")) { // only log if not building javadoc
+        project.logger.lifecycle('npm not found. Using cached fjage.js build')
+      }
+    } else {
+      if (!gradle.taskGraph.hasTask(":javadoc")) { // only log if not building javadoc
+        project.logger.lifecycle('Not bundling fjage.js. WebShell will not work.')
+      }
     }
   }
 }
 
-test.dependsOn 'buildjs'
-
-task jars() {
-  dependsOn 'lite'
-  dependsOn 'buildjs'
-  tasks.findByName('buildjs').mustRunAfter 'lite'
-}
-
-jars.outputs.upToDateWhen { false }
-
-javadoc.doLast {
-  mkdir 'docs/javadoc'
-  copy {
-    from javadoc.destinationDir
-    into 'docs/javadoc'
+tasks.register('jsdoc', Exec) {
+  doFirst{
+    if (!npmExists) {
+      throw new GradleException("npm not found. Cannot generate JSDoc.")
+    }
   }
-}
-
-task jsdoc(type: Exec){
   workingDir 'gateways/js'
   executable npmcmd
   args = ['run', 'docs']
 }
 
-task updatexterm {
+tasks.register('updatexterm') {
+  doFirst{
+    if (!npmExists) {
+      throw new GradleException("npm not found. Cannot update xterm.")
+    }
+  }
   doLast {
     // create package.json with `{}` if it does not exist
     if (!file('package.json').exists()) {
@@ -163,15 +125,54 @@ task updatexterm {
       args 'install', '@xterm/xterm@5.5.0', '@xterm/addon-attach@0.11.0', '@xterm/addon-fit@0.10.0', '@xterm/addon-web-links@0.11.0'
     }
     copy {
-      from (['node_modules/@xterm/addon-web-links/lib', 'node_modules/@xterm/addon-attach/lib', 'node_modules/@xterm/addon-fit/lib', 'node_modules/@xterm/xterm/lib']) {
+      from(['node_modules/@xterm/addon-web-links/lib', 'node_modules/@xterm/addon-attach/lib', 'node_modules/@xterm/addon-fit/lib', 'node_modules/@xterm/xterm/lib']) {
         include '*.js'
       }
-      from ('node_modules/@xterm/xterm/css'){
+      from('node_modules/@xterm/xterm/css') {
         include 'xterm.css'
       }
       into 'src/main/resources/org/arl/fjage/web/shell'
     }
     delete "node_modules", "package.json", "package-lock.json"
+  }
+}
+
+jar {
+  manifest {
+    attributes (
+        "Build-Owner": System.getenv().USER ?: "fjage",
+        "Build-Timestamp": new Date().format('d-MM-yyyy_HH:mm:ss'),
+        "Build-Version": "${project.version}/${commit}")
+  }
+}
+
+processResources {
+  exclude '**/readme.md'
+  with copySpec {
+    from { tasks.named('buildjs').get()?.outputs?.files?.asFileTree?.matching {include 'dist/fjage.js'} ?: [] }
+    into('org/arl/fjage/web/shell')
+  }
+}
+
+test {
+  dependsOn 'buildjs'
+  systemProperties project.properties.subMap(["manualJSTest"])
+  systemProperties project.properties.subMap(["manualPyTest"])
+  systemProperties project.properties.subMap(["manualCTest"])
+  testLogging {
+    events "passed", "skipped", "failed"
+    exceptionFormat "full"
+  }
+}
+
+javadoc {
+  options.addStringOption('Xdoclint:none', '-quiet')
+  doLast {
+    mkdir 'docs/javadoc'
+    copy {
+      from javadoc.destinationDir
+      into 'docs/javadoc'
+    }
   }
 }
 

--- a/gateways/js/.gitignore
+++ b/gateways/js/.gitignore
@@ -2,4 +2,3 @@ node_modules
 test/spec/fjageSpec.cjs
 test/spec/fjageSpec.mjs
 dist/*
-!dist/esm/fjage.js

--- a/src/main/resources/org/arl/fjage/web/fjage.js
+++ b/src/main/resources/org/arl/fjage/web/fjage.js
@@ -1,1 +1,0 @@
-../../../../../../../gateways/js/dist/esm/fjage.js


### PR DESCRIPTION
This commit https://github.com/org-arl/fjage/commit/4107d9a6a5a20f859f1c257d283b7af26dc97931 accidentaly removed the fjage.js distribution files `gateways/js/dist/fjage.js` from the repo. That caused the fjage build to break : #365 


This PR fixes the build by adding `gateways/js/dist/fjage.js` into the fjage jar at build time instead of the symlink we had before. This allows the fjage.js file to be built by the `buildjs` task instead of having it in the repo.

In the case of not having `npm` or the fjage.js build failing, a warning is printed out during the build process, but the jar is still created. This fallback allows someone without `npm` installed on their system to be able to still build and use fjage.

**Aside : This PR also removes the `./gradlew lite` build option which built the jar without the web shell resources. Instead the the default gradle task will automatically detect and build a jar without failing.**
