### PR TITLE
Fix import error when `numpy` is not installed in `fjagepy`

### DIFF
--- a/gateways/python/fjagepy/Message.py
+++ b/gateways/python/fjagepy/Message.py
@@ -32,8 +32,6 @@ try:
 
 except ImportError:
     _NUMPY_AVAILABLE = False
-    def _serialize_numpy_array(value: numpy.ndarray, key: str, props: Dict):
-        return value
 
 def _normalize_field_name(name: str) -> str:
     """

--- a/gateways/python/test/test_message.py
+++ b/gateways/python/test/test_message.py
@@ -1,4 +1,5 @@
 import inspect
+import pytest
 
 from fjagepy import Message, AgentID, Performative, MessageClass, message
 
@@ -81,7 +82,7 @@ def test_messageclass_name_req():
 
 def test_message_encode_numpy_array():
     """Message should encode numpy arrays correctly."""
-    import numpy as np
+    np = pytest.importorskip("numpy")
     arr = np.array([1, 2, 3])
     msg = Message()
     msg.data = arr
@@ -91,7 +92,7 @@ def test_message_encode_numpy_array():
 
 def test_message_encode_complex_array():
     """Message should encode complex arrays correctly."""
-    import numpy as np
+    np = pytest.importorskip("numpy")
     arr = np.array([1+2j, 3+4j, 5+6j])
     msg = Message()
     msg.data = arr


### PR DESCRIPTION
`numpy` is not listed as a dependency of `fjagepy`. However, importing `fjagepy` causes an `ImportError` as it tries to import `numpy`. The problem is that, although we do check if `numpy` is installed, in the case where `numpy` is *not* installed, we are using `numpy.ndarray` in the type:
https://github.com/org-arl/fjage/blob/c09f1b76f9a89cba13baa0422060af2928faad40/gateways/python/fjagepy/Message.py#L33-L36

The only use of `_serialize_numpy_array` is here:
https://github.com/org-arl/fjage/blob/c09f1b76f9a89cba13baa0422060af2928faad40/gateways/python/fjagepy/Message.py#L136-L137

Since it already checks the `_NUMPY_AVAILABLE` flag, we can just omit the `_serialize_numpy_array()` definition in the case where `numpy` isn't installed.
