### PR TITLE
Use UUID7 

### DIFF
--- a/gateways/js/src/message.js
+++ b/gateways/js/src/message.js
@@ -1,5 +1,5 @@
 import { Performative } from './performative.js';
-import { _guid } from './utils.js';
+import { UUID7 } from './utils.js';
 import { AgentID } from './agentid.js';  // import AgentID class for type checking. Remove if not needed.
 
 /**
@@ -21,7 +21,7 @@ export class Message {
   */
   constructor(inReplyToMsg, perf=Performative.INFORM) {
     this.__clazz__ = 'org.arl.fjage.Message';
-    this.msgID = _guid(8);
+    this.msgID = UUID7.generate().toString();
     this.perf = perf;
     this.sender = null;
     this.recipient = inReplyToMsg ? inReplyToMsg.sender : null;

--- a/gateways/js/src/utils.js
+++ b/gateways/js/src/utils.js
@@ -10,3 +10,106 @@ export function _guid(len) {
   const s4 = () => Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
   return Array.from({ length: len }, s4).join('');
 }
+
+
+/**
+ * A simple and lightweight implementation of UUIDv7.
+ *
+ * UUIDv7 is a time-based UUID version that is lexicographically sortable and
+ * is designed to be used as a database key.
+ *
+ * The structure is as follows:
+ * 0                   1                   2                   3
+ * 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                           unix_ts_ms                          |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |          unix_ts_ms           |  ver  |      rand_a           |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |var|                        rand_b                             |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                            rand_b                             |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ * - unix_ts_ms (48 bits): Unix timestamp in milliseconds.
+ * - ver (4 bits): Version, set to 7.
+ * - rand_a (12 bits): Random data.
+ * - var (2 bits): Variant, set to '10'.
+ * - rand_b (62 bits): Random data.
+ */
+export class UUID7 {
+    /**
+     * Private constructor to create a UUID7 from a byte array.
+     * @param {Uint8Array} bytes The 16 bytes of the UUID.
+     */
+    constructor(bytes) {
+        if (bytes.length !== 16) {
+            throw new Error('UUID7 must be constructed with a 16-byte array.');
+        }
+        this.bytes = bytes;
+    }
+
+    /**
+     * Generates a new UUIDv7.
+     * @returns {UUID7} A new UUIDv7 instance.
+     */
+    static generate() {
+        const bytes = new Uint8Array(16);
+        const randomBytes = crypto.getRandomValues(new Uint8Array(10));
+        const timestamp = Date.now();
+
+        // Set the 48-bit timestamp
+        // JavaScript numbers are 64-bit floats, but bitwise operations treat them
+        // as 32-bit signed integers. We need to handle the 48-bit timestamp carefully.
+        const timestampHi = Math.floor(timestamp / 2 ** 16);
+        const timestampLo = timestamp % 2 ** 16;
+
+        bytes[0] = (timestampHi >> 24) & 0xff;
+        bytes[1] = (timestampHi >> 16) & 0xff;
+        bytes[2] = (timestampHi >> 8) & 0xff;
+        bytes[3] = timestampHi & 0xff;
+        bytes[4] = (timestampLo >> 8) & 0xff;
+        bytes[5] = timestampLo & 0xff;
+
+        // Copy the 10 random bytes
+        bytes.set(randomBytes, 6);
+
+        // Set the 4-bit version (0111) in byte 6
+        bytes[6] = (bytes[6] & 0x0f) | 0x70;
+
+        // Set the 2-bit variant (10) in byte 8
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+        return new UUID7(bytes);
+    }
+
+    /**
+     * Extracts the timestamp from the UUID.
+     * @returns {number} The Unix timestamp in milliseconds.
+     */
+    getTimestamp() {
+        let timestamp = 0;
+        timestamp = this.bytes[0] * 2 ** 40;
+        timestamp += this.bytes[1] * 2 ** 32;
+        timestamp += this.bytes[2] * 2 ** 24;
+        timestamp += this.bytes[3] * 2 ** 16;
+        timestamp += this.bytes[4] * 2 ** 8;
+        timestamp += this.bytes[5];
+        return timestamp;
+    }
+
+    /**
+     * Formats the UUID into the standard string representation.
+     * @returns {string} The UUID string.
+     */
+    toString() {
+        let result = '';
+        for (let i = 0; i < 16; i++) {
+            result += this.bytes[i].toString(16).padStart(2, '0');
+            if (i === 3 || i === 5 || i === 7 || i === 9) {
+                result += '-';
+            }
+        }
+        return result;
+    }
+}

--- a/gateways/js/test/spec/fjage.spec.js
+++ b/gateways/js/test/spec/fjage.spec.js
@@ -60,7 +60,7 @@ function fjageMessageChecker() {
 
       if (!msg.message.data) return ret;
 
-      ret = ret && !!msg.message.data.msgID && msg.message.data.msgID.length == 32;
+      ret = ret && !!msg.message.data.msgID && msg.message.data.msgID.length >= 32;
       ret = ret && !!msg.message.data.sender;
       ret = ret && !!msg.message.data.recipient;
       ret = ret && msg.message.data.perf && ValidFjagePerformatives.includes(msg.message.data.perf);
@@ -89,7 +89,7 @@ function ShellExecReqChecker() {
       ret = ret && !!msg.message;
       ret = ret && msg.message.clazz == 'org.arl.fjage.shell.ShellExecReq';
       ret = ret && !!msg.message.data;
-      ret = ret && !!msg.message.data.msgID && msg.message.data.msgID.length == 32;
+      ret = ret && !!msg.message.data.msgID && msg.message.data.msgID.length >= 32;
       ret = ret && !!msg.message.data.sender;
       ret = ret && !!msg.message.data.recipient;
       ret = ret && msg.message.data.perf && ValidFjagePerformatives.includes(msg.message.data.perf);

--- a/gateways/python/fjagepy/UUID7.py
+++ b/gateways/python/fjagepy/UUID7.py
@@ -1,0 +1,95 @@
+import time
+import os
+import uuid
+from functools import total_ordering
+
+@total_ordering
+class UUID7:
+    """
+    A simple and lightweight implementation of UUIDv7 in Python.
+
+    UUIDv7 is a time-based UUID version that is lexicographically sortable and
+    is designed to be used as a database key.
+
+    The structure is as follows:
+    - 48-bit Unix timestamp in milliseconds.
+    - 4-bit version, set to 7.
+    - 12 bits of random data.
+    - 2-bit variant, set to '10'.
+    - 62 bits of random data.
+    """
+
+    def __init__(self, bytes_val):
+        """
+        Private constructor to create a UUID7 from a 16-byte value.
+        :param bytes_val: The 16 bytes of the UUID.
+        """
+        if len(bytes_val) != 16:
+            raise ValueError("UUID7 must be constructed with a 16-byte value.")
+        self._bytes = bytes_val
+
+    @classmethod
+    def generate(cls):
+        """
+        Generates a new UUIDv7.
+        :return: A new UUID7 instance.
+        """
+        # Get the current time in milliseconds since the Unix epoch
+        timestamp_ms = int(time.time() * 1000)
+
+        # Generate 10 random bytes (80 bits)
+        random_bytes = os.urandom(10)
+
+        # Create a 16-byte array
+        uuid_bytes = bytearray(16)
+
+        # Set the 48-bit timestamp
+        uuid_bytes[0:6] = timestamp_ms.to_bytes(6, 'big')
+
+        # Set the 4-bit version (0111) and the first 4 random bits
+        uuid_bytes[6] = 0x70 | (random_bytes[0] & 0x0F)
+
+        # Set the rest of the first random part
+        uuid_bytes[7] = random_bytes[1]
+
+        # Set the 2-bit variant (10) and the first 6 random bits of the second part
+        uuid_bytes[8] = 0x80 | (random_bytes[2] & 0x3F)
+
+        # Set the remaining random bytes
+        uuid_bytes[9:16] = random_bytes[3:]
+
+        return cls(bytes(uuid_bytes))
+
+    def get_timestamp(self):
+        """
+        Extracts the timestamp from the UUID.
+        :return: The Unix timestamp in milliseconds.
+        """
+        return int.from_bytes(self._bytes[0:6], 'big')
+
+    def to_uuid(self):
+        """
+        Converts this UUID7 to a standard uuid.UUID object.
+        :return: A uuid.UUID instance.
+        """
+        return uuid.UUID(bytes=self._bytes)
+
+    def __str__(self):
+        """
+        Formats the UUID into the standard string representation.
+        :return: The UUID string.
+        """
+        return str(self.to_uuid())
+
+    def __repr__(self):
+        return f"UUID7('{str(self)}')"
+
+    def __eq__(self, other):
+        if not isinstance(other, UUID7):
+            return NotImplemented
+        return self._bytes == other._bytes
+
+    def __lt__(self, other):
+        if not isinstance(other, UUID7):
+            return NotImplemented
+        return self._bytes < other._bytes

--- a/gateways/python/fjagepy/__init__.py
+++ b/gateways/python/fjagepy/__init__.py
@@ -8,6 +8,7 @@ import base64 as _base64
 import struct as _struct
 import time as _time
 from warnings import warn as _warn
+from .UUID7 import UUID7
 
 
 def _current_time_millis():
@@ -278,7 +279,7 @@ class Message(object):
 
     def __init__(self, inReplyTo=None, perf=Performative.INFORM, **kwargs):
         self.__clazz__ = 'org.arl.fjage.Message'
-        self.msgID = str(_uuid.uuid4())
+        self.msgID = str(UUID7.generate())
         self.perf = perf
         self.recipient = None
         self.sender = None
@@ -525,7 +526,7 @@ class GenericMessage(Message):
 
     def __init__(self, **kwargs):
         self.__clazz__ = 'org.arl.fjage.GenericMessage'
-        self.msgID = str(_uuid.uuid4())
+        self.msgID = str(UUID7.generate())
         self.perf = None
         self.recipient = None
         self.sender = None
@@ -598,8 +599,6 @@ class Gateway:
         """
         req = _json.loads(rmsg, object_hook=_decode_base64)
         rsp = dict()
-        if "id" in req:
-            req['id'] = _uuid.UUID(req['id'])
         if "action" in req:
             if req["action"] == Action.AGENTS:
                 rsp["inResponseTo"] = req["action"]
@@ -914,8 +913,8 @@ class Gateway:
         :param service: the named service of interest.
         :returns: an agent id for an agent that provides the service.
         """
-        req_id = _uuid.uuid4()
-        rq = {'action': Action.AGENT_FOR_SERVICE, 'service': service, 'id': str(req_id)}
+        req_id = str(UUID7.generate())
+        rq = {'action': Action.AGENT_FOR_SERVICE, 'service': service, 'id': req_id}
         self.socket.sendall((_json.dumps(rq, cls=_CustomEncoder) + '\n').encode())
         res_event = _td.Event()
         self.pending[req_id] = (res_event, None)
@@ -941,10 +940,10 @@ class Gateway:
         :param service: the named service of interest.
         :returns: a list of agent ids representing all agent that provide the service.
         """
-        req_id = _uuid.uuid4()
+        req_id = str(UUID7.generate())
         j_dict = dict()
         j_dict["action"] = Action.AGENTS_FOR_SERVICE
-        j_dict["id"] = str(req_id)
+        j_dict["id"] = req_id
         if isinstance(service, str):
             j_dict["service"] = service
         else:
@@ -975,10 +974,10 @@ class Gateway:
         return self.aid
 
     def _is_duplicate(self):
-        req_id = _uuid.uuid4()
+        req_id = str(UUID7.generate())
         req = dict()
         req["action"] = Action.CONTAINS_AGENT
-        req["id"] = str(req_id)
+        req["id"] = req_id
         req["agentID"] = self.aid.name
         self.socket.sendall((_json.dumps(req, cls=_CustomEncoder) + '\n').encode())
         res_event = _td.Event()

--- a/src/main/java/org/arl/fjage/Message.java
+++ b/src/main/java/org/arl/fjage/Message.java
@@ -10,10 +10,7 @@ for full license details.
 
 package org.arl.fjage;
 
-import org.arl.fjage.remote.JsonMessage;
-
 import java.io.Serializable;
-import java.util.UUID;
 
 /**
  * Base class for messages transmitted by one agent to another. This class provides
@@ -30,7 +27,7 @@ public class Message implements Serializable {
 
   //////////// Private attributes
 
-  protected String msgID = UUID.randomUUID().toString();
+  protected String msgID = UUID7.generate().toString();
   protected Performative perf;
   protected AgentID recipient;
   protected AgentID sender = null;

--- a/src/main/java/org/arl/fjage/UUID7.java
+++ b/src/main/java/org/arl/fjage/UUID7.java
@@ -1,0 +1,147 @@
+package org.arl.fjage;
+
+import java.io.Serializable;
+import java.security.SecureRandom;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * A simple and lightweight implementation of UUIDv7 that is compatible with Java 8.
+ *
+ * <p>UUIDv7 is a time-based UUID version that is lexicographically sortable and contains a
+ * timestamp.
+ *
+ * <p>The structure of a UUIDv7 is as follows:
+ *
+ * <pre>
+ * 0                   1                   2                   3
+ * 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                           unix_ts_ms                          |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |          unix_ts_ms           |  ver  |      rand_a           |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |var|                        rand_b                             |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                            rand_b                             |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * </pre>
+ *
+ * <ul>
+ * <li><b>unix_ts_ms (48 bits):</b> The Unix timestamp in milliseconds.
+ * <li><b>ver (4 bits):</b> The version number, which is 7.
+ * <li><b>rand_a (12 bits):</b> Random bits.
+ * <li><b>var (2 bits):</b> The variant, which is '10'.
+ * <li><b>rand_b (62 bits):</b> More random bits.
+ * </ul>
+ */
+public final class UUID7 implements Comparable<UUID7>, Serializable {
+
+  private static final long serialVersionUID = -1234567890123456789L;
+  private final long mostSigBits;
+  private final long leastSigBits;
+
+  private static final class Holder {
+    static final SecureRandom numberGenerator = new SecureRandom();
+  }
+
+  /**
+   * Private constructor to create a UUID7 from the most and least significant bits.
+   *
+   * @param mostSigBits The most significant 64 bits of the UUID.
+   * @param leastSigBits The least significant 64 bits of the UUID.
+   */
+  private UUID7(long mostSigBits, long leastSigBits) {
+    this.mostSigBits = mostSigBits;
+    this.leastSigBits = leastSigBits;
+  }
+
+  /**
+   * Generates a new UUIDv7.
+   *
+   * @return A new UUIDv7 instance.
+   */
+  public static UUID7 generate() {
+    final long timestamp = System.currentTimeMillis();
+    final byte[] randomBytes = new byte[10]; // 74 bits of random data
+    Holder.numberGenerator.nextBytes(randomBytes);
+
+    // 48-bit timestamp
+    long mostSigBits = timestamp << 16;
+
+    // 4-bit version and 12-bit rand_a
+    mostSigBits |= 0x7000; // Version 7
+    mostSigBits |= ((long) (randomBytes[0] & 0xFF)) << 4 | ((long) (randomBytes[1] & 0xF0) >> 4);
+
+
+    // 2-bit variant and 62-bit rand_b
+    long leastSigBits = 0x8000000000000000L; // Variant '10'
+    leastSigBits |= ((long) (randomBytes[1] & 0x0F)) << 60;
+    leastSigBits |= ((long) (randomBytes[2] & 0xFF)) << 52;
+    leastSigBits |= ((long) (randomBytes[3] & 0xFF)) << 44;
+    leastSigBits |= ((long) (randomBytes[4] & 0xFF)) << 36;
+    leastSigBits |= ((long) (randomBytes[5] & 0xFF)) << 28;
+    leastSigBits |= ((long) (randomBytes[6] & 0xFF)) << 20;
+    leastSigBits |= ((long) (randomBytes[7] & 0xFF)) << 12;
+    leastSigBits |= ((long) (randomBytes[8] & 0xFF)) << 4;
+    leastSigBits |= ((long) (randomBytes[9] & 0xFF)) >> 4;
+
+
+    return new UUID7(mostSigBits, leastSigBits);
+  }
+
+  /**
+   * Creates a UUID7 from a standard java.util.UUID.
+   *
+   * @param uuid The UUID to convert.
+   * @return A new UUID7 instance.
+   */
+  public static UUID7 fromUUID(UUID uuid) {
+    return new UUID7(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+  }
+
+  /**
+   * Returns the timestamp embedded in this UUIDv7.
+   *
+   * @return The timestamp in milliseconds since the Unix epoch.
+   */
+  public long getTimestamp() {
+    return mostSigBits >> 16;
+  }
+
+  /**
+   * Converts this UUIDv7 to a standard java.util.UUID.
+   *
+   * @return A java.util.UUID representation of this UUIDv7.
+   */
+  public UUID toUUID() {
+    return new UUID(this.mostSigBits, this.leastSigBits);
+  }
+
+  @Override
+  public int compareTo(UUID7 o) {
+    int result = Long.compare(this.mostSigBits, o.mostSigBits);
+    if (result == 0) {
+      result = Long.compare(this.leastSigBits, o.leastSigBits);
+    }
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    UUID7 uuid7 = (UUID7) o;
+    return mostSigBits == uuid7.mostSigBits && leastSigBits == uuid7.leastSigBits;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mostSigBits, leastSigBits);
+  }
+
+  @Override
+  public String toString() {
+    return toUUID().toString();
+  }
+}


### PR DESCRIPTION
We need UUID when creating new `Message.msgID` and `JSONMessage.id` for fjage. Historically we used various UUID/GUID implementations mainly from standard library but sometimes custom. The main requirement is uniqueness across all messages send in a single fjage "universe".

While the previous implementations of UUID/GUID were sufficient for that, the new (and upcoming) UUID7 standard has a couple of useful features. 

- Since the MSB of the UUID7 is a millisecond level timestamp, it's easy to sort messages using the `msgID`.
- Since the MSB of the UUID7 is a millisecond level timestamp, we can use the timestamp to know when messages were created. This could be useful for collecting metrics and logging how long messages stayed in queues etc. 

See more : http://uuid7.com/