### PR TITLE
Clean up of classes related to remote containers

### DIFF
--- a/src/main/java/org/arl/fjage/Container.java
+++ b/src/main/java/org/arl/fjage/Container.java
@@ -45,10 +45,10 @@ public class Container {
 
   protected String name;
   protected Platform platform;
-  protected Map<AgentID,Agent> agents = new ConcurrentHashMap<AgentID,Agent>();
-  protected Map<AgentID,Agent> agentsToAdd = new ConcurrentHashMap<AgentID,Agent>();
-  protected Map<AgentID,Set<Agent>> topics = new HashMap<AgentID,Set<Agent>>();
-  protected Map<String,Set<AgentID>> services = new HashMap<String,Set<AgentID>>();
+  protected final Map<AgentID,Agent> agents = new ConcurrentHashMap<>();
+  protected Map<AgentID,Agent> agentsToAdd = new ConcurrentHashMap<>();
+  protected Map<AgentID,Set<Agent>> topics = new HashMap<>();
+  protected Map<String,Set<AgentID>> services = new HashMap<>();
   protected Logger log = Logger.getLogger(getClass().getName());
   protected boolean running = false;
   protected boolean initing = false;
@@ -56,8 +56,8 @@ public class Container {
   protected Object cloner;
   protected Method doClone;
   protected boolean autoclone = false;
-  protected Set<AgentID> idle = new HashSet<AgentID>();
-  protected Set<MessageListener> listeners = new HashSet<MessageListener>();
+  protected final Set<AgentID> idle = new HashSet<>();
+  protected final Set<MessageListener> listeners = new HashSet<>();
 
   //////////// Interface methods
 
@@ -149,7 +149,7 @@ public class Container {
         throw new FjageException("Unknown cloner name");
       }
     } catch (Exception ex) {
-      log.log(Level.WARNING, "Cloner creation failed: "+ex.toString(), ex);
+      log.log(Level.WARNING, "Cloner creation failed: "+ ex, ex);
       cloner = null;
       doClone = null;
       throw new FjageException("Cloner creation failed");
@@ -169,7 +169,7 @@ public class Container {
     try {
       return (T)doClone.invoke(cloner, obj);
     } catch (Exception ex) {
-      log.log(Level.WARNING, "Cloning failed: "+ex.toString(), ex);
+      log.log(Level.WARNING, "Cloning failed: "+ ex, ex);
       throw new FjageException("Cloning failed");
     }
   }
@@ -402,11 +402,7 @@ public class Container {
       log.warning("Unable to subscribe unknown agent "+aid+" to topic "+topic);
       return false;
     }
-    Set<Agent> subscribers = topics.get(topic);
-    if (subscribers == null) {
-      subscribers = new HashSet<Agent>();
-      topics.put(topic, subscribers);
-    }
+    Set<Agent> subscribers = topics.computeIfAbsent(topic, k -> new HashSet<>());
     subscribers.add(agent);
     return true;
   }
@@ -449,11 +445,7 @@ public class Container {
    * @return true on success, false on failure.
    */
   public synchronized boolean register(AgentID aid, String service) {
-    Set<AgentID> providers = services.get(service);
-    if (providers == null) {
-      providers = new HashSet<AgentID>();
-      services.put(service, providers);
-    }
+    Set<AgentID> providers = services.computeIfAbsent(service, k -> new HashSet<>());
     providers.add(aid);
     return true;
   }
@@ -476,7 +468,7 @@ public class Container {
    */
   public synchronized AgentID agentForService(String service) {
     Set<AgentID> providers = services.get(service);
-    if (providers == null || providers.size() == 0) return null;
+    if (providers == null || providers.isEmpty()) return null;
     return providers.iterator().next();
   }
 
@@ -488,7 +480,7 @@ public class Container {
    */
   public synchronized AgentID[] agentsForService(String service) {
     Set<AgentID> providers = services.get(service);
-    if (providers == null || providers.size() == 0) return null;
+    if (providers == null || providers.isEmpty()) return null;
     return providers.toArray(new AgentID[0]);
   }
 
@@ -526,7 +518,7 @@ public class Container {
       log.info("Initializing agents...");
       initing = true;
       synchronized (agents) {
-        SortedSet<AgentID> keys = new TreeSet<AgentID>(agents.keySet());
+        SortedSet<AgentID> keys = new TreeSet<>(agents.keySet());
         for (AgentID aid: keys) {
           log.fine("Starting agent "+aid);
           Agent a = agents.get(aid);
@@ -547,10 +539,10 @@ public class Container {
           initing = false;
           return;
         }
-        if (agentsToAdd.size() > 0) {
+        if (!agentsToAdd.isEmpty()) {
           synchronized (agents) {
             agents.putAll(agentsToAdd);
-            SortedSet<AgentID> keys = new TreeSet<AgentID>(agentsToAdd.keySet());
+            SortedSet<AgentID> keys = new TreeSet<>(agentsToAdd.keySet());
             for (AgentID aid: keys) {
               log.fine("Starting agent "+aid);
               Agent a = agents.get(aid);

--- a/src/main/java/org/arl/fjage/remote/ArrayAdapterFactory.java
+++ b/src/main/java/org/arl/fjage/remote/ArrayAdapterFactory.java
@@ -25,8 +25,8 @@ import com.google.gson.reflect.TypeToken;
  */
 class ArrayAdapterFactory implements TypeAdapterFactory {
 
-  private boolean bare;
-  private int threshold;
+  private final boolean bare;
+  private final int threshold;
 
   public ArrayAdapterFactory() {
     bare = false;
@@ -167,43 +167,37 @@ class ArrayAdapterFactory implements TypeAdapterFactory {
 
       private void writeArray(JsonWriter out, byte[] arr) throws IOException {
         out.beginArray();
-        for (int i = 0; i < arr.length; i++)
-          out.value(arr[i]);
+        for (byte b : arr) out.value(b);
         out.endArray();
       }
 
       private void writeArray(JsonWriter out, int[] arr) throws IOException {
         out.beginArray();
-        for (int i = 0; i < arr.length; i++)
-          out.value(arr[i]);
+        for (int j : arr) out.value(j);
         out.endArray();
       }
 
       private void writeArray(JsonWriter out, short[] arr) throws IOException {
         out.beginArray();
-        for (int i = 0; i < arr.length; i++)
-          out.value(arr[i]);
+        for (short value : arr) out.value(value);
         out.endArray();
       }
 
       private void writeArray(JsonWriter out, long[] arr) throws IOException {
         out.beginArray();
-        for (int i = 0; i < arr.length; i++)
-          out.value(arr[i]);
+        for (long l : arr) out.value(l);
         out.endArray();
       }
 
       private void writeArray(JsonWriter out, float[] arr) throws IOException {
         out.beginArray();
-        for (int i = 0; i < arr.length; i++)
-          out.value(arr[i]);
+        for (float v : arr) out.value(v);
         out.endArray();
       }
 
       private void writeArray(JsonWriter out, double[] arr) throws IOException {
         out.beginArray();
-        for (int i = 0; i < arr.length; i++)
-          out.value(arr[i]);
+        for (double v : arr) out.value(v);
         out.endArray();
       }
 

--- a/src/main/java/org/arl/fjage/remote/ConnectionHandler.java
+++ b/src/main/java/org/arl/fjage/remote/ConnectionHandler.java
@@ -14,6 +14,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.arl.fjage.AgentID;
 import org.arl.fjage.auth.*;
@@ -31,15 +32,17 @@ public class ConnectionHandler extends Thread {
 
   private Connector conn;
   private DataOutputStream out;
-  private Map<String,Object> pending = Collections.synchronizedMap(new HashMap<String,Object>());
-  private Deque<String> failed = new ArrayDeque<String>(FAILED_SIZE);
-  private Logger log = Logger.getLogger(getClass().getName());
-  private RemoteContainer container;
-  private boolean alive, keepAlive, closeOnDead;
-  private ExecutorService pool = Executors.newSingleThreadExecutor();
-  private Set<AgentID> watchList = new HashSet<>();
+  private final Map<String,Object> pending = Collections.synchronizedMap(new HashMap<>());
+  private final Deque<String> failed = new ArrayDeque<>(FAILED_SIZE);
+  private final Logger log = Logger.getLogger(getClass().getName());
+  private final RemoteContainer container;
+  private boolean alive;
+  private final boolean keepAlive;
+  private final boolean closeOnDead;
+  private final ExecutorService pool = Executors.newSingleThreadExecutor();
+  private final Set<AgentID> watchList = new HashSet<>();
   private String clientName = "-";
-  private Firewall fw;
+  private final Firewall fw;
 
   public ConnectionHandler(Connector conn, RemoteContainer container) {
     this.conn = conn;
@@ -154,7 +157,7 @@ public class ConnectionHandler extends Thread {
           else respondAuth(rq, false);
         }
       } catch(Exception ex) {
-        log.warning("Bad JSON request: "+ex.toString() + " in " + s);
+        log.log(Level.WARNING, "Failed to process message: "+s, ex);
       }
     }
     fw.signoff();
@@ -172,7 +175,7 @@ public class ConnectionHandler extends Thread {
   @Override
   public String toString() {
     if (conn == null) return super.toString() + " <" + clientName + ">";
-    return conn.toString() + " <" + clientName + ">";
+    return conn + " <" + clientName + ">";
   }
 
   private void respondAuth(JsonMessage rq, boolean auth) {
@@ -226,7 +229,7 @@ public class ConnectionHandler extends Thread {
       conn.waitOutputCompletion(1000);
     } catch(IOException ex) {
       if (!s.equals(SIGN_OFF)) {
-        log.warning("Write failed: "+ex.toString());
+        log.log(Level.WARNING, "Failed to send message: "+s, ex);
         close();
       }
     }
@@ -298,7 +301,7 @@ public class ConnectionHandler extends Thread {
 
   private class RemoteTask implements Runnable {
 
-    private JsonMessage rq;
+    private final JsonMessage rq;
 
     RemoteTask(JsonMessage rq) {
       this.rq = rq;
@@ -332,8 +335,7 @@ public class ConnectionHandler extends Thread {
         case WANTS_MESSAGES_FOR:
           synchronized(watchList) {
             watchList.clear();
-            for (AgentID aid: rq.agentIDs)
-              watchList.add(aid);
+            Collections.addAll(watchList, rq.agentIDs);
           }
           break;
       }

--- a/src/main/java/org/arl/fjage/remote/EnumTypeAdapter.java
+++ b/src/main/java/org/arl/fjage/remote/EnumTypeAdapter.java
@@ -22,7 +22,7 @@ import com.google.gson.stream.*;
 public class EnumTypeAdapter extends TypeAdapter<Object> {
 
   private static ClassLoader classloader = null;
-  private static Logger log;
+  private static final Logger log;
 
   static {
     log = Logger.getLogger(EnumTypeAdapter.class.getName());
@@ -71,7 +71,7 @@ public class EnumTypeAdapter extends TypeAdapter<Object> {
   @Override public void write(JsonWriter out, Object value) throws IOException {
     if (value == null) out.value((String)null);
     else if (value instanceof NamedParameter) out.value(value.toString());
-    else out.value(value.getClass().getName().replace('$','.')+"."+value.toString());
+    else out.value(value.getClass().getName().replace('$','.')+"."+ value);
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
@@ -86,8 +86,7 @@ public class EnumTypeAdapter extends TypeAdapter<Object> {
     String value = s.substring(pos+1);
     Class<? extends Enum> cls = enumClass(s.substring(0,pos));
     if (cls != null) return Enum.valueOf(cls, value);
-    if (value != null) return new NamedParameter(s);
-    return null;
+    return new NamedParameter(s);
   }
 
 }

--- a/src/main/java/org/arl/fjage/remote/Gateway.java
+++ b/src/main/java/org/arl/fjage/remote/Gateway.java
@@ -106,7 +106,7 @@ public class Gateway implements Messenger, Closeable {
   }
 
   /**
-   * Creates a gateway based on an exsiting container.
+   * Creates a gateway based on an existing container.
    */
   public Gateway(Container container) {
     this.container = container;
@@ -117,7 +117,7 @@ public class Gateway implements Messenger, Closeable {
   protected void init() {
     agent = new Agent() {
       private Message rsp;
-      private Object sync = new Object();
+      private final Object sync = new Object();
       @Override
       public Message receive(final MessageFilter filter, long timeout) {
         if (Thread.currentThread().getId() == tid) return super.receive(filter, timeout);
@@ -188,7 +188,7 @@ public class Gateway implements Messenger, Closeable {
   }
 
   /**
-   * Closes the gateway. The gateway functionality may not longer be accessed after
+   * Closes the gateway. The gateway functionality may no longer be accessed after
    * this method is called.
    */
   @Override
@@ -235,7 +235,7 @@ public class Gateway implements Messenger, Closeable {
 
   @Override
   public Message receive(final Class<?> cls, long timeout) {
-    return receive(m -> cls.isInstance(m), timeout);
+    return receive(cls::isInstance, timeout);
   }
 
   @Override
@@ -248,7 +248,7 @@ public class Gateway implements Messenger, Closeable {
     if (container instanceof SlaveContainer)
       ((SlaveContainer)container).checkAuthFailure(m.getMessageID());
     Message rsp = receive(new MessageFilter() {
-      private String mid = m.getMessageID();
+      private final String mid = m.getMessageID();
       @Override
       public boolean matches(Message m) {
         String s = m.getInReplyTo();
@@ -400,7 +400,7 @@ public class Gateway implements Messenger, Closeable {
    */
   public AgentID agentForService(Enum<?> service) {
     if (container == null) return null;
-    AgentID t = container.agentForService(service.getClass().getName()+"."+service.toString());
+    AgentID t = container.agentForService(service.getClass().getName()+"."+service);
     if (t == null) return null;
     return new AgentID(t, this);
   }
@@ -428,7 +428,7 @@ public class Gateway implements Messenger, Closeable {
    */
   public AgentID[] agentsForService(Enum<?> service) {
     if (container == null) return null;
-    AgentID[] t = container.agentsForService(service.getClass().getName()+"."+service.toString());
+    AgentID[] t = container.agentsForService(service.getClass().getName()+"."+service);
     if (t == null) return null;
     for (int i = 0; i < t.length; i++)
       t[i] = new AgentID(t[i], this);

--- a/src/main/java/org/arl/fjage/remote/JsonMessage.java
+++ b/src/main/java/org/arl/fjage/remote/JsonMessage.java
@@ -36,7 +36,7 @@ public class JsonMessage {
   public Boolean auth;
   public String name;
 
-  private static GsonBuilder gsonBuilder = new GsonBuilder()
+  private static final GsonBuilder gsonBuilder = new GsonBuilder()
     .setFieldNamingPolicy(FieldNamingPolicy.IDENTITY)
     .registerTypeAdapter(Float.class, (JsonSerializer<Float>) (value, type, jsonSerializationContext) -> value.isNaN()?null:new JsonPrimitive(value))
     .registerTypeAdapter(Double.class, (JsonSerializer<Double>) (value, type, jsonSerializationContext) -> value.isNaN()?null:new JsonPrimitive(value))

--- a/src/main/java/org/arl/fjage/remote/MasterContainer.java
+++ b/src/main/java/org/arl/fjage/remote/MasterContainer.java
@@ -32,7 +32,7 @@ public class MasterContainer extends RemoteContainer implements ConnectionListen
 
   private TcpServer tcpListener = null;
   private WebSocketServer websocketListener = null;
-  private List<ConnectionHandler> slaves = new ArrayList<ConnectionHandler>();
+  private final List<ConnectionHandler> slaves = new ArrayList<>();
   private boolean needsCleanup = false;
   private Supplier<Firewall> fwSupplier = AllowAll.SUPPLIER;
 
@@ -249,7 +249,7 @@ public class MasterContainer extends RemoteContainer implements ConnectionListen
   @Override
   public AgentID[] getAgents() {
     AgentID[] aids = super.getAgents();
-    List<AgentID> rv = new ArrayList<AgentID>(Arrays.asList(aids));
+    List<AgentID> rv = new ArrayList<>(Arrays.asList(aids));
     JsonMessage rq = new JsonMessage();
     rq.action = Action.AGENTS;
     rq.id = UUID.randomUUID().toString();
@@ -273,7 +273,7 @@ public class MasterContainer extends RemoteContainer implements ConnectionListen
   @Override
   public String[] getServices() {
     String[] svc = super.getServices();
-    Set<String> rv = new HashSet<String>(Arrays.asList(svc));
+    Set<String> rv = new HashSet<>(Arrays.asList(svc));
     JsonMessage rq = new JsonMessage();
     rq.action = Action.SERVICES;
     rq.id = UUID.randomUUID().toString();
@@ -303,7 +303,7 @@ public class MasterContainer extends RemoteContainer implements ConnectionListen
     synchronized(slaves) {
       for (ConnectionHandler slave: slaves) {
         JsonMessage rsp = slave.printlnAndGetResponse(json, rq.id, TIMEOUT);
-        if (rsp != null && rsp.agentID != null && rsp.agentID.getName().length() > 0) return rsp.agentID;
+        if (rsp != null && rsp.agentID != null && !rsp.agentID.getName().isEmpty()) return rsp.agentID;
       }
     }
     return null;
@@ -311,7 +311,7 @@ public class MasterContainer extends RemoteContainer implements ConnectionListen
 
   @Override
   public AgentID[] agentsForService(String service) {
-    List<AgentID> rv = new ArrayList<AgentID>();
+    List<AgentID> rv = new ArrayList<>();
     AgentID[] aids = super.agentsForService(service);
     if (aids != null)
       rv.addAll(Arrays.asList(aids));

--- a/src/main/java/org/arl/fjage/remote/RemoteContainer.java
+++ b/src/main/java/org/arl/fjage/remote/RemoteContainer.java
@@ -55,7 +55,7 @@ abstract class RemoteContainer extends Container {
    * On the master container, this method should be the same as getServices(). On the
    * slave container, however, this method should only list services residing in that slave.
    *
-   * @return list of all services.
+   * @return array of all services.
    */
   abstract String[] getLocalServices();
 

--- a/src/main/java/org/arl/fjage/remote/SlaveContainer.java
+++ b/src/main/java/org/arl/fjage/remote/SlaveContainer.java
@@ -31,8 +31,10 @@ public class SlaveContainer extends RemoteContainer {
   private static final long TIMEOUT = 2000;
 
   private ConnectionHandler master;
-  private String hostname, settings;
-  private int port, baud;
+  private final String hostname;
+  private String settings;
+  private final int port;
+  private final int baud;
   private boolean quit = false;
   private String watchListCache = null;
 
@@ -45,7 +47,7 @@ public class SlaveContainer extends RemoteContainer {
    * @param hostname hostname of the master container.
    * @param port port on which the master container's TCP server runs.
    */
-  public SlaveContainer(Platform platform, String hostname, int port) throws IOException {
+  public SlaveContainer(Platform platform, String hostname, int port) {
     super(platform);
     this.hostname = hostname;
     this.port = port;
@@ -61,7 +63,7 @@ public class SlaveContainer extends RemoteContainer {
    * @param hostname hostname of the master container.
    * @param port port on which the master container's TCP server runs.
    */
-  public SlaveContainer(Platform platform, String name, String hostname, int port) throws IOException {
+  public SlaveContainer(Platform platform, String name, String hostname, int port) {
     super(platform, name);
     this.hostname = hostname;
     this.port = port;
@@ -77,7 +79,7 @@ public class SlaveContainer extends RemoteContainer {
    * @param baud baud rate for the RS232 port.
    * @param settings RS232 settings (null for defaults, or "N81" for no parity, 8 bits, 1 stop bit).
    */
-  public SlaveContainer(Platform platform, String devname, int baud, String settings) throws IOException {
+  public SlaveContainer(Platform platform, String devname, int baud, String settings) {
     super(platform);
     this.hostname = devname;
     this.port = -1;
@@ -97,7 +99,7 @@ public class SlaveContainer extends RemoteContainer {
    * @param baud baud rate for the RS232 port.
    * @param settings RS232 settings (null for defaults, or "N81" for no parity, 8 bits, 1 stop bit).
    */
-  public SlaveContainer(Platform platform, String name, String devname, int baud, String settings) throws IOException {
+  public SlaveContainer(Platform platform, String name, String devname, int baud, String settings) {
     super(platform, name);
     this.hostname = devname;
     this.port = -1;
@@ -169,7 +171,6 @@ public class SlaveContainer extends RemoteContainer {
       rq.relay = true;
       String json = rq.toJson();
       master.println(json);
-      return true;
     } else {
       if (super.send(m, false)) return true;
       if (!relay) return false;
@@ -180,8 +181,8 @@ public class SlaveContainer extends RemoteContainer {
       rq.relay = true;
       String json = rq.toJson();
       master.println(json);
-      return true;
     }
+    return true;
   }
 
   @Override
@@ -193,7 +194,7 @@ public class SlaveContainer extends RemoteContainer {
     String json = rq.toJson();
     JsonMessage rsp = master.printlnAndGetResponse(json, rq.id, TIMEOUT);
     if (rsp == null) return null;
-    if (rsp.auth != null && rsp.auth == false) throw new AuthFailureException();
+    if (rsp.auth != null && !rsp.auth) throw new AuthFailureException();
     return rsp.agentIDs;
   }
 
@@ -206,7 +207,7 @@ public class SlaveContainer extends RemoteContainer {
     String json = rq.toJson();
     JsonMessage rsp = master.printlnAndGetResponse(json, rq.id, TIMEOUT);
     if (rsp == null) return null;
-    if (rsp.auth != null && rsp.auth == false) throw new AuthFailureException();
+    if (rsp.auth != null && !rsp.auth) throw new AuthFailureException();
     return rsp.services;
   }
 
@@ -220,7 +221,7 @@ public class SlaveContainer extends RemoteContainer {
     String json = rq.toJson();
     JsonMessage rsp = master.printlnAndGetResponse(json, rq.id, TIMEOUT);
     if (rsp == null) return null;
-    if (rsp.auth != null && rsp.auth == false) throw new AuthFailureException();
+    if (rsp.auth != null && !rsp.auth) throw new AuthFailureException();
     return rsp.agentID;
   }
 
@@ -234,7 +235,7 @@ public class SlaveContainer extends RemoteContainer {
     String json = rq.toJson();
     JsonMessage rsp = master.printlnAndGetResponse(json, rq.id, TIMEOUT);
     if (rsp == null) return null;
-    if (rsp.auth != null && rsp.auth == false) throw new AuthFailureException();
+    if (rsp.auth != null && !rsp.auth) throw new AuthFailureException();
     return rsp.agentIDs;
   }
 
@@ -280,8 +281,9 @@ public class SlaveContainer extends RemoteContainer {
   @Override
   public String getState() {
     if (!running) return "Not running";
-    if (master == null) return "Running, connecting to "+hostname+(port>=0?":"+port:"@"+baud)+"...";
-    return "Running, connected to "+hostname+(port>=0?":"+port:"@"+baud);
+    String details = port >= 0 ? ":" + port : "@" + baud;
+    if (master == null) return "Running, connecting to " + displayhost(hostname, port, baud);
+    return "Running, connected to "+ displayhost(hostname, port, baud);
   }
 
   @Override
@@ -341,7 +343,7 @@ public class SlaveContainer extends RemoteContainer {
     master = new ConnectionHandler(conn, SlaveContainer.this);
   }
 
-  private void connectToMaster() throws IOException {
+  private void connectToMaster() {
     new Thread(getClass().getSimpleName()+">"+hostname) {
       @Override
       public void run() {
@@ -349,11 +351,12 @@ public class SlaveContainer extends RemoteContainer {
           while (!quit) {
             try {
               tryConnecting();
-              log.info("Connected to "+hostname+":"+(port>=0?":"+port:"@"+baud));
+              String details = port >= 0 ? ":" + port : "@" + baud;
+              log.info("Connected to "+ displayhost(hostname, port, baud));
               while (!quit && !inited) Thread.sleep(100);
               master.start();
               master.join();
-              log.info("Connection to "+hostname+(port>=0?":"+port:"@"+baud)+" lost");
+              log.info("Connection to "+  displayhost(hostname, port, baud) + " lost");
               synchronized (SlaveContainer.this) {
                 master = null;
               }
@@ -372,10 +375,9 @@ public class SlaveContainer extends RemoteContainer {
   private synchronized void updateWatchList() {
     if (master == null) return;
     List<AgentID> watchList = new ArrayList<>();
-    for (AgentID aid: getLocalAgents())
-      watchList.add(aid);
+    Collections.addAll(watchList, getLocalAgents());
     for (AgentID aid: topics.keySet())
-      if (topics.get(aid).size() > 0)
+      if (!topics.get(aid).isEmpty())
         watchList.add(aid);
     JsonMessage rq = new JsonMessage();
     rq.action = Action.WANTS_MESSAGES_FOR;
@@ -386,6 +388,10 @@ public class SlaveContainer extends RemoteContainer {
       master.println(json);
       watchListCache = json;
     }
+  }
+
+  private static String displayhost(String hostname, int port, int baud) {
+    return hostname + (port >= 0 ? ":" + port : "@" + baud);
   }
 
 }

--- a/src/main/java/org/arl/fjage/remote/Tunnel.java
+++ b/src/main/java/org/arl/fjage/remote/Tunnel.java
@@ -7,7 +7,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import org.arl.fjage.*;
 import org.arl.fjage.param.*;
-import org.arl.fjage.remote.JsonMessage;
 import org.arl.fjage.connectors.*;
 
 /**
@@ -31,8 +30,8 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
   protected int port;
 
   protected TcpServer server = null;
-  protected List<AgentID> agents = new ArrayList<>();
-  protected List<Connector> connectors = new ArrayList<>();
+  protected final List<AgentID> agents = new ArrayList<>();
+  protected final List<Connector> connectors = new ArrayList<>();
   protected ExecutorService writeExecutor = null;
   protected ExecutorService readExecutor = null;
   protected int connID = 0;
@@ -138,7 +137,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
     AgentID sender = msg.getSender();
     if (rcpt == null || sender == null) return false;
     if (sender.getName().contains("@")) return false;
-    boolean shouldForward = false;
+    boolean shouldForward;
     synchronized (agents) {
       shouldForward = agents.contains(rcpt);
     }
@@ -151,11 +150,11 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
         for (Connector c: connectors)
           sendToRemote(c, json.getBytes(StandardCharsets.UTF_8));
       }
-      if (!rcpt.isTopic()) return true;
+      return !rcpt.isTopic();
     } else if (!rcpt.isTopic() && rcpt.getName().contains("@")) {
-      int id = 0;
-      Connector c = null;
-      String rname = null;
+      int id;
+      Connector c;
+      String rname;
       try {
         String s = rcpt.getName();
         int i = s.lastIndexOf('@');
@@ -181,47 +180,41 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
   }
 
   protected void monitor(int id, Connector c) {
-    readExecutor.submit(new Runnable() {
-      @Override
-      public void run() {
-        String cname = c.getName();
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(c.getInputStream(), StandardCharsets.UTF_8))) {
-          String line;
-          while ((line = in.readLine()) != null) {
-            log.info(id+" >> "+line);
-            JsonMessage jmsg = JsonMessage.fromJson(line);
-            if (jmsg == null || jmsg.message == null) continue;
-            AgentID sender = jmsg.message.getSender();
-            if (sender == null) continue;
-            jmsg.message.setSender(new AgentID(sender.getName() + "@" + id));
-            getContainer().send(jmsg.message);
-          }
-        } catch (IOException ex) {
-          log.info("Read from "+cname+" failed: "+ex.getMessage());
-        } catch (Exception ex) {
-          log.log(Level.WARNING, "Exception on "+cname+": "+ex.getMessage(), ex);
+    readExecutor.submit(() -> {
+      String cname = c.getName();
+      try (BufferedReader in = new BufferedReader(new InputStreamReader(c.getInputStream(), StandardCharsets.UTF_8))) {
+        String line;
+        while ((line = in.readLine()) != null) {
+          log.info(id+" >> "+line);
+          JsonMessage jmsg = JsonMessage.fromJson(line);
+          if (jmsg == null || jmsg.message == null) continue;
+          AgentID sender = jmsg.message.getSender();
+          if (sender == null) continue;
+          jmsg.message.setSender(new AgentID(sender.getName() + "@" + id));
+          getContainer().send(jmsg.message);
         }
-        removeConnector(c);
+      } catch (IOException ex) {
+        log.info("Read from "+cname+" failed: "+ex.getMessage());
+      } catch (Exception ex) {
+        log.log(Level.WARNING, "Exception on "+cname+": "+ex.getMessage(), ex);
       }
+      removeConnector(c);
     });
   }
 
   protected void sendToRemote(Connector c, byte[] data) {
-    writeExecutor.submit(new Runnable() {
-      @Override
-      public void run() {
-        try {
-          OutputStream out = c.getOutputStream();
-          if (out == null) removeConnector(c);
-          else synchronized (out) {
-            out.write(data);
-            out.write('\n');
-            out.flush();
-          }
-        } catch (IOException ex) {
-          log.warning("Write to "+c.getName()+" failed: "+ex.getMessage());
-          removeConnector(c);
+    writeExecutor.submit(() -> {
+      try {
+        OutputStream out = c.getOutputStream();
+        if (out == null) removeConnector(c);
+        else synchronized (out) {
+          out.write(data);
+          out.write('\n');
+          out.flush();
         }
+      } catch (IOException ex) {
+        log.warning("Write to "+c.getName()+" failed: "+ex.getMessage());
+        removeConnector(c);
       }
     });
   }
@@ -266,9 +259,7 @@ public class Tunnel extends Agent implements ConnectionListener, MessageListener
    */
   public List<AgentID> getAgents() {
     synchronized (agents) {
-      List<AgentID> copy = new ArrayList<>();
-      for (AgentID aid: agents) copy.add(aid);
-      return copy;
+      return new ArrayList<>(agents);
     }
   }
 


### PR DESCRIPTION
This PR doesn't change any functionality, but just cleans up the classes related to remote containers based on some JDK8 features.

- Convert generics based initializers to use the diamond (`<>`) operator
- Make fields that used for synchronisation `final`.
- Make fields that don't change `final`.
- Use modern Java methods like `isEmpty` instead of checking `.size() == 0` and `.computeIfAbsent`
- Convert simple for loops to `for (v: Iterable)` loop
- Change logs to `log.log` if logging exceptions.