### PR TITLE
Tunnels - fjåge version of UnetStack wormholes

### DIFF
--- a/src/main/java/org/arl/fjage/connectors/TcpConnector.java
+++ b/src/main/java/org/arl/fjage/connectors/TcpConnector.java
@@ -93,11 +93,8 @@ public class TcpConnector implements Connector {
 
   @Override
   public String[] connections() {
-      if (sock == null || sock.isClosed()){
-        return new String[0];
-      }else {
-        return new String[] { sock.getInetAddress().getHostAddress()+":"+sock.getPort() };
-      }
+    if (sock == null || sock.isClosed()) return new String[0];
+    return new String[] { sock.getInetAddress().getHostAddress()+":"+sock.getPort() };
   }
 
   @Override

--- a/src/main/java/org/arl/fjage/remote/Tunnel.java
+++ b/src/main/java/org/arl/fjage/remote/Tunnel.java
@@ -1,0 +1,266 @@
+package org.arl.fjage.remote;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.io.*;
+import org.arl.fjage.*;
+import org.arl.fjage.param.*;
+import org.arl.fjage.remote.JsonMessage;
+import org.arl.fjage.connectors.*;
+
+/**
+ * An agent that serves as a tunnel for messages between two fjage platforms.
+ */
+public class Tunnel extends Agent implements ConnectionListener, MessageListener {
+
+  //// private attributes
+
+  protected final static long MONITOR_PERIOD = 5000;
+
+  protected String ip;
+  protected int port;
+
+  protected TcpServer server = null;
+  protected List<AgentID> agents = new ArrayList<>();
+  protected List<Connector> connectors = new ArrayList<>();
+  protected ExecutorService executor = null;
+  protected int connID = 0;
+  protected Map<Integer,Connector> connIDs = new HashMap<>();
+
+  //// constructors
+
+  public Tunnel(int port) {
+    this.ip = null;
+    this.port = port;
+  }
+
+  public Tunnel(String ip, int port) {
+    this.ip = ip;
+    this.port = port;
+  }
+
+  //// agent methods
+
+  @Override
+  public void init() {
+    log.info("Agent "+getName()+" init");
+    executor = Executors.newFixedThreadPool(2);
+    add(new ParameterMessageBehavior(TunnelParam.class));
+    if (ip == null) server = new TcpServer(port, this);
+    else add(new TickerBehavior(MONITOR_PERIOD) {
+      @Override
+      public void onTick() {
+        synchronized (connectors) {
+          if (connectors.isEmpty()) connect();
+        }
+      }
+    });
+    getContainer().addListener(this);
+  }
+
+  @Override
+  public void shutdown() {
+    log.info("Agent "+getName()+" shutdown");
+    getContainer().removeListener(this);
+    executor.shutdown();
+    if (server != null) {
+      server.close();
+      server = null;
+    }
+    synchronized (connectors) {
+      for (Connector c : connectors) c.close();
+      connectors.clear();
+      connIDs.clear();
+    }
+  }
+
+  //// connection & message management
+
+  @Override
+  public void connected(Connector connector) {
+    log.info("Incoming connection: "+connector.getName());
+    synchronized (connectors) {
+      connectors.add(connector);
+      connIDs.put(++connID, connector);
+      monitor(connID, connector);
+    }
+  }
+
+  protected void connect() {
+    try {
+      Connector c = new TcpConnector(ip, port);
+      log.info("Connected to "+ip+":"+port);
+      synchronized (connectors) {
+        connectors.add(c);
+        connIDs.put(++connID, c);
+        monitor(connID, c);
+      }
+    } catch (IOException ex) {
+      log.fine("Failed to connect to "+ip+":"+port+": "+ex.getMessage());
+    }
+  }
+
+  @Override
+  public boolean onReceive(Message msg) {
+    synchronized (connectors) {
+      if (connectors.isEmpty()) return false;
+    }
+    AgentID rcpt = msg.getRecipient();
+    if (rcpt == null) return false;
+    if (agents.contains(rcpt)) {
+      JsonMessage jmsg = new JsonMessage();
+      jmsg.message = msg;
+      String json = jmsg.toJson();
+      log.fine("* << "+json);
+      synchronized (connectors) {
+        for (Connector c: connectors)
+          sendToRemote(c, json.getBytes());
+      }
+      if (!rcpt.isTopic()) return true;
+    } else if (!rcpt.isTopic() && rcpt.getName().contains("@")) {
+      int id = 0;
+      Connector c = null;
+      String rname = null;
+      try {
+        String s = rcpt.getName();
+        int i = s.lastIndexOf('@');
+        id = Integer.parseInt(s.substring(i+1));
+        rname = s.substring(0, i);
+        synchronized (connectors) {
+          c = connIDs.get(id);
+        }
+      } catch (NumberFormatException ex) {
+        return false;
+      }
+      if (c != null) {
+        msg.setRecipient(new AgentID(rname));
+        JsonMessage jmsg = new JsonMessage();
+        jmsg.message = msg;
+        String json = jmsg.toJson();
+        log.fine(id+" << "+json);
+        sendToRemote(c, json.getBytes());
+        return true;
+      }
+    }
+    return false;
+  }
+
+  protected void monitor(int id, Connector c) {
+    executor.submit(new Runnable() {
+      @Override
+      public void run() {
+        String cname = c.getName();
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(c.getInputStream()))) {
+          String line;
+          while ((line = in.readLine()) != null) {
+            log.fine(id+" >> "+line);
+            JsonMessage jmsg = JsonMessage.fromJson(line);
+            if (jmsg == null || jmsg.message == null) continue;
+            AgentID sender = jmsg.message.getSender();
+            jmsg.message.setSender(new AgentID(sender.getName() + "@" + id));
+            getContainer().send(jmsg.message);
+          }
+        } catch (IOException ex) {
+          log.fine("Read from "+cname+" failed: "+ex.getMessage());
+        }
+        removeConnector(c);
+      }
+    });
+  }
+
+  protected void sendToRemote(Connector c, byte[] data) {
+    executor.submit(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          OutputStream out = c.getOutputStream();
+          out.write(data);
+          out.write('\n');
+          out.flush();
+        } catch (IOException ex) {
+          log.warning("Write to "+c.getName()+" failed: "+ex.getMessage());
+          removeConnector(c);
+        }
+      }
+    });
+  }
+
+  protected void removeConnector(Connector c) {
+    synchronized (connectors) {
+      connectors.remove(c);
+      connIDs.values().removeIf(v -> v.equals(c));
+    }
+    c.close();
+  }
+
+  //// parameters
+
+  /**
+   * Get IP address for the tunnel. In case of a client tunnel, this is the IP
+   * address of the server to connect to. In case of a server tunnel, this is
+   * set to null.
+   *
+   * @return IP address for the tunnel, or null if this is a server tunnel.
+   */
+  public String getIp() {
+    return ip;
+  }
+
+  /**
+   * Get TCP port number for the tunnel. In case of a client tunnel, this is the
+   * TCP port number of the server to connect to. In case of a server tunnel,
+   * this is the TCP port number to listen on for incoming client connections.
+   *
+   * @return TCP port number for the tunnel.
+   */
+  public int getPort() {
+    return port;
+  }
+
+  /**
+   * Get the list of remote agents or topics visible through the tunnel.
+   *
+   * @return List of remote agents/topics visible through the tunnel.
+   */
+  public List<AgentID> getAgents() {
+    return agents;
+  }
+
+  /**
+   * Set the list of remote agents or topics visible through the tunnel.
+   *
+   * @param agents List of remote agents/topics visible through the tunnel.
+   */
+  public void setAgents(List<AgentID> agents) {
+    this.agents.clear();
+    if (agents == null) return;
+    for (AgentID aid : agents)
+      if (aid != null) this.agents.add(new AgentID(aid.getName(), aid.isTopic()));
+  }
+
+  /**
+   * Get title of the tunnel agent.
+   *
+   * @return title.
+   */
+  public String getTitle() {
+    return "Tunnel";
+  }
+
+  /**
+   * Get description of the tunnel agent.
+   *
+   * @return description.
+   */
+  public String getDescription() {
+    String s = " (no connections)";
+    synchronized (connectors) {
+      int n = connectors.size();
+      if (n == 1) s = " (1 connection)";
+      else if (n > 1) s = " ("+n+" connections)";
+    }
+    if (ip != null) return "Tunnel to " + ip + ":" + port + s;
+    return "Tunnel listening on port " + port + s;
+  }
+
+}

--- a/src/main/java/org/arl/fjage/remote/Tunnel.java
+++ b/src/main/java/org/arl/fjage/remote/Tunnel.java
@@ -172,7 +172,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
         jmsg.message = msg;
         String json = jmsg.toJson();
         log.fine(id+" << "+json);
-        sendToRemote(c, json.getBytes());
+        sendToRemote(c, json.getBytes(StandardCharsets.UTF_8));
         return true;
       }
     }
@@ -184,7 +184,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
       @Override
       public void run() {
         String cname = c.getName();
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(c.getInputStream()), StandardCharsets.UTF_8)) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(c.getInputStream(), StandardCharsets.UTF_8))) {
           String line;
           while ((line = in.readLine()) != null) {
             log.fine(id+" >> "+line);

--- a/src/main/java/org/arl/fjage/remote/Tunnel.java
+++ b/src/main/java/org/arl/fjage/remote/Tunnel.java
@@ -10,6 +10,14 @@ import org.arl.fjage.connectors.*;
 
 /**
  * An agent that serves as a tunnel for messages between two fjage platforms.
+ * <p>
+ * A tunnel can be configured as a server or a client. A server tunnel listens on
+ * a specified TCP port for incoming connections from client tunnels. A client
+ * tunnel connects to a server tunnel at a specified IP address and TCP port.
+ * <p>
+ * Once a connection is established, the tunnel agent forwards selected messages
+ * between the two platforms. The `agents` parameter specifies the list of remote
+ * agents or topics forwarded through the tunnel.
  */
 public class Tunnel extends Agent implements ConnectionListener, MessageListener {
 
@@ -39,11 +47,22 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
     this.port = port;
   }
 
+  //// documentation
+
+  public final static String __doc__ =
+    "# @@ - tunnel\n\n" +
+    "Tunnels messages between two fjage platforms over a TCP/IP link.\n\n" +
+    "## Parameters:\n\n" +
+    "### @@.agents - list of remote agents/topics visible through the tunnel\n\n" +
+    "Example:\n  @@.agents = [agent('remoteAgent'), topic('remoteTopic')]\n\n" +
+    "### @@.ip - IP address of the server to connect to (null for servers)\n" +
+    "### @@.port - TCP port number\n";
+
   //// agent methods
 
   @Override
   public void init() {
-    log.info("Agent "+getName()+" init");
+    register(org.arl.fjage.shell.Services.DOCUMENTATION);
     executor = Executors.newFixedThreadPool(2);
     add(new ParameterMessageBehavior(TunnelParam.class));
     if (ip == null) server = new TcpServer(port, this);
@@ -56,6 +75,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
       }
     });
     getContainer().addListener(this);
+    log.info("Agent "+getName()+" init");
   }
 
   @Override

--- a/src/main/java/org/arl/fjage/remote/Tunnel.java
+++ b/src/main/java/org/arl/fjage/remote/Tunnel.java
@@ -255,7 +255,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
    * @return TCP port number for the tunnel.
    */
   public int getPort() {
-    if (port == 0) return server.getPort();
+    if (port == 0 && server != null) return server.getPort();
     return port;
   }
 
@@ -307,8 +307,8 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
       if (n == 1) s = " (1 connection)";
       else if (n > 1) s = " ("+n+" connections)";
     }
-    if (ip != null) return "Tunnel to " + ip + ":" + port + s;
-    return "Tunnel listening on port " + port + s;
+    if (ip != null) return "Tunnel to " + ip + ":" + getPort() + s;
+    return "Tunnel listening on port " + getPort() + s;
   }
 
 }

--- a/src/main/java/org/arl/fjage/remote/Tunnel.java
+++ b/src/main/java/org/arl/fjage/remote/Tunnel.java
@@ -125,7 +125,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
         monitor(connID, c);
       }
     } catch (IOException ex) {
-      log.fine("Failed to connect to "+ip+":"+port+": "+ex.getMessage());
+      log.info("Failed to connect to "+ip+":"+port+": "+ex.getMessage());
     }
   }
 
@@ -146,7 +146,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
       JsonMessage jmsg = new JsonMessage();
       jmsg.message = msg;
       String json = jmsg.toJson();
-      log.fine("* << "+json);
+      log.info("* << "+json);
       synchronized (connectors) {
         for (Connector c: connectors)
           sendToRemote(c, json.getBytes(StandardCharsets.UTF_8));
@@ -172,7 +172,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
         JsonMessage jmsg = new JsonMessage();
         jmsg.message = msg;
         String json = jmsg.toJson();
-        log.fine(id+" << "+json);
+        log.info(id+" << "+json);
         sendToRemote(c, json.getBytes(StandardCharsets.UTF_8));
         return true;
       }
@@ -188,7 +188,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
         try (BufferedReader in = new BufferedReader(new InputStreamReader(c.getInputStream(), StandardCharsets.UTF_8))) {
           String line;
           while ((line = in.readLine()) != null) {
-            log.fine(id+" >> "+line);
+            log.info(id+" >> "+line);
             JsonMessage jmsg = JsonMessage.fromJson(line);
             if (jmsg == null || jmsg.message == null) continue;
             AgentID sender = jmsg.message.getSender();
@@ -197,7 +197,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
             getContainer().send(jmsg.message);
           }
         } catch (IOException ex) {
-          log.fine("Read from "+cname+" failed: "+ex.getMessage());
+          log.info("Read from "+cname+" failed: "+ex.getMessage());
         } catch (Exception ex) {
           log.log(Level.WARNING, "Exception on "+cname+": "+ex.getMessage(), ex);
         }

--- a/src/main/java/org/arl/fjage/remote/Tunnel.java
+++ b/src/main/java/org/arl/fjage/remote/Tunnel.java
@@ -4,7 +4,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-
+import java.util.logging.Level;
 import org.arl.fjage.*;
 import org.arl.fjage.param.*;
 import org.arl.fjage.remote.JsonMessage;
@@ -33,7 +33,8 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
   protected TcpServer server = null;
   protected List<AgentID> agents = new ArrayList<>();
   protected List<Connector> connectors = new ArrayList<>();
-  protected ExecutorService executor = null;
+  protected ExecutorService writeExecutor = null;
+  protected ExecutorService readExecutor = null;
   protected int connID = 0;
   protected Map<Integer,Connector> connIDs = new HashMap<>();
 
@@ -65,7 +66,8 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
   @Override
   public void init() {
     register(org.arl.fjage.shell.Services.DOCUMENTATION);
-    executor = Executors.newCachedThreadPool();
+    readExecutor = Executors.newCachedThreadPool();
+    writeExecutor = Executors.newSingleThreadExecutor();
     add(new ParameterMessageBehavior(TunnelParam.class));
     if (ip == null) {
       server = new TcpServer(port, this);
@@ -74,14 +76,17 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
         if (p > 0) port = p;
         else log.warning("Failed to get TCP server port number");
       }
-    } else add(new TickerBehavior(MONITOR_PERIOD) {
-      @Override
-      public void onTick() {
-        synchronized (connectors) {
-          if (connectors.isEmpty()) connect();
+    } else {
+      connect();
+      add(new TickerBehavior(MONITOR_PERIOD) {
+        @Override
+        public void onTick() {
+          synchronized (connectors) {
+            if (connectors.isEmpty()) connect();
+          }
         }
-      }
-    });
+      });
+    }
     getContainer().addListener(this);
     log.info("Agent "+getName()+" init");
   }
@@ -90,7 +95,8 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
   public void shutdown() {
     log.info("Agent "+getName()+" shutdown");
     getContainer().removeListener(this);
-    executor.shutdownNow();
+    readExecutor.shutdownNow();
+    writeExecutor.shutdownNow();
     if (server != null) {
       server.close();
       server = null;
@@ -180,7 +186,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
   }
 
   protected void monitor(int id, Connector c) {
-    executor.submit(new Runnable() {
+    readExecutor.submit(new Runnable() {
       @Override
       public void run() {
         String cname = c.getName();
@@ -206,7 +212,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
   }
 
   protected void sendToRemote(Connector c, byte[] data) {
-    executor.submit(new Runnable() {
+    writeExecutor.submit(new Runnable() {
       @Override
       public void run() {
         try {

--- a/src/main/java/org/arl/fjage/remote/Tunnel.java
+++ b/src/main/java/org/arl/fjage/remote/Tunnel.java
@@ -71,11 +71,6 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
     add(new ParameterMessageBehavior(TunnelParam.class));
     if (ip == null) {
       server = new TcpServer(port, this);
-      if (port == 0) {
-        int p = server.getPort();
-        if (p > 0) port = p;
-        else log.warning("Failed to get TCP server port number");
-      }
     } else {
       connect();
       add(new TickerBehavior(MONITOR_PERIOD) {
@@ -260,6 +255,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
    * @return TCP port number for the tunnel.
    */
   public int getPort() {
+    if (port == 0) return server.getPort();
     return port;
   }
 
@@ -285,7 +281,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
     synchronized (this.agents) {
       this.agents.clear();
       if (agents == null) return;
-      for (AgentID aid : agents)
+      for (AgentID aid: agents)
         if (aid != null) this.agents.add(new AgentID(aid.getName(), aid.isTopic()));
     }
   }

--- a/src/main/java/org/arl/fjage/remote/Tunnel.java
+++ b/src/main/java/org/arl/fjage/remote/Tunnel.java
@@ -3,6 +3,8 @@ package org.arl.fjage.remote;
 import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
+
 import org.arl.fjage.*;
 import org.arl.fjage.param.*;
 import org.arl.fjage.remote.JsonMessage;
@@ -63,10 +65,16 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
   @Override
   public void init() {
     register(org.arl.fjage.shell.Services.DOCUMENTATION);
-    executor = Executors.newFixedThreadPool(2);
+    executor = Executors.newCachedThreadPool();
     add(new ParameterMessageBehavior(TunnelParam.class));
-    if (ip == null) server = new TcpServer(port, this);
-    else add(new TickerBehavior(MONITOR_PERIOD) {
+    if (ip == null) {
+      server = new TcpServer(port, this);
+      if (port == 0) {
+        int p = server.getPort();
+        if (p > 0) port = p;
+        else log.warning("Failed to get TCP server port number");
+      }
+    } else add(new TickerBehavior(MONITOR_PERIOD) {
       @Override
       public void onTick() {
         synchronized (connectors) {
@@ -82,7 +90,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
   public void shutdown() {
     log.info("Agent "+getName()+" shutdown");
     getContainer().removeListener(this);
-    executor.shutdown();
+    executor.shutdownNow();
     if (server != null) {
       server.close();
       server = null;
@@ -126,15 +134,21 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
       if (connectors.isEmpty()) return false;
     }
     AgentID rcpt = msg.getRecipient();
-    if (rcpt == null) return false;
-    if (agents.contains(rcpt)) {
+    AgentID sender = msg.getSender();
+    if (rcpt == null || sender == null) return false;
+    if (sender.getName().contains("@")) return false;
+    boolean shouldForward = false;
+    synchronized (agents) {
+      shouldForward = agents.contains(rcpt);
+    }
+    if (shouldForward) {
       JsonMessage jmsg = new JsonMessage();
       jmsg.message = msg;
       String json = jmsg.toJson();
       log.fine("* << "+json);
       synchronized (connectors) {
         for (Connector c: connectors)
-          sendToRemote(c, json.getBytes());
+          sendToRemote(c, json.getBytes(StandardCharsets.UTF_8));
       }
       if (!rcpt.isTopic()) return true;
     } else if (!rcpt.isTopic() && rcpt.getName().contains("@")) {
@@ -170,13 +184,14 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
       @Override
       public void run() {
         String cname = c.getName();
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(c.getInputStream()))) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(c.getInputStream()), StandardCharsets.UTF_8)) {
           String line;
           while ((line = in.readLine()) != null) {
             log.fine(id+" >> "+line);
             JsonMessage jmsg = JsonMessage.fromJson(line);
             if (jmsg == null || jmsg.message == null) continue;
             AgentID sender = jmsg.message.getSender();
+            if (sender == null) continue;
             jmsg.message.setSender(new AgentID(sender.getName() + "@" + id));
             getContainer().send(jmsg.message);
           }
@@ -194,9 +209,12 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
       public void run() {
         try {
           OutputStream out = c.getOutputStream();
-          out.write(data);
-          out.write('\n');
-          out.flush();
+          if (out == null) removeConnector(c);
+          else synchronized (out) {
+            out.write(data);
+            out.write('\n');
+            out.flush();
+          }
         } catch (IOException ex) {
           log.warning("Write to "+c.getName()+" failed: "+ex.getMessage());
           removeConnector(c);
@@ -243,7 +261,9 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
    * @return List of remote agents/topics visible through the tunnel.
    */
   public List<AgentID> getAgents() {
-    return agents;
+    synchronized (agents) {
+      return agents;
+    }
   }
 
   /**
@@ -252,10 +272,12 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
    * @param agents List of remote agents/topics visible through the tunnel.
    */
   public void setAgents(List<AgentID> agents) {
-    this.agents.clear();
-    if (agents == null) return;
-    for (AgentID aid : agents)
-      if (aid != null) this.agents.add(new AgentID(aid.getName(), aid.isTopic()));
+    synchronized (agents) {
+      this.agents.clear();
+      if (agents == null) return;
+      for (AgentID aid : agents)
+        if (aid != null) this.agents.add(new AgentID(aid.getName(), aid.isTopic()));
+    }
   }
 
   /**

--- a/src/main/java/org/arl/fjage/remote/Tunnel.java
+++ b/src/main/java/org/arl/fjage/remote/Tunnel.java
@@ -197,6 +197,8 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
           }
         } catch (IOException ex) {
           log.fine("Read from "+cname+" failed: "+ex.getMessage());
+        } catch (Exception ex) {
+          log.log(Level.WARNING, "Exception on "+cname+": "+ex.getMessage(), ex);
         }
         removeConnector(c);
       }
@@ -262,7 +264,9 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
    */
   public List<AgentID> getAgents() {
     synchronized (agents) {
-      return agents;
+      List<AgentID> copy = new ArrayList<>();
+      for (AgentID aid: agents) copy.add(aid);
+      return copy;
     }
   }
 
@@ -272,7 +276,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
    * @param agents List of remote agents/topics visible through the tunnel.
    */
   public void setAgents(List<AgentID> agents) {
-    synchronized (agents) {
+    synchronized (this.agents) {
       this.agents.clear();
       if (agents == null) return;
       for (AgentID aid : agents)

--- a/src/main/java/org/arl/fjage/remote/TunnelParam.java
+++ b/src/main/java/org/arl/fjage/remote/TunnelParam.java
@@ -1,0 +1,26 @@
+package org.arl.fjage.remote;
+
+import org.arl.fjage.param.Parameter;
+
+public enum TunnelParam implements Parameter {
+
+  /**
+   * IP address for the tunnel. In case of a client tunnel, this is the IP
+   * address of the server to connect to. In case of a server tunnel, this is
+   * set to null.
+   */
+  ip,
+
+  /**
+   * TCP port number for the tunnel. In case of a client tunnel, this is the
+   * TCP port number of the server to connect to. In case of a server tunnel,
+   * this is the TCP port number to listen on for incoming client connections.
+   */
+  port,
+
+  /**
+   * List of remote agents/topics visible through the tunnel.
+   */
+  agents
+
+}

--- a/src/test/java/org/arl/fjage/test/BasicTests.java
+++ b/src/test/java/org/arl/fjage/test/BasicTests.java
@@ -415,7 +415,7 @@ public class BasicTests {
     platform.start();
     Tunnel t1 = new Tunnel(0);
     c1.add("t1", t1);
-    platform.delay(500);
+    platform.delay(250);
     Tunnel t2 = new Tunnel("localhost", t1.getPort());
     c2.add("t2", t2);
     List<AgentID> agents = new ArrayList<>();
@@ -426,29 +426,29 @@ public class BasicTests {
     agents.add(new AgentID("t1"));
     agents.add(new AgentID("sharedTopic", true));
     t2.setAgents(agents);
-    platform.delay(500);
+    platform.delay(250);
     Message msg = new ParameterReq();
     msg.setRecipient(new AgentID("t2"));
     msg.setSender(new AgentID("test-c1"));
     c1.send(msg);
-    platform.delay(500);
-    assertTrue(l1.msgs.get(1) instanceof ParameterRsp);
+    platform.delay(250);
+    assertTrue(l1.msgs.get(l1.msgs.size()-1) instanceof ParameterRsp);
     l1.msgs.clear();
     l2.msgs.clear();
     msg = new ParameterReq();
     msg.setRecipient(new AgentID("t1"));
     msg.setSender(new AgentID("test-c2"));
     c2.send(msg);
-    platform.delay(500);
-    assertTrue(l2.msgs.get(1) instanceof ParameterRsp);
+    platform.delay(250);
+    assertTrue(l2.msgs.get(l2.msgs.size()-1) instanceof ParameterRsp);
     l1.msgs.clear();
     l2.msgs.clear();
     msg = new Message();
     msg.setRecipient(new AgentID("sharedTopic", true));
     msg.setSender(new AgentID("test-c1"));
     c1.send(msg);
-    platform.delay(500);
-    assertTrue(l2.msgs.get(0) instanceof Message);
+    platform.delay(250);
+    assertTrue(l2.msgs.get(l2.msgs.size()-1) instanceof Message);
     platform.shutdown();
   }
 

--- a/src/test/java/org/arl/fjage/test/BasicTests.java
+++ b/src/test/java/org/arl/fjage/test/BasicTests.java
@@ -12,9 +12,7 @@ package org.arl.fjage.test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 import java.util.logging.Logger;
 import org.arl.fjage.*;
 import org.arl.fjage.param.*;
@@ -417,7 +415,7 @@ public class BasicTests {
     platform.start();
     Tunnel t1 = new Tunnel(0);
     c1.add("t1", t1);
-    platform.delay(100);
+    platform.delay(500);
     Tunnel t2 = new Tunnel("localhost", t1.getPort());
     c2.add("t2", t2);
     List<AgentID> agents = new ArrayList<>();
@@ -428,12 +426,12 @@ public class BasicTests {
     agents.add(new AgentID("t1"));
     agents.add(new AgentID("sharedTopic", true));
     t2.setAgents(agents);
-    platform.delay(100);
+    platform.delay(500);
     Message msg = new ParameterReq();
     msg.setRecipient(new AgentID("t2"));
     msg.setSender(new AgentID("test-c1"));
     c1.send(msg);
-    platform.delay(100);
+    platform.delay(500);
     assertTrue(l1.msgs.get(1) instanceof ParameterRsp);
     l1.msgs.clear();
     l2.msgs.clear();
@@ -441,7 +439,7 @@ public class BasicTests {
     msg.setRecipient(new AgentID("t1"));
     msg.setSender(new AgentID("test-c2"));
     c2.send(msg);
-    platform.delay(100);
+    platform.delay(500);
     assertTrue(l2.msgs.get(1) instanceof ParameterRsp);
     l1.msgs.clear();
     l2.msgs.clear();
@@ -449,7 +447,7 @@ public class BasicTests {
     msg.setRecipient(new AgentID("sharedTopic", true));
     msg.setSender(new AgentID("test-c1"));
     c1.send(msg);
-    platform.delay(100);
+    platform.delay(500);
     assertTrue(l2.msgs.get(0) instanceof Message);
     platform.shutdown();
   }
@@ -959,7 +957,7 @@ public class BasicTests {
   }
 
   private class MyMessageListener implements MessageListener {
-    public List<Message> msgs = new ArrayList<Message>();
+    public List<Message> msgs = Collections.synchronizedList(new ArrayList<Message>());
     public int n = 0;
     public boolean eat = false;
     @Override

--- a/src/test/java/org/arl/fjage/test/BasicTests.java
+++ b/src/test/java/org/arl/fjage/test/BasicTests.java
@@ -22,6 +22,7 @@ import org.arl.fjage.persistence.Store;
 import org.arl.fjage.remote.Gateway;
 import org.arl.fjage.remote.MasterContainer;
 import org.arl.fjage.remote.SlaveContainer;
+import org.arl.fjage.remote.Tunnel;
 import org.arl.fjage.shell.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -401,6 +402,56 @@ public class BasicTests {
     platform.shutdown();
     assertEquals(n1,listener.n);
     assertTrue(server.nuisance > 0);
+  }
+
+  @Test
+  public void testTunnel() {
+    log.info("testTunnel");
+    Platform platform = new RealTimePlatform();
+    Container c1 = new Container(platform);
+    Container c2 = new Container(platform);
+    MyMessageListener l1 = new MyMessageListener();
+    c1.addListener(l1);
+    MyMessageListener l2 = new MyMessageListener();
+    c2.addListener(l2);
+    platform.start();
+    Tunnel t1 = new Tunnel(0);
+    c1.add("t1", t1);
+    platform.delay(100);
+    Tunnel t2 = new Tunnel("localhost", t1.getPort());
+    c2.add("t2", t2);
+    List<AgentID> agents = new ArrayList<>();
+    agents.add(new AgentID("t2"));
+    agents.add(new AgentID("sharedTopic", true));
+    t1.setAgents(agents);
+    agents.clear();
+    agents.add(new AgentID("t1"));
+    agents.add(new AgentID("sharedTopic", true));
+    t2.setAgents(agents);
+    platform.delay(100);
+    Message msg = new ParameterReq();
+    msg.setRecipient(new AgentID("t2"));
+    msg.setSender(new AgentID("test-c1"));
+    c1.send(msg);
+    platform.delay(100);
+    assertTrue(l1.msgs.get(1) instanceof ParameterRsp);
+    l1.msgs.clear();
+    l2.msgs.clear();
+    msg = new ParameterReq();
+    msg.setRecipient(new AgentID("t1"));
+    msg.setSender(new AgentID("test-c2"));
+    c2.send(msg);
+    platform.delay(100);
+    assertTrue(l2.msgs.get(1) instanceof ParameterRsp);
+    l1.msgs.clear();
+    l2.msgs.clear();
+    msg = new Message();
+    msg.setRecipient(new AgentID("sharedTopic", true));
+    msg.setSender(new AgentID("test-c1"));
+    c1.send(msg);
+    platform.delay(100);
+    assertTrue(l2.msgs.get(0) instanceof Message);
+    platform.shutdown();
   }
 
   @Test
@@ -908,10 +959,12 @@ public class BasicTests {
   }
 
   private class MyMessageListener implements MessageListener {
+    public List<Message> msgs = new ArrayList<Message>();
     public int n = 0;
     public boolean eat = false;
     @Override
     public boolean onReceive(Message msg) {
+      msgs.add(msg);
       n++;
       return eat;
     }


### PR DESCRIPTION
Implements tunnels that allow multiple fjåge universes to be connected over TCP/IP.

### Example usage

**fjåge container 1**:
```groovy
> container.add 't1', new org.arl.fjage.remote.Tunnel(12345);
> subscribe topic('sharedTopic')
```

**fjåge container 2**:
```groovy
> container.add 't2', new org.arl.fjage.remote.Tunnel('localhost', 12345);
> subscribe topic('sharedTopic')
> t2.agents = [agent('t1'), topic('sharedTopic')]
[t1, sharedTopic]

> agent('t1')       // access agent t1 through the tunnel
« Tunnel »

Tunnel listening on port 12345 (1 connection)

[org.arl.fjage.remote.TunnelParam]
  agents = []
  ip ⤇ null
  port ⤇ 12345

> send new Message(recipient: topic('sharedTopic'))
true
shell >> INFORM
```

You should see that message in container 1 too:

**fjåge container 1**:
```groovy
shell@1 >> INFORM
```

### Additional notes

- Server and client can be started in any order.
- Client will reconnect to server if it loses connections (retries every 5 seconds).
- `@id` suffix is added to remote agent names to avoid confusion with similar named local agents. The `id` is auto-generated and has no user-facing semantics other than to make agentIDs unique in each container.
- `ip` and `port` can only be setup when loading the agent and cannot be modified during runtime. An agent can be killed and re-loaded, if a different IP or port is desired.
- To get detailed logs of every message exchange, do: `logLevel 'org.arl.fjage.remote', FINE`
