### PR TITLE
fix(ws): Log WebSocket EofExceptions at info level

### DIFF
--- a/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
+++ b/src/main/java/org/arl/fjage/connectors/WebSocketConnector.java
@@ -55,6 +55,10 @@ public class WebSocketConnector implements Connector{
 
     @OnWebSocketError
     public void onWebSocketError(Throwable cause)  {
+        if (cause instanceof org.eclipse.jetty.io.EofException) {
+            log.info(cause.toString());
+            return;
+        }
         log.log(Level.WARNING, "WebSocket error: ", cause);
     }
 

--- a/src/main/java/org/arl/fjage/connectors/WebSocketHubConnector.java
+++ b/src/main/java/org/arl/fjage/connectors/WebSocketHubConnector.java
@@ -231,8 +231,12 @@ public class WebSocketHubConnector implements Connector, WebSocketCreator {
     }
 
     @OnWebSocketError
-    public void onError(Throwable t) {
-      log.warning(t.toString());
+    public void onWebSocketError(Throwable cause)  {
+      if (cause instanceof org.eclipse.jetty.io.EofException) {
+        log.info(cause.toString());
+        return;
+      }
+      log.log(Level.WARNING, "WebSocket error: ", cause);
     }
 
     @OnWebSocketMessage


### PR DESCRIPTION
Downgrades logging of Jetty WebSocket `EofException`s from `WARNING` to `INFO`. @notthetup suggested on [Discord](https://discord.com/channels/1071020492070342736/1071215948574490715/1445225663316361399) to log these errors at `FINE` instead, but given that atm we log any WebSocket connect / disconnect event at `INFO`, logging this error at `INFO` level seems appropriate. 