### PR TITLE
Add support for new iframe-parent messaging in webshell

### DIFF
--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -6,7 +6,7 @@
 - window.prefersColorScheme : 'dark'/'light' used to set the default colour scheme (and disable toggle)
 - receive window.postMessage({type: IFRAME_COLOUR_EVENT, scheme: 'dark'/'light'}) : to set the colour scheme dynamically
 - receive window.postMessage({type: IFRAME_FOCUS_EVENT}) : to focus the shell (only when in an iframe)
-- will transmit a window.postMessage({type: IFRAME_BRIDGE_EVENT, action: 'toggle'}) : if a (Ctrl+)Backquote key is pressed while the shell is focused
+- will transmit a window.postMessage({type: IFRAME_TOGGLE_EVENT, action: 'toggle'}) : if a Ctrl+Backquote key is pressed while the shell is focused
 
 -->
 <html>

--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -137,6 +137,7 @@
     const HIDE_CURSOR = "\x1B[?25l"; // hide cursor
     const CLEAR_LINE = '\x1B[1G\x1B[2K'; // clear line
     const CONNECTION_LOST = "\x1B[1G\x1B[2K\x1B[31m\x1B[2m(connection lost)\x1B[0m"; // connection lost message
+    const IFRAME_BRIDGE_EVENT = 'fjage:shell-toggle';
 
     let currentScheme = null;
     let userScheme = false; // true if the user manually changed the scheme
@@ -265,6 +266,18 @@
           fitAddon.fit();
         }, RESIZE_DELAY);
       });
+
+      if (window.parent !== window) {
+        window.addEventListener('keydown', (event) => {
+          if (!event.ctrlKey || event.altKey || event.metaKey || event.code !== 'Backquote') return;
+          event.preventDefault();
+          window.parent.postMessage({
+            type: IFRAME_BRIDGE_EVENT,
+            action: 'toggle'
+          }, window.location.origin);
+        }, true);
+      }
+
     });
 
 

--- a/src/main/resources/org/arl/fjage/web/shell/index.html
+++ b/src/main/resources/org/arl/fjage/web/shell/index.html
@@ -4,7 +4,9 @@
 
 - window.shellready : will be true when the shell is ready to accept input
 - window.prefersColorScheme : 'dark'/'light' used to set the default colour scheme (and disable toggle)
-- window.postMessage({scheme: 'dark'/'light'}) : to set the colour scheme dynamically
+- receive window.postMessage({type: IFRAME_COLOUR_EVENT, scheme: 'dark'/'light'}) : to set the colour scheme dynamically
+- receive window.postMessage({type: IFRAME_FOCUS_EVENT}) : to focus the shell (only when in an iframe)
+- will transmit a window.postMessage({type: IFRAME_BRIDGE_EVENT, action: 'toggle'}) : if a (Ctrl+)Backquote key is pressed while the shell is focused
 
 -->
 <html>
@@ -137,7 +139,9 @@
     const HIDE_CURSOR = "\x1B[?25l"; // hide cursor
     const CLEAR_LINE = '\x1B[1G\x1B[2K'; // clear line
     const CONNECTION_LOST = "\x1B[1G\x1B[2K\x1B[31m\x1B[2m(connection lost)\x1B[0m"; // connection lost message
-    const IFRAME_BRIDGE_EVENT = 'fjage:shell-toggle';
+    const IFRAME_TOGGLE_EVENT = 'fjage:shell-toggle';
+    const IFRAME_COLOUR_EVENT = 'fjage:shell-color-scheme';
+    const IFRAME_FOCUS_EVENT = 'fjage:shell-focus';
 
     let currentScheme = null;
     let userScheme = false; // true if the user manually changed the scheme
@@ -202,7 +206,7 @@
 
       // Change scheme on message from parent document
       window.addEventListener('message', evt => {
-        if (evt.data && evt.data.scheme){
+        if (evt.data && evt.data.type === IFRAME_COLOUR_EVENT && evt.data.scheme) {
           setScheme(term, evt.data.scheme, true);
         }
       });
@@ -267,12 +271,19 @@
         }, RESIZE_DELAY);
       });
 
+      // Listen for messages from the parent document to focus
+      window.addEventListener('message', evt => {
+        if (evt.data && evt.data.type === IFRAME_FOCUS_EVENT) {
+          term.focus();
+        }
+      });
+
       if (window.parent !== window) {
         window.addEventListener('keydown', (event) => {
           if (!event.ctrlKey || event.altKey || event.metaKey || event.code !== 'Backquote') return;
           event.preventDefault();
           window.parent.postMessage({
-            type: IFRAME_BRIDGE_EVENT,
+            type: IFRAME_TOGGLE_EVENT,
             action: 'toggle'
           }, window.location.origin);
         }, true);


### PR DESCRIPTION
With this change the web shell support 2 incoming and transmits a 1 new event using (`window.postMessage`) for communicating with a host webpage when the web shell is used as an iFrame. 

It's common for the fjåge web shell to be used in an iframe. To support the host application to communicate with the webshell iframe, we use `window.postMessage` to send events back and forth.

This PR adds the following events

- An incoming `window.postMessage({type: IFRAME_FOCUS_EVENT})` which will force the iframe to force the HTML user focus on terminal. 
- An outgoing `window.postMessage({type: IFRAME_TOGGLE_EVENT, action: 'toggle'}) ` which is triggered when the iframe detects the (Ctrl+Backquote) keypress. This maybe be used by the host in showing/hiding the shell when displayed as an overlay for example.

This PR also changes the format of the existing color scheme event, which is an incoming event that the host uses to indicate to the iframe that the user has selected a different colour scheme/mode.