### PR TITLE
Add `py.typed` marker to fjagepy

### DIFF
--- a/gateways/python/fjagepy/AgentID.py
+++ b/gateways/python/fjagepy/AgentID.py
@@ -240,32 +240,25 @@ class AgentID:
         new_aid._timeout = self._timeout
         return new_aid
 
-# Magic methods to support dynamic parameter access using dot notation
+    # Magic methods to support dynamic parameter access using dot notation
+    def __getattr__(self, param: str) -> None | Any:
+        if param in ['name', 'owner', 'topic', 'index', '_timeout'] or param.startswith('_ipython'):
+            return self.__dict__[param]
 
-def __getter(self, param: str) -> None | Any:
-    if param in ['name', 'owner', 'topic', 'index', '_timeout'] or param.startswith('_ipython'):
-        return self.__dict__[param]
+        from .Message import ParameterReq
 
-    from .Message import ParameterReq
+        rsp = self.request(ParameterReq(index=self.index).get(param))
+        if rsp is None or 'param' not in rsp.__dict__ or 'value' not in rsp.__dict__:
+            return None
+        return rsp.__dict__.get('value', None)
 
-    rsp = self.request(ParameterReq(index=self.index).get(param))
-    if rsp is None or 'param' not in rsp.__dict__ or 'value' not in rsp.__dict__:
-        return None
-    return rsp.__dict__.get('value', None)
+    def __setattr__(self, param : str, value : Any) -> Any | None:
+        if param in ['name', 'owner', 'topic', 'index', '_timeout']:
+            self.__dict__[param] = value
+            return value
 
-
-setattr(AgentID, '__getattr__', __getter)
-
-
-def __setter(self, param : str, value : Any) -> Any | None:
-    if param in ['name', 'owner', 'topic', 'index', '_timeout']:
-        self.__dict__[param] = value
-        return value
-
-    from .Message import ParameterReq
-    rsp = self.request(ParameterReq(index=self.index).set(param, value))
-    if rsp is None or 'param' not in rsp.__dict__ or 'value' not in rsp.__dict__:
-        return None
-    return rsp.__dict__.get('value', None)
-
-setattr(AgentID, '__setattr__', __setter)
+        from .Message import ParameterReq
+        rsp = self.request(ParameterReq(index=self.index).set(param, value))
+        if rsp is None or 'param' not in rsp.__dict__ or 'value' not in rsp.__dict__:
+            return None
+        return rsp.__dict__.get('value', None)


### PR DESCRIPTION
Now that most type-checking issues have been fixed in https://github.com/org-arl/fjage/pull/399, I think it's a good idea to expose these types to dependent packages by adding a [`py.typed` marker file](https://peps.python.org/pep-0561/#packaging-type-information). One example of a package that would benefit greatly from the types is unetpy (in unetsockets) (see https://github.com/org-arl/unetsockets/pull/19).

In addition to adding the `py.typed` marker, I've also moved the `__getter` and `__setter` functions for `AgentID` so that they're defined directly in `AgentID` as `__getattr__` and `__setattr__` respectively. Previously, they were dynamically set on the class using `setattr(AgentID, '__getattr__', __getter)` and `setattr(AgentID, '__setattr__', __setter)`, which doesn't play nice with static type checkers.