### PR TITLE
Serialise Instant as ISO 8601 string, Duration as number of milliseconds, and allow registering of custom TypeAdapterFactories

### DIFF
--- a/src/main/java/org/arl/fjage/remote/DurationTypeAdapter.java
+++ b/src/main/java/org/arl/fjage/remote/DurationTypeAdapter.java
@@ -1,0 +1,27 @@
+package org.arl.fjage.remote;
+
+import java.time.Duration;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.stream.JsonToken;
+
+public class DurationTypeAdapter extends TypeAdapter<Duration> {
+  @Override
+  public void write(JsonWriter out, Duration value) throws java.io.IOException {
+    if (value == null) {
+      out.nullValue();
+      return;
+    }
+    out.value(value.toMillis());
+  }
+  @Override
+  public Duration read(JsonReader in) throws java.io.IOException {
+    if (in.peek() == JsonToken.NULL) {
+      in.nextNull();
+      return null;
+    }
+    return Duration.ofMillis(in.nextLong());
+  }
+}

--- a/src/main/java/org/arl/fjage/remote/InstantTypeAdapter.java
+++ b/src/main/java/org/arl/fjage/remote/InstantTypeAdapter.java
@@ -1,0 +1,27 @@
+package org.arl.fjage.remote;
+
+import java.time.Instant;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.stream.JsonToken;
+
+public class InstantTypeAdapter extends TypeAdapter<Instant> {
+  @Override
+  public void write(JsonWriter out, Instant value) throws java.io.IOException {
+    if (value == null) {
+      out.nullValue();
+      return;
+    }
+    out.value(value.toString());
+  }
+  @Override
+  public Instant read(JsonReader in) throws java.io.IOException {
+    if (in.peek() == JsonToken.NULL) {
+      in.nextNull();
+      return null;
+    }
+    return Instant.parse(in.nextString());
+  }
+}

--- a/src/main/java/org/arl/fjage/remote/JsonMessage.java
+++ b/src/main/java/org/arl/fjage/remote/JsonMessage.java
@@ -54,7 +54,7 @@ public class JsonMessage {
           out.nullValue();
           return;
         }
-        out.value(value.toEpochMilli());
+        out.value(value.toString());
       }
       @Override
       public Instant read(JsonReader in) throws java.io.IOException {
@@ -62,7 +62,7 @@ public class JsonMessage {
           in.nextNull();
           return null;
         }
-        return Instant.ofEpochMilli(in.nextLong());
+        return Instant.parse(in.nextString());
       }
     })
     .registerTypeAdapter(Duration.class, new TypeAdapter<Duration>() {

--- a/src/main/java/org/arl/fjage/remote/JsonMessage.java
+++ b/src/main/java/org/arl/fjage/remote/JsonMessage.java
@@ -47,42 +47,8 @@ public class JsonMessage {
     .registerTypeAdapter(Double.class, (JsonSerializer<Double>) (value, type, jsonSerializationContext) -> value.isNaN()?null:new JsonPrimitive(value))
     .registerTypeAdapter(Date.class, (JsonDeserializer<Date>) (json, typeOfT, context) -> new Date(json.getAsJsonPrimitive().getAsLong()))
     .registerTypeAdapter(Date.class, (JsonSerializer<Date>) (date, type, jsonSerializationContext) -> new JsonPrimitive(date.getTime()))
-    .registerTypeAdapter(Instant.class, new TypeAdapter<Instant>() {
-      @Override
-      public void write(JsonWriter out, Instant value) throws java.io.IOException {
-        if (value == null) {
-          out.nullValue();
-          return;
-        }
-        out.value(value.toString());
-      }
-      @Override
-      public Instant read(JsonReader in) throws java.io.IOException {
-        if (in.peek() == JsonToken.NULL) {
-          in.nextNull();
-          return null;
-        }
-        return Instant.parse(in.nextString());
-      }
-    })
-    .registerTypeAdapter(Duration.class, new TypeAdapter<Duration>() {
-      @Override
-      public void write(JsonWriter out, Duration value) throws java.io.IOException {
-        if (value == null) {
-          out.nullValue();
-          return;
-        }
-        out.value(value.toMillis());
-      }
-      @Override
-      public Duration read(JsonReader in) throws java.io.IOException {
-        if (in.peek() == JsonToken.NULL) {
-          in.nextNull();
-          return null;
-        }
-        return Duration.ofMillis(in.nextLong());
-      }
-    })
+    .registerTypeAdapter(Instant.class, new InstantTypeAdapter())
+    .registerTypeAdapter(Duration.class, new DurationTypeAdapter())
     .registerTypeHierarchyAdapter(AgentID.class, new AgentIDAdapter())
     .registerTypeHierarchyAdapter(Parameter.class, new EnumTypeAdapter())
     .registerTypeAdapterFactory(new MessageAdapterFactory())

--- a/src/main/java/org/arl/fjage/remote/JsonMessage.java
+++ b/src/main/java/org/arl/fjage/remote/JsonMessage.java
@@ -11,7 +11,12 @@ for full license details.
 package org.arl.fjage.remote;
 
 import java.util.Date;
+import java.time.Instant;
+import java.time.Duration;
 import com.google.gson.*;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.stream.JsonToken;
 import org.arl.fjage.AgentID;
 import org.arl.fjage.Message;
 import org.arl.fjage.param.Parameter;
@@ -42,6 +47,42 @@ public class JsonMessage {
     .registerTypeAdapter(Double.class, (JsonSerializer<Double>) (value, type, jsonSerializationContext) -> value.isNaN()?null:new JsonPrimitive(value))
     .registerTypeAdapter(Date.class, (JsonDeserializer<Date>) (json, typeOfT, context) -> new Date(json.getAsJsonPrimitive().getAsLong()))
     .registerTypeAdapter(Date.class, (JsonSerializer<Date>) (date, type, jsonSerializationContext) -> new JsonPrimitive(date.getTime()))
+    .registerTypeAdapter(Instant.class, new TypeAdapter<Instant>() {
+      @Override
+      public void write(JsonWriter out, Instant value) throws java.io.IOException {
+        if (value == null) {
+          out.nullValue();
+          return;
+        }
+        out.value(value.toEpochMilli());
+      }
+      @Override
+      public Instant read(JsonReader in) throws java.io.IOException {
+        if (in.peek() == JsonToken.NULL) {
+          in.nextNull();
+          return null;
+        }
+        return Instant.ofEpochMilli(in.nextLong());
+      }
+    })
+    .registerTypeAdapter(Duration.class, new TypeAdapter<Duration>() {
+      @Override
+      public void write(JsonWriter out, Duration value) throws java.io.IOException {
+        if (value == null) {
+          out.nullValue();
+          return;
+        }
+        out.value(value.toMillis());
+      }
+      @Override
+      public Duration read(JsonReader in) throws java.io.IOException {
+        if (in.peek() == JsonToken.NULL) {
+          in.nextNull();
+          return null;
+        }
+        return Duration.ofMillis(in.nextLong());
+      }
+    })
     .registerTypeHierarchyAdapter(AgentID.class, new AgentIDAdapter())
     .registerTypeHierarchyAdapter(Parameter.class, new EnumTypeAdapter())
     .registerTypeAdapterFactory(new MessageAdapterFactory())

--- a/src/main/java/org/arl/fjage/remote/JsonMessage.java
+++ b/src/main/java/org/arl/fjage/remote/JsonMessage.java
@@ -100,6 +100,11 @@ public class JsonMessage {
     gson = gsonBuilder.create();
   }
 
+  public static void addTypeAdapterFactory(TypeAdapterFactory factory) {
+    gsonBuilder.registerTypeAdapterFactory(factory);
+    gson = gsonBuilder.create();
+  }
+
   public static JsonMessage fromJson(String s) {
     return gson.fromJson(s, JsonMessage.class);
   }


### PR DESCRIPTION
This PR bundles two unrelated changes. 

#### Serialisation of Instant and Duration

By default, Gson serialises `java.time.Instant` and `java.time.Duration` objects as JSON objects with `seconds` and `nanos` fields (same JSON format for both Java classes). 

```
{ "seconds": ..., "nanos": ... }
```

This representation feels needlessly Java-specific. This PR proposes to serialise `Instant` values as ISO 8601 strings (`"2026-03-23T05:20:06.323Z"`), and `Duration` values as number of milliseconds (`1000` == 1 second) instead. The rationale behind this is that ISO 8601 strings are instantly human-readable and easily parsable in any reasonable language (including C), and fjage already uses milliseconds in many places to represent durations. 

#### Support custom type adapter factories

Fjage already supports registering of custom type hierarchy adapters, but not type adapter factories. I'm assuming the only reason for this is that so far no one had a need for type adapter factories, but now I do. Therefore, I've added a new method `JsonMessage.addTypeAdapterFactory()`. 