### PR TITLE
fix(store): Avoid race condition when creating store folder

### DIFF
--- a/src/main/java/org/arl/fjage/persistence/Store.java
+++ b/src/main/java/org/arl/fjage/persistence/Store.java
@@ -109,7 +109,7 @@ public class Store implements Closeable {
   public void put(Serializable obj) {
     if (root == null) throw new FjageException("Store has been closed");
     File d = new File(root, obj.getClass().getName());
-    if (!d.exists() && !d.mkdirs()) throw new FjageException("Cannot create directory " + d);
+    if (!d.mkdirs() && !d.exists()) throw new FjageException("Cannot create directory " + d);
     File f = new File(d, getId(obj));
     FileOutputStream fout = null;
     ObjectOutputStream out = null;


### PR DESCRIPTION
The current logic for creating a store folder is this: 

https://github.com/org-arl/fjage/blob/9d66d364a6e54f13abcfc1faf433605569dcdf70/src/main/java/org/arl/fjage/persistence/Store.java#L111-L112

This code throws a spurious exception if `d` is created between the `d.exists()` and `d.mkdirs()` calls. This can happen e.g. if you run multiple fjage instances from the same project folder. (I've actually seen this in practice in unet-sim!) This PR fixes this race condition by swapping the order of the statements. 