### PR TITLE
Add `APPLICATION_CURSOR` mode to console shell by default

### DIFF
--- a/src/main/java/org/arl/fjage/shell/ConsoleShell.java
+++ b/src/main/java/org/arl/fjage/shell/ConsoleShell.java
@@ -33,6 +33,7 @@ public class ConsoleShell implements Shell, ConnectionListener {
 
   private static final String FORCE_BRACKETED_PASTE_ON = "FORCE_BRACKETED_PASTE_ON";
   private static final String BRACKETED_PASTE_ON = "\033[?2004h";
+  private static final String APPLICATION_CURSOR = "\033[?1h";
   private final Logger log = Logger.getLogger(getClass().getName());
   private Terminal term = null;
   private LineReader console = null;
@@ -170,6 +171,8 @@ public class ConsoleShell implements Shell, ConnectionListener {
       console.setOpt(LineReader.Option.ERASE_LINE_ON_FINISH);
       console.getWidgets().put(FORCE_BRACKETED_PASTE_ON, () -> {
         console.getTerminal().writer().write(BRACKETED_PASTE_ON);
+        console.getTerminal().writer().write(APPLICATION_CURSOR);
+        console.getTerminal().flush();
         return true;
       });
     }

--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -181,7 +181,7 @@
           theme = window.matchMedia ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : 'light';
           schemeToggleBnt.addEventListener('click', evt => {
             setScheme(term, currentScheme == 'dark' ? 'light' : 'dark', true);
-          })
+          });
         }
       } catch {
         // If we can't access the parent document (e.g., cross-origin, or not in an iframe),

--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -177,6 +177,11 @@
         if (window.frameElement && window.frameElement.dataset) {
           theme = window.frameElement.dataset.prefersColorScheme;
           if (theme != null) schemeToggleBnt.parentElement.style.display = 'none';
+        } else {
+          theme = window.matchMedia ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : 'light';
+          schemeToggleBnt.addEventListener('click', evt => {
+            setScheme(term, currentScheme == 'dark' ? 'light' : 'dark', true);
+          })
         }
       } catch {
         // If we can't access the parent document (e.g., cross-origin, or not in an iframe),


### PR DESCRIPTION
Without the `APPLICATION_CURSOR` mode, the terminal (xterm.js) seems to not allow a cursor (right-arrow key) in the first line before either the line/prompt is redrawn.

So this PR forces the Shell to sending the "Cursor key mode" escape sequence at connection time so that the user can use the Autosuggestion widget to complete a suggestion even on the first line.