### PR TITLE
fix(ws): Set closeOnDead flag for WebSocket connections

### DIFF
--- a/src/main/java/org/arl/fjage/remote/ConnectionHandler.java
+++ b/src/main/java/org/arl/fjage/remote/ConnectionHandler.java
@@ -48,7 +48,7 @@ public class ConnectionHandler extends Thread {
     setName(conn.toString());
     alive = false;
     keepAlive = true;
-    closeOnDead = (conn instanceof TcpConnector) && (container instanceof MasterContainer);
+    closeOnDead = ((conn instanceof TcpConnector) || (conn instanceof WebSocketConnector)) && (container instanceof MasterContainer);
   }
 
   public ConnectionHandler(Connector conn, RemoteContainer container, Firewall fw) {
@@ -58,7 +58,7 @@ public class ConnectionHandler extends Thread {
     setName(conn.toString());
     alive = false;
     keepAlive = true;
-    closeOnDead = (conn instanceof TcpConnector) && (container instanceof MasterContainer);
+    closeOnDead = ((conn instanceof TcpConnector) || (conn instanceof WebSocketConnector)) && (container instanceof MasterContainer);
   }
 
   /**


### PR DESCRIPTION
See title. This is the minimum-change fix to improve the handling of WebSocket connections. Might we worth moving this logic from `ConnectionHandler` to `Connector` at some point to reduce coupling between components. 