### PR TITLE
Improve fjagejs JSDoc types

### DIFF
--- a/gateways/js/fjage.d.ts
+++ b/gateways/js/fjage.d.ts
@@ -1,0 +1,10 @@
+import './dist/esm/message.js';
+
+export as namespace fjage;
+export * from './dist/esm/fjage.js';
+
+declare module './dist/esm/message.js' {
+  interface GenericMessage {
+    [key: string]: unknown;
+  }
+}

--- a/gateways/js/package.json
+++ b/gateways/js/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "npx eslint src/*.js && tsc && rollup --silent -c rollup.config.js",
     "pretest": "playwright install --with-deps && node test/spec/create-spec.cjs",
+    "typecheck": "tsc",
     "test": "node test/run-tests.cjs",
     "docs": "npx documentation lint src/**; npx documentation build src/gateway.js src/message.js src/agentid.js src/performative.js src/services.js src/jsonmessage.js --config documentation.yml -f html --github --document-exported -o ../../docs/jsdoc",
     "clean": "npx rimraf -rf dist/"

--- a/gateways/js/package.json
+++ b/gateways/js/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "npx eslint src/*.js && tsc && rollup --silent -c rollup.config.js",
     "pretest": "playwright install --with-deps && node test/spec/create-spec.cjs",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "test": "node test/run-tests.cjs",
     "docs": "npx documentation lint src/**; npx documentation build src/gateway.js src/message.js src/agentid.js src/performative.js src/services.js src/jsonmessage.js --config documentation.yml -f html --github --document-exported -o ../../build/docs/jsdoc",
     "clean": "npx rimraf -rf dist/"

--- a/gateways/js/package.json
+++ b/gateways/js/package.json
@@ -3,14 +3,16 @@
   "version": "2.4.0",
   "description": "JS Gateway for fjåge",
   "main": "./dist/cjs/fjage.cjs",
-  "types": "./dist/esm/fjage.d.ts",
+  "types": "./fjage.d.ts",
   "exports": {
+    "types": "./fjage.d.ts",
     "import": "./dist/esm/fjage.js",
     "require": "./dist/cjs/fjage.cjs"
   },
   "type": "module",
   "files": [
-    "dist/**"
+    "dist/**",
+    "fjage.d.ts"
   ],
   "scripts": {
     "build": "npx eslint src/*.js && tsc && rollup --silent -c rollup.config.js",

--- a/gateways/js/package.json
+++ b/gateways/js/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "npx eslint src/*.js && tsc && rollup --silent -c rollup.config.js",
     "pretest": "playwright install --with-deps && node test/spec/create-spec.cjs",
+    "typecheck": "tsc",
     "test": "node test/run-tests.cjs",
     "docs": "npx documentation lint src/**; npx documentation build src/gateway.js src/message.js src/agentid.js src/performative.js src/services.js src/jsonmessage.js --config documentation.yml -f html --github --document-exported -o ../../build/docs/jsdoc",
     "clean": "npx rimraf -rf dist/"

--- a/gateways/js/package.json
+++ b/gateways/js/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "npx eslint src/*.js && tsc && rollup --silent -c rollup.config.js",
     "pretest": "playwright install --with-deps && node test/spec/create-spec.cjs",
-    "typecheck": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "node test/run-tests.cjs",
     "docs": "npx documentation lint src/**; npx documentation build src/gateway.js src/message.js src/agentid.js src/performative.js src/services.js src/jsonmessage.js --config documentation.yml -f html --github --document-exported -o ../../build/docs/jsdoc",
     "clean": "npx rimraf -rf dist/"

--- a/gateways/js/src/agentid.js
+++ b/gateways/js/src/agentid.js
@@ -9,14 +9,33 @@ const DEFAULT_TIMEOUT = 10000; // Default timeout for non-owned AgentIDs
 /**
 * An identifier for an agent or a topic. This can be to send, receive messages, and set or get parameters
 * on an agent or topic on the fjåge master container.
-*
-* @class
-* @param {string} name - name of the agent
-* @param {boolean} [topic=false] - name of topic
-* @param {Gateway} [owner] - Gateway owner for this AgentID
 */
 export class AgentID {
+  /**
+   * Name of the agent
+   * @type {string}
+   */
+  name;
 
+  /**
+   * Whether the identifer is for a topic
+   * @type {boolean}
+   */
+  topic;
+
+  /**
+   * Gateway owner for this AgentID
+   * @type {Gateway}
+   */
+  owner;
+
+  /**
+   * Construct an AgentID.
+   *
+   * @param {string} name
+   * @param {boolean} [topic=false]
+   * @param {Gateway} [owner]
+   */
   constructor(name, topic=false, owner) {
     this.name = name;
     this.topic = topic;
@@ -86,9 +105,9 @@ export class AgentID {
   }
 
   /**
-   * Inflate the AgentID from a JSON string or object.
+   * Inflate the AgentID from a JSON string.
    *
-   * @param {string} json - JSON string or object to be converted to an AgentID
+   * @param {string} json - JSON string to be converted to an AgentID
    * @param {Gateway} [owner] - Gateway owner for this AgentID
    * @returns {AgentID} - AgentID created from the JSON string or object
    */
@@ -105,19 +124,42 @@ export class AgentID {
   }
 
   /**
+   * @overload
+   * @param {string} param - parameter name to set
+   * @param {unknown} value - parameter value to set
+   * @param {number} [index=-1] - index of parameter to be set
+   * @param {number} [timeout=owner.timeout] - timeout for the response
+   * @returns {Promise<unknown>} - a promise which returns the new value of the parameter
+   */
+
+  /**
+   * @overload
+   * @param {string[]} params - parameter names to set
+   * @param {unknown[]} values - parameter values to set
+   * @param {number} [index=-1] - index of parameters to be set
+   * @param {number} [timeout=owner.timeout] - timeout for the response
+   * @returns {Promise<unknown[]>} - a promise which returns the new value of the parameters
+   */
+
+  /**
   * Sets parameter(s) on the Agent referred to by this AgentID.
   *
   * @param {(string|string[])} params - parameters name(s) to be set
-  * @param {(Object|Object[])} values - parameters value(s) to be set
+  * @param {(unknown|unknown[])} values - parameters value(s) to be set
   * @param {number} [index=-1] - index of parameter(s) to be set
   * @param {number} [timeout=owner.timeout] - timeout for the response
-  * @returns {Promise<(Object|Object[])>} - a promise which returns the new value(s) of the parameters
+  * @returns {Promise<(unknown | unknown[])>} - a promise which returns the new value(s) of the parameters
   */
   async set (params, values, index=-1, timeout=this._timeout) {
     if (!params) return null;
     let msg = new ParameterReq();
     msg.recipient = this;
-    if (Array.isArray(params)){
+
+    if (Array.isArray(params)) {
+      if (!Array.isArray(values)) {
+        throw new Error('Values must be an array because an array was passed for parameters');
+      }
+
       if (params.length != values.length) throw new Error(`Parameters and values arrays must have the same length: ${params.length} != ${values.length}`);
       const clonedParams = params.slice(); // Clone the array to avoid side effects
       const clonedValues = values.slice(); // Clone the values array
@@ -136,32 +178,48 @@ export class AgentID {
     msg.index = Number.isInteger(index) ? index : -1;
     const rsp = await this.owner.request(msg, timeout);
     var ret = Array.isArray(params) ? new Array(params.length).fill(null) : null;
-    if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) {
+    if (!rsp || rsp.perf != Performative.INFORM || !('param' in rsp) || !rsp.param || typeof rsp.param !== 'string') {
       if (this.owner._returnNullOnFailedResponse) return ret;
       else throw new Error(`Unable to set ${this.name}.${params} to ${values}`);
     }
     if (Array.isArray(params)) {
-      if (!rsp.values) rsp.values = {};
-      if (rsp.param) rsp.values[rsp.param] = rsp.value;
-      const rkeys = Object.keys(rsp.values);
+      const values = 'values' in rsp && rsp.values ? rsp.values : {};
+      values[rsp.param] = 'value' in rsp ? rsp.value : undefined;
+      const rkeys = Object.keys(values);
       return params.map( p => {
         if (p.includes('.')) p = p.split('.').pop();
         let f = rkeys.find(k => (k.includes('.') ? k.split('.').pop() : k) == p);
-        return f ? rsp.values[f] : undefined;
+        return f ? values[f] : undefined;
       });
     } else {
-      return rsp.value;
+      return 'value' in rsp ? rsp.value : undefined;
     }
   }
 
 
   /**
+   * @overload
+   * @param {string} param - name of the parameter to get
+   * @param {number} [index=-1] - index of the parameter to get
+   * @param {number} [timeout=owner.timeout] - timeout for the response
+   * @returns {Promise<unknown>} - a promise which returns the value of the parameter
+   */
+
+  /**
+   * @overload
+   * @param {string[] | null} param - names of the parameters to get, or null to get the value of all parameters on the Agent
+   * @param {number} [index=-1] - index of parameters to get
+   * @param {number} [timeout=owner.timeout] - timeout for the response
+   * @returns {Promise<unknown[]>} - a promise which returns the values of the parameters
+   */
+
+  /**
   * Gets parameter(s) on the Agent referred to by this AgentID.
   *
-  * @param {(string|string[])} params - parameters name(s) to be get, null implies get value of all parameters on the Agent
+  * @param {string | string[] | null} params - parameters name(s) to be get, null implies get value of all parameters on the Agent
   * @param {number} [index=-1] - index of parameter(s) to be get
   * @param {number} [timeout=owner.timeout] - timeout for the response
-  * @returns {Promise<(Object|Object[])>} - a promise which returns the value(s) of the parameters
+  * @returns {Promise<unknown | unknown[]>} - a promise which returns the value(s) of the parameters
   */
   async get(params, index=-1, timeout=this._timeout) {
     let msg = new ParameterReq();
@@ -177,26 +235,26 @@ export class AgentID {
     msg.index = Number.isInteger(index) ? index : -1;
     const rsp = await this.owner.request(msg, timeout);
     var ret = Array.isArray(params) ? new Array(params.length).fill(null) : null;
-    if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) {
+    if (!rsp || rsp.perf != Performative.INFORM || !('param' in rsp) || !rsp.param || typeof rsp.param !== 'string') {
       if (this.owner._returnNullOnFailedResponse) return ret;
       else throw new Error(`Unable to get ${this.name}.${params}`);
     }
     // Request for listing of all parameters.
     if (!params) {
-      if (!rsp.values) rsp.values = {};
-      if (rsp.param) rsp.values[rsp.param] = rsp.value;
-      return rsp.values;
+      const values = 'values' in rsp && rsp.values ? rsp.values : {};
+      values[rsp.param] = 'value' in rsp ? rsp.value : undefined;
+      return values;
     } else if (Array.isArray(params)) {
-      if (!rsp.values) rsp.values = {};
-      if (rsp.param) rsp.values[rsp.param] = rsp.value;
-      const rkeys = Object.keys(rsp.values);
+      const values = 'values' in rsp && rsp.values ? rsp.values : {};
+      values[rsp.param] = 'value' in rsp ? rsp.value : undefined;
+      const rkeys = Object.keys(values);
       return params.map( p => {
         if (p.includes('.')) p = p.split('.').pop();
         let f = rkeys.find(k => (k.includes('.') ? k.split('.').pop() : k) == p);
-        return f ? rsp.values[f] : undefined;
+        return f ? values[f] : undefined;
       });
     } else {
-      return rsp.value;
+      return 'value' in rsp ? rsp.value : undefined;
     }
   }
 }

--- a/gateways/js/src/agentid.js
+++ b/gateways/js/src/agentid.js
@@ -26,7 +26,7 @@ export class AgentID {
 
   /**
    * Gateway owner for this AgentID
-   * @type {Gateway}
+   * @type {Gateway|undefined}
    */
   owner;
 
@@ -153,6 +153,7 @@ export class AgentID {
   */
   async set (params, values, index=-1, timeout=this._timeout) {
     if (!params) return null;
+    if (!this.owner) throw new Error('Unowned AgentID cannot set parameters');
     let msg = new ParameterReq();
     msg.recipient = this;
 
@@ -231,6 +232,7 @@ export class AgentID {
   * @returns {Promise<unknown | unknown[]>} - a promise which returns the value(s) of the parameters
   */
   async get(params, index=-1, timeout=this._timeout) {
+    if (!this.owner) throw new Error('Unowned AgentID cannot get parameters');
     let msg = new ParameterReq();
     msg.recipient = this;
     if (params){

--- a/gateways/js/src/agentid.js
+++ b/gateways/js/src/agentid.js
@@ -208,10 +208,18 @@ export class AgentID {
 
   /**
    * @overload
-   * @param {string[] | null} param - names of the parameters to get, or null to get the value of all parameters on the Agent
+   * @param {string[]} params - names of the parameters to get
    * @param {number} [index=-1] - index of parameters to get
    * @param {number} [timeout=owner.timeout] - timeout for the response
    * @returns {Promise<unknown[]>} - a promise which returns the values of the parameters
+   */
+
+  /**
+   * @overload
+   * @param {null} [params] - null or omitted to get all parameters on the Agent
+   * @param {number} [index=-1] - index of parameters to get
+   * @param {number} [timeout=owner.timeout] - timeout for the response
+   * @returns {Promise<Record<string, unknown>>} - a promise which returns a map of parameter names to values
    */
 
   /**

--- a/gateways/js/src/agentid.js
+++ b/gateways/js/src/agentid.js
@@ -110,7 +110,7 @@ export class AgentID {
    *
    * @param {string} json - JSON string to be converted to an AgentID
    * @param {Gateway} [owner] - Gateway owner for this AgentID
-   * @returns {AgentID} - AgentID created from the JSON string or object
+   * @returns {AgentID} - AgentID created from the JSON string
    */
   static fromJSON(json, owner) {
     if (typeof json !== 'string') {

--- a/gateways/js/src/agentid.js
+++ b/gateways/js/src/agentid.js
@@ -10,14 +10,33 @@ const DEFAULT_TIMEOUT = 1000; // Default timeout for non-owned AgentIDs
 /**
 * An identifier for an agent or a topic. This can be to send, receive messages, and set or get parameters
 * on an agent or topic on the fjåge master container.
-*
-* @class
-* @param {string} name - name of the agent
-* @param {boolean} [topic=false] - name of topic
-* @param {Gateway} [owner] - Gateway owner for this AgentID
 */
 export class AgentID {
+  /**
+   * Name of the agent
+   * @type {string}
+   */
+  name;
 
+  /**
+   * Whether the identifer is for a topic
+   * @type {boolean}
+   */
+  topic;
+
+  /**
+   * Gateway owner for this AgentID
+   * @type {Gateway}
+   */
+  owner;
+
+  /**
+   * Construct an AgentID.
+   *
+   * @param {string} name
+   * @param {boolean} [topic=false]
+   * @param {Gateway} [owner]
+   */
   constructor(name, topic=false, owner) {
     this.name = name;
     this.topic = topic;
@@ -87,9 +106,9 @@ export class AgentID {
   }
 
   /**
-   * Inflate the AgentID from a JSON string or object.
+   * Inflate the AgentID from a JSON string.
    *
-   * @param {string} json - JSON string or object to be converted to an AgentID
+   * @param {string} json - JSON string to be converted to an AgentID
    * @param {Gateway} [owner] - Gateway owner for this AgentID
    * @returns {AgentID} - AgentID created from the JSON string or object
    */
@@ -106,19 +125,42 @@ export class AgentID {
   }
 
   /**
+   * @overload
+   * @param {string} param - parameter name to set
+   * @param {unknown} value - parameter value to set
+   * @param {number} [index=-1] - index of parameter to be set
+   * @param {number} [timeout=owner.timeout] - timeout for the response
+   * @returns {Promise<unknown>} - a promise which returns the new value of the parameter
+   */
+
+  /**
+   * @overload
+   * @param {string[]} params - parameter names to set
+   * @param {unknown[]} values - parameter values to set
+   * @param {number} [index=-1] - index of parameters to be set
+   * @param {number} [timeout=owner.timeout] - timeout for the response
+   * @returns {Promise<unknown[]>} - a promise which returns the new value of the parameters
+   */
+
+  /**
   * Sets parameter(s) on the Agent referred to by this AgentID.
   *
   * @param {(string|string[])} params - parameters name(s) to be set
-  * @param {(Object|Object[])} values - parameters value(s) to be set
+  * @param {(unknown|unknown[])} values - parameters value(s) to be set
   * @param {number} [index=-1] - index of parameter(s) to be set
   * @param {number} [timeout=owner.timeout] - timeout for the response
-  * @returns {Promise<(Object|Object[])>} - a promise which returns the new value(s) of the parameters
+  * @returns {Promise<(unknown | unknown[])>} - a promise which returns the new value(s) of the parameters
   */
   async set (params, values, index=-1, timeout=this._timeout) {
     if (!params) return null;
     let msg = new ParameterReq();
     msg.recipient = this;
-    if (Array.isArray(params)){
+
+    if (Array.isArray(params)) {
+      if (!Array.isArray(values)) {
+        throw new Error('Values must be an array because an array was passed for parameters');
+      }
+
       if (params.length != values.length) throw new Error(`Parameters and values arrays must have the same length: ${params.length} != ${values.length}`);
       const clonedParams = params.slice(); // Clone the array to avoid side effects
       const clonedValues = values.slice(); // Clone the values array
@@ -138,29 +180,47 @@ export class AgentID {
     }
     msg.index = Number.isInteger(index) ? index : -1;
     const rsp = await this.owner.request(msg, timeout);
-    if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) throw new Error(`Unable to set ${this.name}.${params} to ${values}`);
+    if (!rsp || rsp.perf != Performative.INFORM || !('param' in rsp) || !rsp.param || typeof rsp.param !== 'string') {
+      throw new Error(`Unable to set ${this.name}.${params} to ${values}`);
+    }
     if (Array.isArray(params)) {
-      if (!rsp.values) rsp.values = {};
-      if (rsp.param) rsp.values[rsp.param] = rsp.value;
-      const rkeys = Object.keys(rsp.values);
+      const values = 'values' in rsp && rsp.values ? rsp.values : {};
+      values[rsp.param] = 'value' in rsp ? rsp.value : undefined;
+      const rkeys = Object.keys(values);
       return params.map( p => {
         if (p.includes('.')) p = p.split('.').pop();
         let f = rkeys.find(k => (k.includes('.') ? k.split('.').pop() : k) == p);
-        return f ? rsp.values[f] : undefined;
+        return f ? values[f] : undefined;
       });
     } else {
-      return rsp.value;
+      return 'value' in rsp ? rsp.value : undefined;
     }
   }
 
 
   /**
+   * @overload
+   * @param {string} param - name of the parameter to get
+   * @param {number} [index=-1] - index of the parameter to get
+   * @param {number} [timeout=owner.timeout] - timeout for the response
+   * @returns {Promise<unknown>} - a promise which returns the value of the parameter
+   */
+
+  /**
+   * @overload
+   * @param {string[] | null} param - names of the parameters to get, or null to get the value of all parameters on the Agent
+   * @param {number} [index=-1] - index of parameters to get
+   * @param {number} [timeout=owner.timeout] - timeout for the response
+   * @returns {Promise<unknown[]>} - a promise which returns the values of the parameters
+   */
+
+  /**
   * Gets parameter(s) on the Agent referred to by this AgentID.
   *
-  * @param {(string|string[])} params - parameters name(s) to be get, null implies get value of all parameters on the Agent
+  * @param {string | string[] | null} params - parameters name(s) to be get, null implies get value of all parameters on the Agent
   * @param {number} [index=-1] - index of parameter(s) to be get
   * @param {number} [timeout=owner.timeout] - timeout for the response
-  * @returns {Promise<(Object|Object[])>} - a promise which returns the value(s) of the parameters
+  * @returns {Promise<unknown | unknown[]>} - a promise which returns the value(s) of the parameters
   */
   async get(params, index=-1, timeout=this._timeout) {
     let msg = new ParameterReq();
@@ -179,23 +239,25 @@ export class AgentID {
     }
     msg.index = Number.isInteger(index) ? index : -1;
     const rsp = await this.owner.request(msg, timeout);
-    if (!rsp || rsp.perf != Performative.INFORM || !rsp.param) throw new Error(`Unable to get ${this.name}.${params}`);
+    if (!rsp || rsp.perf != Performative.INFORM || !('param' in rsp) || !rsp.param || typeof rsp.param !== 'string') {
+      throw new Error(`Unable to get ${this.name}.${params}`);
+    }
     // Request for listing of all parameters.
     if (!params) {
-      if (!rsp.values) rsp.values = {};
-      if (rsp.param) rsp.values[rsp.param] = rsp.value;
-      return rsp.values;
+      const values = 'values' in rsp && rsp.values ? rsp.values : {};
+      values[rsp.param] = 'value' in rsp ? rsp.value : undefined;
+      return values;
     } else if (Array.isArray(params)) {
-      if (!rsp.values) rsp.values = {};
-      if (rsp.param) rsp.values[rsp.param] = rsp.value;
-      const rkeys = Object.keys(rsp.values);
+      const values = 'values' in rsp && rsp.values ? rsp.values : {};
+      values[rsp.param] = 'value' in rsp ? rsp.value : undefined;
+      const rkeys = Object.keys(values);
       return params.map( p => {
         if (p.includes('.')) p = p.split('.').pop();
         let f = rkeys.find(k => (k.includes('.') ? k.split('.').pop() : k) == p);
-        return f ? rsp.values[f] : undefined;
+        return f ? values[f] : undefined;
       });
     } else {
-      return rsp.value;
+      return 'value' in rsp ? rsp.value : undefined;
     }
   }
 }

--- a/gateways/js/src/agentid.js
+++ b/gateways/js/src/agentid.js
@@ -19,7 +19,7 @@ export class AgentID {
   name;
 
   /**
-   * Whether the identifer is for a topic
+   * Whether the identifier is for a topic
    * @type {boolean}
    */
   topic;

--- a/gateways/js/src/agentid.js
+++ b/gateways/js/src/agentid.js
@@ -79,7 +79,7 @@ export class AgentID {
   *
   * @param {Message} msg - request to send
   * @param {number} [timeout=owner.timeout] - timeout in milliseconds
-  * @returns {Promise<Message>} - response
+  * @returns {Promise<Message|void>} - response, or no value on timeout
   */
   async request(msg, timeout=this._timeout) {
     msg.recipient = this;

--- a/gateways/js/src/agentid.js
+++ b/gateways/js/src/agentid.js
@@ -79,7 +79,7 @@ export class AgentID {
   *
   * @param {Message} msg - request to send
   * @param {number} [timeout=owner.timeout] - timeout in milliseconds
-  * @returns {Promise<Message|void>} - response, or no value on timeout
+  * @returns {Promise<Message|undefined>} - response message, or undefined on timeout
   */
   async request(msg, timeout=this._timeout) {
     msg.recipient = this;

--- a/gateways/js/src/fjage.js
+++ b/gateways/js/src/fjage.js
@@ -5,6 +5,10 @@ import { Services } from './services.js';
 import { Performative } from './performative.js';
 import { JSONMessage } from './jsonmessage.js';
 
+/** @typedef {import('./gateway.js').GatewayOptions} GatewayOptions */
+/** @typedef {import('./gateway.js').GatewayEventMap} GatewayEventMap */
+/** @typedef {import('./message.js').MessageJSON} MessageJSON */
+
 init();
 
 export { Gateway, AgentID, Message, MessageClass, GenericMessage, Services, ParameterReq, ParameterRsp, Performative, JSONMessage, PutFileReq, GetFileReq, GetFileRsp, DeleteFileReq, ShellExecReq };

--- a/gateways/js/src/gateway.js
+++ b/gateways/js/src/gateway.js
@@ -19,7 +19,10 @@ const GATEWAY_DEFAULTS = {
   'returnNullOnFailedResponse': true
 };
 
+/** @type URL */
 let DEFAULT_URL;
+
+/** @type {{ fjage?: {gateways?: Gateway[]} } & Partial<typeof globalThis>} */
 let gObj = {};
 
 /**
@@ -35,8 +38,8 @@ export function init(){
   if (isBrowser || isWebWorker){
     gObj = window;
     Object.assign(GATEWAY_DEFAULTS, {
-      'hostname': gObj.location.hostname,
-      'port': gObj.location.port,
+      'hostname': window.location.hostname,
+      'port': window.location.port,
       'pathname' : '/ws/'
     });
     DEFAULT_URL = new URL('ws://localhost');
@@ -64,25 +67,104 @@ export function init(){
 *
 * @example <caption>Connects to the origin</caption>
 * const gw = new Gateway();
-*
-* @class
-* @property {AgentID} aid - agent id of the gateway
-* @property {boolean} connected - true if the gateway is connected to the master container
-* @property {boolean} debug - true if debug messages should be logged to the console
-*
-* Constructor arguments:
-* @param {Object} opts
-* @param {string} [opts.hostname="localhost"] - hostname/ip address of the master container to connect to
-* @param {number} [opts.port=1100]          - port number of the master container to connect to
-* @param {string} [opts.pathname=""]        - path of the master container to connect to (for WebSockets)
-* @param {boolean} [opts.keepAlive=true]     - try to reconnect if the connection is lost
-* @param {number} [opts.queueSize=128]      - size of the _queue of received messages that haven't been consumed yet
-* @param {number} [opts.timeout=10000]       - timeout for fjage level messages in ms
-* @param {boolean} [opts.returnNullOnFailedResponse=true] - return null instead of throwing an error when a parameter is not found
-* @param {boolean} [opts.cancelPendingOnDisconnect=false] - cancel pending requests on disconnects
 */
 export class Gateway {
+  /**
+   * Agent ID of the gateway
+   * @type {AgentID}
+   */
+  aid;
 
+  /**
+   * Whether the gateway is connected to the master container
+   * @type {boolean}
+   */
+  connected;
+
+  /**
+   * Whether debug messages should be logged to the console
+   * @type {boolean}
+   */
+  debug;
+
+/**
+   * Timeout for fjage level messages (agentForService, etc.)
+   * @packagee @type {number}
+   */
+  _timeout;
+
+  /**
+   * Whether to reconnect if connection gets closed/errored
+   * @private @type {boolean}
+   */
+  _keepAlive;
+
+  /**
+   * Size of {@link Gateway._queue}
+   * @private @type {number}
+   */
+  _queueSize;
+
+  /**
+   * Whether to return null instead of throwing an error when a parameter is not found
+   * @package @type {boolean}
+   */
+  _returnNullOnFailedResponse;
+
+  /**
+   * Whether to cancel pending requests on disconnect
+   * @private @type {boolean}
+   */
+  _cancelPendingOnDisconnect;
+
+  /**
+   * Map of message IDs to callbacks for pending actions
+   * @private @type {Record<string, (msg: JSONMessage) => void>}
+   */
+  _pending_actions;
+
+  /**
+   * Map for all topics that are subscribed
+   * @private @type {Record<string, boolean>}
+   */
+  _subscriptions;
+
+  /**
+   * Map of UUIDs to callbacks mapping for pending receives
+   * @private @type {Record<string, (msg: Message) => boolean>}
+   */
+  _pending_receives;
+
+  /**
+   * @callback EventListener
+   * @param {unknown} value
+   * @returns {void}
+   */
+  /**
+   * External listeners wanting to listen internal events
+   * @private @type {Record<string, EventListener[]>}
+   */
+  _eventListeners;
+
+  /**
+   * incoming message _queue
+   * @private @type {Array}
+   */
+  _queue;
+
+  /**
+   * Construct a gateway.
+   *
+   * @param {Object} opts
+   * @param {string} [opts.hostname="localhost"] - hostname/ip address of the master container to connect to
+   * @param {number} [opts.port=1100]          - port number of the master container to connect to
+   * @param {string} [opts.pathname=""]        - path of the master container to connect to (for WebSockets)
+   * @param {boolean} [opts.keepAlive=true]     - try to reconnect if the connection is lost
+   * @param {number} [opts.queueSize=128]      - size of the _queue of received messages that haven't been consumed yet
+   * @param {number} [opts.timeout=10000]       - timeout for fjage level messages in ms
+   * @param {boolean} [opts.returnNullOnFailedResponse=true] - return null instead of throwing an error when a parameter is not found
+   * @param {boolean} [opts.cancelPendingOnDisconnect=false] - cancel pending requests on disconnects
+   */
   constructor(opts = {}) {
     // Similar to Object.assign but also overwrites `undefined` and empty strings with defaults
     for (var key in GATEWAY_DEFAULTS){
@@ -90,23 +172,23 @@ export class Gateway {
     }
     var url = DEFAULT_URL;
     url.hostname = opts.hostname;
-    url.port = opts.port;
+    url.port = opts.port.toString();
     url.pathname = opts.pathname;
     let existing = this._getGWCache(url);
     if (existing) return existing;
-    this._timeout = opts.timeout;         // timeout for fjage level messages (agentForService etc)
-    this._keepAlive = opts.keepAlive;     // reconnect if connection gets closed/errored
-    this._queueSize = opts.queueSize;     // size of _queue
-    this._returnNullOnFailedResponse = opts.returnNullOnFailedResponse; // null or error
-    this._cancelPendingOnDisconnect = opts.cancelPendingOnDisconnect; // cancel pending requests on disconnect
-    this._pending_actions = {};            // msgid to callback mapping for pending actions
-    this._subscriptions = {};              // map for all topics that are subscribed
-    this._pending_receives = {};           // uuid to callbacks mapping for pending receives
-    this._eventListeners = {};             // external listeners wanting to listen internal events
-    this._queue = [];                      // incoming message _queue
-    this.connected = false;               // connection status
-    this.debug = false;                   // debug info to be logged to console?
-    this.aid = new AgentID('gateway-'+_guid(4));         // gateway agent name
+    this._timeout = opts.timeout;
+    this._keepAlive = opts.keepAlive;
+    this._queueSize = opts.queueSize;
+    this._returnNullOnFailedResponse = opts.returnNullOnFailedResponse;
+    this._cancelPendingOnDisconnect = opts.cancelPendingOnDisconnect;
+    this._pending_actions = {};
+    this._subscriptions = {};
+    this._pending_receives = {};
+    this._eventListeners = {};
+    this._queue = [];
+    this.connected = false;
+    this.debug = false;
+    this.aid = new AgentID('gateway-'+_guid(4));
     this.connector = this._createConnector(url);
     this._addGWCache(this);
   }
@@ -115,7 +197,7 @@ export class Gateway {
   * Sends an event to all registered listeners of the given type.
   * @private
   * @param {string} type - type of event
-  * @param {Object|Message|string} val - value to be sent to the listeners
+  * @param {unknown} val - value to be sent to the listeners
   */
   _sendEvent(type, val) {
     if (!Array.isArray(this._eventListeners[type])) return;
@@ -359,7 +441,7 @@ export class Gateway {
   * Gets a cached gateway object for the given URL (if it exists).
   * @private
   * @param {URL} url - URL object of the master container to connect to
-  * @returns {Gateway|void} - gateway object for the given URL
+  * @returns {Gateway|null} - gateway object for the given URL
   */
   _getGWCache(url){
     if (!gObj.fjage || !gObj.fjage.gateways) return null;
@@ -401,7 +483,7 @@ export class Gateway {
   * Add an event listener to listen to various events happening on this Gateway
   *
   * @param {string} type - type of event to be listened to
-  * @param {function} listener - new callback/function to be called when the event happens
+  * @param {EventListener} listener - new callback/function to be called when the event happens
   * @returns {void}
   */
   addEventListener(type, listener) {
@@ -415,7 +497,7 @@ export class Gateway {
   * Remove an event listener.
   *
   * @param {string} type - type of event the listener was for
-  * @param {function} listener - callback/function which was to be called when the event happens
+  * @param {EventListener} listener - callback/function which was to be called when the event happens
   * @returns {void}
   */
   removeEventListener(type, listener) {
@@ -427,7 +509,7 @@ export class Gateway {
   /**
   * Add a new listener to listen to all {Message}s sent to this Gateway
   *
-  * @param {function} listener - new callback/function to be called when a {Message} is received
+  * @param {EventListener} listener - new callback/function to be called when a {Message} is received
   * @returns {void}
   */
   addMessageListener(listener) {
@@ -437,7 +519,7 @@ export class Gateway {
   /**
   * Remove a message listener.
   *
-  * @param {function} listener - removes a previously registered listener/callback
+  * @param {EventListener} listener - removes a previously registered listener/callback
   * @returns {void}
   */
   removeMessageListener(listener) {
@@ -447,7 +529,7 @@ export class Gateway {
   /**
   * Add a new listener to get notified when the connection to master is created and terminated.
   *
-  * @param {function} listener - new callback/function to be called connection to master is created and terminated
+  * @param {EventListener} listener - new callback/function to be called connection to master is created and terminated
   * @returns {void}
   */
   addConnListener(listener) {
@@ -457,7 +539,7 @@ export class Gateway {
   /**
   * Remove a connection listener.
   *
-  * @param {function} listener - removes a previously registered listener/callback
+  * @param {EventListener} listener - removes a previously registered listener/callback
   * @returns {void}
   */
   removeConnListener(listener) {
@@ -491,7 +573,8 @@ export class Gateway {
   * @returns {AgentID} - object representing the topic
   */
   topic(topic, topic2) {
-    if (typeof topic == 'string' || topic instanceof String) return new AgentID(topic, true, this);
+    if (topic instanceof String) topic = topic.valueOf(); // Convert to primitive string
+    if (typeof topic == 'string') return new AgentID(topic, true, this);
     if (topic instanceof AgentID) {
       if (topic.isTopic()) return topic;
       return new AgentID(topic.getName()+(topic2 ? '__' + topic2 : '')+'__ntf', true, this);
@@ -616,7 +699,7 @@ export class Gateway {
   *
   * @param {Message} msg - message to send
   * @param {number} [timeout=opts.timeout] - timeout in milliseconds
-  * @returns {Promise<Message|void>} - a promise which resolves with the received response message, null on timeout
+  * @returns {Promise<Message|undefined>} - a promise which resolves with the received response message, undefined on timeout
   */
   async request(msg, timeout=this._timeout) {
     this.send(msg);
@@ -627,10 +710,10 @@ export class Gateway {
   * Returns a response message received by the gateway. This method returns a {Promise} which resolves when
   * a response is received or if no response is received after the timeout.
   *
-  * @param {function|Message|typeof Message} filter - original message to which a response is expected, or a MessageClass of the type
+  * @param {((val: Message) => boolean)|Message|typeof Message} filter - original message to which a response is expected, or a MessageClass of the type
   * of message to match, or a closure to use to match against the message
   * @param {number} [timeout=0] - timeout in milliseconds
-  * @returns {Promise<Message|void>} - received response message, null on timeout
+  * @returns {Promise<Message|undefined>} - received response message, undefined on timeout
   */
   async receive(filter, timeout=0) {
     return new Promise(resolve => {
@@ -641,7 +724,7 @@ export class Gateway {
       }
       if (timeout == 0) {
         if (this.debug) console.log('Receive Timeout : ' + filter);
-        resolve();
+        resolve(undefined);
         return;
       }
       let lid = UUID7.generate().toString();
@@ -650,7 +733,7 @@ export class Gateway {
         timer = setTimeout(() => {
           this._pending_receives[lid] && delete this._pending_receives[lid];
           if (this.debug) console.log('Receive Timeout : ' + filter);
-          resolve();
+          resolve(undefined);
         }, timeout);
       }
       // listener for each pending receive

--- a/gateways/js/src/gateway.js
+++ b/gateways/js/src/gateway.js
@@ -47,6 +47,24 @@ export function init(){
 }
 
 /**
+ * @typedef {Object} GatewayOptions
+ * @property {string} [hostname="localhost"] - hostname/ip address of the master container
+ * @property {number|string} [port=1100] - port number of the master container
+ * @property {string} [pathname=""] - WebSocket path of the master container
+ * @property {boolean} [keepAlive=true] - reconnect if the connection is lost
+ * @property {number} [queueSize=128] - maximum number of queued received messages
+ * @property {number} [timeout=1000] - default request timeout in milliseconds
+ * @property {number} [directoryTimeout=6000] - default directory-query timeout in milliseconds
+ * @property {boolean} [cancelPendingOnDisconnect=false] - cancel pending requests on disconnect
+ */
+
+/**
+ * @callback EventListener
+ * @param {unknown} value
+ * @returns {void}
+ */
+
+/**
 * A gateway for connecting to a fjage master container. This class provides methods to
 * send and receive messages, subscribe to topics, and manage connections to the master container.
 * It can be used to connect to a fjage master container over WebSockets or TCP.
@@ -79,18 +97,62 @@ export function init(){
 */
 export class Gateway {
 
+  /** @type {AgentID} */
+  aid;
+
+  /** @type {boolean} */
+  connected;
+
+  /** @type {boolean} */
+  debug;
+
+  /** @type {number} */
+  _timeout;
+
+  /** @type {number} */
+  _directoryTimeout;
+
+  /** @type {boolean} */
+  _keepAlive;
+
+  /** @type {number} */
+  _queueSize;
+
+  /** @type {boolean} */
+  _cancelPendingOnDisconnect;
+
+  /** @type {Record<string, (msg: JSONMessage) => void>} */
+  _pending_actions;
+
+  /** @type {Record<string, boolean>} */
+  _subscriptions;
+
+  /** @type {Record<string, (msg: Message) => boolean>} */
+  _pending_receives;
+
+  /** @type {Record<string, EventListener[]>} */
+  _eventListeners;
+
+  /** @type {Message[]} */
+  _queue;
+
+  /** @type {TCPConnector|WSConnector} */
+  connector;
+
   /**
   * Registers a message class for JSON serialization and inflation. The registry is shared by
   * all gateways.
   *
   * @param {string} className - fully qualified message class name
-  * @param {Function} messageClass - Message subclass to register
-  * @returns {Function} registered message class
+  * @template {typeof Message} T
+  * @param {T} messageClass - Message subclass to register
+  * @returns {T} registered message class
   */
   static registerMessage(className, messageClass) {
     return registerMessageClass(className, messageClass);
   }
 
+  /** @param {GatewayOptions} [opts] */
   constructor(opts = {}) {
     // Similar to Object.assign but also overwrites `undefined` and empty strings with defaults
     for (var key in GATEWAY_DEFAULTS){
@@ -207,7 +269,7 @@ export class Gateway {
         rsp.services = [];
         break;
         case 'agentForService':
-        rsp.agentID = '';
+        rsp.agentID = null;
         break;
         case 'agentsForService':
         rsp.agentIDs = [];
@@ -370,7 +432,7 @@ export class Gateway {
   * Add an event listener to listen to various events happening on this Gateway
   *
   * @param {string} type - type of event to be listened to
-  * @param {function} listener - new callback/function to be called when the event happens
+  * @param {EventListener} listener - new callback/function to be called when the event happens
   * @returns {void}
   */
   addEventListener(type, listener) {
@@ -384,7 +446,7 @@ export class Gateway {
   * Remove an event listener.
   *
   * @param {string} type - type of event the listener was for
-  * @param {function} listener - callback/function which was to be called when the event happens
+  * @param {EventListener} listener - callback/function which was to be called when the event happens
   * @returns {void}
   */
   removeEventListener(type, listener) {
@@ -396,7 +458,7 @@ export class Gateway {
   /**
   * Add a new listener to listen to all {Message}s sent to this Gateway
   *
-  * @param {function} listener - new callback/function to be called when a {Message} is received
+  * @param {EventListener} listener - new callback/function to be called when a {Message} is received
   * @returns {void}
   */
   addMessageListener(listener) {
@@ -406,7 +468,7 @@ export class Gateway {
   /**
   * Remove a message listener.
   *
-  * @param {function} listener - removes a previously registered listener/callback
+  * @param {EventListener} listener - removes a previously registered listener/callback
   * @returns {void}
   */
   removeMessageListener(listener) {
@@ -416,7 +478,7 @@ export class Gateway {
   /**
   * Add a new listener to get notified when the connection to master is created and terminated.
   *
-  * @param {function} listener - new callback/function to be called connection to master is created and terminated
+  * @param {EventListener} listener - new callback/function to be called connection to master is created and terminated
   * @returns {void}
   */
   addConnListener(listener) {
@@ -426,7 +488,7 @@ export class Gateway {
   /**
   * Remove a connection listener.
   *
-  * @param {function} listener - removes a previously registered listener/callback
+  * @param {EventListener} listener - removes a previously registered listener/callback
   * @returns {void}
   */
   removeConnListener(listener) {
@@ -460,7 +522,7 @@ export class Gateway {
   * @returns {AgentID} - object representing the topic
   */
   topic(topic, topic2) {
-    if (typeof topic == 'string' || topic instanceof String) return new AgentID(topic, true, this);
+    if (typeof topic == 'string' || topic instanceof String) return new AgentID(topic.toString(), true, this);
     if (topic instanceof AgentID) {
       if (topic.isTopic()) return topic;
       return new AgentID(topic.getName()+(topic2 ? '__' + topic2 : '')+'__ntf', true, this);

--- a/gateways/js/src/gateway.js
+++ b/gateways/js/src/gateway.js
@@ -59,9 +59,20 @@ export function init(){
  */
 
 /**
- * @callback EventListener
- * @param {unknown} value
- * @returns {void}
+ * Maps Gateway event names to the values supplied to their listeners.
+ * @typedef {Object} GatewayEventMap
+ * @property {string} rx - raw JSON received from the master container
+ * @property {JSONMessage} rxp - parsed JSON message received from the master container
+ * @property {Message} rxmsg - message received from the master container
+ * @property {Message} message - message addressed to this Gateway
+ * @property {string} tx - raw JSON sent to the master container
+ * @property {Message} txmsg - message sent by this Gateway
+ * @property {boolean} conn - connection state
+ */
+
+/**
+ * Maps Gateway event names to their listener types.
+ * @typedef {{[K in keyof GatewayEventMap]?: Array<(value: GatewayEventMap[K]) => void>}} GatewayListenerMap
  */
 
 /**
@@ -130,7 +141,7 @@ export class Gateway {
   /** @type {Record<string, (msg: Message) => boolean>} */
   _pending_receives;
 
-  /** @type {Record<string, EventListener[]>} */
+  /** @type {GatewayListenerMap} */
   _eventListeners;
 
   /** @type {Message[]} */
@@ -181,8 +192,9 @@ export class Gateway {
   /**
   * Sends an event to all registered listeners of the given type.
   * @private
-  * @param {string} type - type of event
-  * @param {Object|Message|string} val - value to be sent to the listeners
+  * @template {keyof GatewayEventMap} K
+  * @param {K} type - type of event
+  * @param {GatewayEventMap[K]} val - value to be sent to the listeners
   */
   _sendEvent(type, val) {
     if (!Array.isArray(this._eventListeners[type])) return;
@@ -431,8 +443,9 @@ export class Gateway {
   /**
   * Add an event listener to listen to various events happening on this Gateway
   *
-  * @param {string} type - type of event to be listened to
-  * @param {EventListener} listener - new callback/function to be called when the event happens
+  * @template {keyof GatewayEventMap} K
+  * @param {K} type - type of event to be listened to
+  * @param {(value: GatewayEventMap[K]) => void} listener - new callback/function to be called when the event happens
   * @returns {void}
   */
   addEventListener(type, listener) {
@@ -445,8 +458,9 @@ export class Gateway {
   /**
   * Remove an event listener.
   *
-  * @param {string} type - type of event the listener was for
-  * @param {EventListener} listener - callback/function which was to be called when the event happens
+  * @template {keyof GatewayEventMap} K
+  * @param {K} type - type of event the listener was for
+  * @param {(value: GatewayEventMap[K]) => void} listener - callback/function which was to be called when the event happens
   * @returns {void}
   */
   removeEventListener(type, listener) {
@@ -458,7 +472,7 @@ export class Gateway {
   /**
   * Add a new listener to listen to all {Message}s sent to this Gateway
   *
-  * @param {EventListener} listener - new callback/function to be called when a {Message} is received
+  * @param {(message: Message) => void} listener - new callback/function to be called when a {Message} is received
   * @returns {void}
   */
   addMessageListener(listener) {
@@ -468,7 +482,7 @@ export class Gateway {
   /**
   * Remove a message listener.
   *
-  * @param {EventListener} listener - removes a previously registered listener/callback
+  * @param {(message: Message) => void} listener - removes a previously registered listener/callback
   * @returns {void}
   */
   removeMessageListener(listener) {
@@ -478,7 +492,7 @@ export class Gateway {
   /**
   * Add a new listener to get notified when the connection to master is created and terminated.
   *
-  * @param {EventListener} listener - new callback/function to be called connection to master is created and terminated
+  * @param {(connected: boolean) => void} listener - new callback/function to be called connection to master is created and terminated
   * @returns {void}
   */
   addConnListener(listener) {
@@ -488,7 +502,7 @@ export class Gateway {
   /**
   * Remove a connection listener.
   *
-  * @param {EventListener} listener - removes a previously registered listener/callback
+  * @param {(connected: boolean) => void} listener - removes a previously registered listener/callback
   * @returns {void}
   */
   removeConnListener(listener) {

--- a/gateways/js/src/gateway.js
+++ b/gateways/js/src/gateway.js
@@ -177,7 +177,7 @@ export class Gateway {
     this._directoryTimeout = opts.directoryTimeout; // timeout for directory queries
     this._keepAlive = opts.keepAlive;     // reconnect if connection gets closed/errored
     this._queueSize = opts.queueSize;     // size of _queue
-    this._cancelPendingOnDisconnect = opts.cancelPendingOnDisconnect; // cancel pending requests on disconnect
+    this._cancelPendingOnDisconnect = opts.cancelPendingOnDisconnect ?? false; // cancel pending requests on disconnect
     this._pending_actions = {};            // msgid to callback mapping for pending actions
     this._subscriptions = {};              // map for all topics that are subscribed
     this._pending_receives = {};           // uuid to callbacks mapping for pending receives

--- a/gateways/js/src/gateway.js
+++ b/gateways/js/src/gateway.js
@@ -658,14 +658,36 @@ export class Gateway {
   }
 
   /**
-  * Returns a response message received by the gateway. This method returns a {Promise} which resolves when
-  * a response is received or if no response is received after the timeout.
-  *
-  * @param {Function|Message} filter - original message to which a response is expected, or a message constructor for the type
-  * of message to match, or a closure to use to match against the message
-  * @param {number} [timeout=0] - timeout in milliseconds
-  * @returns {Promise<Message|void>} - received response message, null on timeout
-  */
+   * @template {typeof Message} T
+   * @overload
+   * @param {T} filter - message constructor to match
+   * @param {number} [timeout=0] - timeout in milliseconds
+   * @returns {Promise<InstanceType<T>|undefined>} matching message, or undefined on timeout
+   */
+
+  /**
+   * @template {Message} M
+   * @overload
+   * @param {(msg: Message) => msg is M} filter - type-guard predicate used to match messages
+   * @param {number} [timeout=0] - timeout in milliseconds
+   * @returns {Promise<M|undefined>} matching message, or undefined on timeout
+   */
+
+  /**
+   * @overload
+   * @param {Message|string|((msg: Message) => boolean)} filter - original message, message ID, or predicate to match
+   * @param {number} [timeout=0] - timeout in milliseconds
+   * @returns {Promise<Message|undefined>} matching message, or undefined on timeout
+   */
+
+  /**
+   * Returns a response message received by the gateway. This method returns a promise which resolves when
+   * a response is received or when the timeout expires.
+   *
+   * @param {typeof Message|Message|string|((msg: Message) => boolean)} filter
+   * @param {number} [timeout=0]
+   * @returns {Promise<Message|undefined>}
+   */
   async receive(filter, timeout=0) {
     return new Promise(resolve => {
       let msg = this._getMessageFromQueue.call(this,filter);
@@ -675,7 +697,7 @@ export class Gateway {
       }
       if (timeout == 0) {
         if (this.debug) console.log('Receive Timeout : ' + filter);
-        resolve();
+        resolve(undefined);
         return;
       }
       let lid = UUID7.generate().toString();
@@ -684,7 +706,7 @@ export class Gateway {
         timer = setTimeout(() => {
           this._pending_receives[lid] && delete this._pending_receives[lid];
           if (this.debug) console.log('Receive Timeout : ' + filter);
-          resolve();
+          resolve(undefined);
         }, timeout);
       }
       // listener for each pending receive

--- a/gateways/js/src/gateway.js
+++ b/gateways/js/src/gateway.js
@@ -664,7 +664,7 @@ export class Gateway {
   *
   * @param {Message} msg - message to send
   * @param {number} [timeout=opts.timeout] - timeout in milliseconds
-  * @returns {Promise<Message|void>} - a promise which resolves with the received response message, null on timeout
+  * @returns {Promise<Message|undefined>} - a promise which resolves with the received response message, or undefined on timeout
   */
   async request(msg, timeout=this._timeout) {
     this.send(msg);

--- a/gateways/js/src/gateway.js
+++ b/gateways/js/src/gateway.js
@@ -213,7 +213,7 @@ export class Gateway {
   * Sends the message to all registered receivers.
   *
   * @private
-  * @param {Message} msg
+  * @param {Message} [msg]
   * @returns {boolean} - true if the message was consumed by any listener
   */
   _sendReceivers(msg) {
@@ -370,7 +370,7 @@ export class Gateway {
         this._update_watch();
       } else{
         if (this._cancelPendingOnDisconnect) {
-          this._sendReceivers(null);
+          this._sendReceivers(undefined);
           this.flush();
         }
       }

--- a/gateways/js/src/jsonmessage.js
+++ b/gateways/js/src/jsonmessage.js
@@ -4,6 +4,9 @@ import { UUID7 } from './utils.js';
 import { AgentID } from './agentid.js';
 import { Message } from './message.js';
 
+/** @import { MessageJSON } from './message.js' */
+/** @import { Gateway } from './gateway.js' */
+
 /**
 * Class representing a fjage's on-the-wire JSON message. A JSONMessage object
 * contains all the fields that can be a part of a fjage JSON message. The class
@@ -29,29 +32,90 @@ import { Message } from './message.js';
 * const jsonString = '{"id":"1234",...}'; // JSON string representation of a JSONMessage
 * const jsonMsg = new JSONMessage(jsonString); // Parses the JSON string into a JSONMessage object
 * jsonMsg.message; // Access the Message object contained in the JSONMessage
-*
-* @class
-* @property {string} [id] - A UUID assigned to each JSONMessage object.
-* @property {string} [action] - Denotes the main action the object is supposed to perform.
-* @property {string} [inResponseTo] - This attribute contains the action to which this object is a response to.
-* @property {AgentID} [agentID] - An AgentID. This attribute is populated in objects which are responses to objects requesting the ID of an agent providing a specific service.
-* @property {Array<AgentID>} [agentIDs] - This attribute is populated in objects which are responses to objects requesting the IDs of agents providing a specific service, or objects which are responses to objects requesting a list of all agents running in a container.
-* @property {Array<string>} [agentTypes] - This attribute is optionally populated in objects which are responses to objects requesting a list of all agents running in a container. If populated, it contains a list of agent types running in the container, with a one-to-one mapping to the agent IDs in the "agentIDs" attribute.
-* @property {string} [service] - Used in conjunction with "action" : "agentForService" and "action" : "agentsForService" to query for agent(s) providing this specific service.
-* @property {Array<string>} [services] - This attribute is populated in objects which are responses to objects requesting the services available with "action" : "services".
-* @property {boolean} [answer] - This attribute is populated in objects which are responses to query objects with "action" : "containsAgent".
-* @property {Message} [message] - This holds the main payload of the message. The structure and format of this object is discussed in the {@link https://fjage.readthedocs.io/en/latest/protocol.html#json-message-request-response-attributes fjage documentation}.
-* @property {boolean} [relay] - This attribute defines if the target container should relay (forward) the message to other containers it is connected to or not.
-* @property {Object} [creds] - Credentials to be used for authentication.
-* @property {Object} [auth] - Authentication information to be used for the message.
-*
-*
 */
 export class JSONMessage {
+  /**
+   * A UUID assigned to each JSONMessage object.
+   * @type {string}
+   */
+  id;
 
   /**
-  * @param {String} [jsonString] - JSON string to be parsed into a JSONMessage object.
-  * @param {Object} [owner] - The owner of the JSONMessage object, typically the Gateway instance.
+   * Denotes the main action the object is supposed to perform.
+   * @type {(typeof Actions)[keyof typeof Actions]}
+   */
+  action;
+
+  /**
+   * This attribute contains the action to which this object is a response to.
+   * @type {string}
+   */
+  inResponseTo;
+
+  /**
+   * An AgentID. This attribute is populated in objects which are responses to objects requesting the ID of an agent providing a specific service.
+   * @type {AgentID | undefined}
+   */
+  agentID;
+
+  /**
+   * This attribute is populated in objects which are responses to objects requesting the IDs of agents providing a specific service, or objects which are responses to objects requesting a list of all agents running in a container.
+   * @type {Array<AgentID> | undefined}
+   */
+  agentIDs;
+
+  /**
+   * This attribute is optionally populated in objects which are responses to objects requesting a list of all agents running in a container. If populated, it contains a list of agent types running in the container, with a one-to-one mapping to the agent IDs in the "agentIDs" attribute.
+   * @type {Array<string>}
+   */
+  agentTypes;
+
+  /**
+   * Used in conjunction with "action" : "agentForService" and "action" : "agentsForService" to query for agent(s) providing this specific service.
+   * @type {string}
+   */
+  service;
+
+  /**
+   * This attribute is populated in objects which are responses to objects requesting the services available with "action" : "services".
+   * @type {Array<string>}
+   */
+  services;
+
+  /**
+   * This attribute is populated in objects which are responses to query objects with "action" : "containsAgent".
+   * @type {boolean}
+   */
+  answer;
+
+  /**
+   * This holds the main payload of the message.
+   * The structure and format of this object is discussed in the {@link https://fjage.readthedocs.io/en/latest/protocol.html#json-message-request-response-attributes fjage documentation}.
+   * @type {Message | undefined}
+   */
+  message;
+
+  /**
+   * This attribute defines if the target container should relay (forward) the message to other containers it is connected to or not.
+   * @type {boolean}
+   */
+  relay;
+
+  /**
+   * Credentials to be used for authentication.
+   * @type {Object}
+   */
+  creds;
+
+  /**
+   * Authentication information to be used for the message.
+   * @type {Object}
+   */
+  auth;
+
+  /**
+  * @param {string} [jsonString] - JSON string to be parsed into a JSONMessage object.
+  * @param {Gateway} [owner] - The owning {@link Gateway} of the JSONMessage object.
   */
   constructor(jsonString, owner) {
     this.id = UUID7.generate().toString(); // unique JSON message ID
@@ -70,14 +134,21 @@ export class JSONMessage {
     this.name =  null;
     if (jsonString && typeof jsonString === 'string') {
       try {
-        const parsed = JSON.parse(jsonString, _decodeBase64);
-        if (parsed.message) parsed.message = Message.fromJSON(parsed.message);
-        if (parsed.agentID) parsed.agentID = AgentID.fromJSON(parsed.agentID, owner);
-        if (parsed.agentIDs) parsed.agentIDs = parsed.agentIDs.map(id => AgentID.fromJSON(id, owner));
+        /** @type {{ message?: MessageJSON; agentID?: string, agentIDs?: string[]}} */
+        const partial = JSON.parse(jsonString, _decodeBase64);
+        /** @type {{ message?: Message; agentID?: AgentID, agentIDs?: AgentID[]}} */
+        const parsed = {
+          ...partial,
+          message: partial.message ? Message.fromJSON(partial.message) : undefined,
+          agentID: partial.agentID ? AgentID.fromJSON(partial.agentID, owner) : undefined,
+          agentIDs: partial.agentIDs ? partial.agentIDs.map(id => AgentID.fromJSON(id, owner)) : undefined,
+        };
         Object.assign(this, parsed);
       } catch (e) {
         throw new Error('Invalid JSON string: ' + e.message);
       }
+    } else {
+        throw new Error('Invalid JSON string: ' + jsonString);
     };
   }
 
@@ -225,7 +296,7 @@ export class JSONMessage {
 *
 * @enum {string} Actions
 */
-export const Actions = {
+export const Actions = /** @type {const} */ ({
   AGENTS : 'agents',
   CONTAINS_AGENT : 'containsAgent',
   SERVICES : 'services',
@@ -234,7 +305,7 @@ export const Actions = {
   SEND : 'send',
   WANTS_MESSAGES_FOR : 'wantsMessagesFor',
   SHUTDOWN : 'shutdown'
-};
+});
 
 ////// private utilities
 
@@ -244,17 +315,49 @@ export const Actions = {
 *
 * @private
 *
+* @template Data
 * @param {string} _k - key (unused)
-* @param {any} d - data
-* @returns {Array} - decoded data in array format
+* @param {Data} d - data
+* @returns {number[] | bigint[] | Data} - decoded data in array format, or the untouched data if it could not be decoded
 * */
 function _decodeBase64(_k, d) {
   if (d === null) return null;
-  if (typeof d == 'object' && 'clazz' in d && 'data' in d && d.clazz.startsWith('[') && d.clazz.length == 2) {
+  if (
+      typeof d == 'object' &&
+      'clazz' in d &&
+      typeof d.clazz === 'string' &&
+      'data' in d &&
+      typeof d.data === 'string' &&
+      (d.clazz === '[B' || d.clazz === '[S' || d.clazz === '[I' || d.clazz === '[F' || d.clazz === '[D' || d.clazz === '[J')
+  ) {
     return _b64toArray(d.data, d.clazz) || d;
   }
   return d;
 }
+
+/**
+ * @overload
+ * @param {string} base64
+ * @param {'[B' | '[S' | '[I' | '[F' | '[D'} dtype
+ * @param {boolean} [littleEndian=true]
+ * @returns {number[]}
+ */
+
+/**
+ * @overload
+ * @param {string} base64
+ * @param {'[J'} dtype
+ * @param {boolean} [littleEndian=true]
+ * @returns {bigint[]}
+ */
+
+/**
+ * @overload
+ * @param {string} base64
+ * @param {string} dtype
+ * @param {boolean} [littleEndian=true]
+ * @returns {number[] | bigint[] | undefined}
+ */
 
 /**
 * Convert a base64 encoded string to an array of numbers of the specified data type.
@@ -264,6 +367,7 @@ function _decodeBase64(_k, d) {
 * @param {string} base64 - base64 encoded string
 * @param {string} dtype - data type, e.g. '[B' for byte array, '[S' for short array, etc.
 * @param {boolean} [littleEndian=true] - whether to use little-endian byte order
+* @returns {number[] | bigint[] | undefined}
 */
 function _b64toArray(base64, dtype, littleEndian=true) {
   let s = _atob(base64);
@@ -277,37 +381,37 @@ function _b64toArray(base64, dtype, littleEndian=true) {
     case '[B': // byte array
     for (i = 0; i < len; i++)
       rv.push(view.getUint8(i));
-    break;
+    return rv;
     case '[S': // short array
     for (i = 0; i < len; i+=2)
       rv.push(view.getInt16(i, littleEndian));
-    break;
+    return rv;
     case '[I': // integer array
     for (i = 0; i < len; i+=4)
       rv.push(view.getInt32(i, littleEndian));
-    break;
+    return rv;
     case '[J': // long array
     for (i = 0; i < len; i+=8)
       rv.push(view.getBigInt64(i, littleEndian));
-    break;
+    return rv;
     case '[F': // float array
     for (i = 0; i < len; i+=4)
       rv.push(view.getFloat32(i, littleEndian));
-    break;
+    return rv;
     case '[D': // double array
     for (i = 0; i < len; i+=8)
       rv.push(view.getFloat64(i, littleEndian));
-    break;
+    return rv;
     default:
-    return;
+    return undefined;
   }
-  return rv;
 }
 
 // node.js safe atob function
 /**
 * @private
 * @param {string} a
+* @returns {string}
 */
 export function _atob(a){
   if (isBrowser || isWebWorker) return window.atob(a);

--- a/gateways/js/src/jsonmessage.js
+++ b/gateways/js/src/jsonmessage.js
@@ -278,9 +278,9 @@ export class JSONMessage {
 * Actions supported by the fjåge JSON message protocol. See
 * {@link https://org-arl.github.io/fjage/protocol.html#json-message-requestresponse-attributes fjage documentation} for more details.
 *
-* @enum {string} Actions
+* @enum {'agents'|'containsAgent'|'services'|'agentForService'|'agentsForService'|'send'|'wantsMessagesFor'|'shutdown'} Actions
 */
-export const Actions = {
+export const Actions = /** @type {const} */ ({
   AGENTS : 'agents',
   CONTAINS_AGENT : 'containsAgent',
   SERVICES : 'services',
@@ -289,7 +289,7 @@ export const Actions = {
   SEND : 'send',
   WANTS_MESSAGES_FOR : 'wantsMessagesFor',
   SHUTDOWN : 'shutdown'
-};
+});
 
 ////// private utilities
 

--- a/gateways/js/src/jsonmessage.js
+++ b/gateways/js/src/jsonmessage.js
@@ -4,6 +4,8 @@ import { UUID7 } from './utils.js';
 import { AgentID } from './agentid.js';
 import { Message } from './message.js';
 
+/** @typedef {import('./gateway.js').Gateway} Gateway */
+
 /**
 * Class representing a fjage's on-the-wire JSON message. A JSONMessage object
 * contains all the fields that can be a part of a fjage JSON message. The class
@@ -49,9 +51,51 @@ import { Message } from './message.js';
 */
 export class JSONMessage {
 
+  /** @type {string} */
+  id;
+
+  /** @type {string|null} */
+  action;
+
+  /** @type {string|null} */
+  inResponseTo;
+
+  /** @type {AgentID|null} */
+  agentID;
+
+  /** @type {AgentID[]|null} */
+  agentIDs;
+
+  /** @type {string[]|null} */
+  agentTypes;
+
+  /** @type {string|null} */
+  service;
+
+  /** @type {string[]|null} */
+  services;
+
+  /** @type {boolean|null} */
+  answer;
+
+  /** @type {Message|null} */
+  message;
+
+  /** @type {boolean|null} */
+  relay;
+
+  /** @type {Record<string, unknown>|null} */
+  creds;
+
+  /** @type {Record<string, unknown>|null} */
+  auth;
+
+  /** @type {string|null} */
+  name;
+
   /**
-  * @param {String} [jsonString] - JSON string to be parsed into a JSONMessage object.
-  * @param {Object} [owner] - The owner of the JSONMessage object, typically the Gateway instance.
+  * @param {string} [jsonString] - JSON string to be parsed into a JSONMessage object.
+  * @param {Gateway} [owner] - The owner of the JSONMessage object, typically the Gateway instance.
   */
   constructor(jsonString, owner) {
     this.id = UUID7.generate().toString(); // unique JSON message ID

--- a/gateways/js/src/message.js
+++ b/gateways/js/src/message.js
@@ -3,17 +3,51 @@ import { UUID7 } from './utils.js';
 import { AgentID } from './agentid.js';  // import AgentID class for type checking. Remove if not needed.
 
 /**
+ * @typedef MessageJSON
+ * @property {string} clazz
+ * @property {Record<string, unknown>} data
+ */;
+
+
+/**
 * Base class for messages transmitted by one agent to another. Creates an empty message.
-* @class
-*
-* @property {string} msgID - unique message ID
-* @property {Performative} perf - performative of the message
-* @property {AgentID} [sender] - AgentID of the sender of the message
-* @property {AgentID} [recipient] - AgentID of the recipient of the message
-* @property {string} [inReplyTo] - ID of the message to which this message is a response
-* @property {number} [sentAt] - timestamp when the message was sent
 */
 export class Message {
+  /**
+   * unique message ID
+   * @type {string}
+   */
+  msgID;
+
+  /**
+   * performative of the message
+   * @type {Performative}
+   */
+  perf;
+
+  /**
+   * AgentID of the sender of the message
+   * @type {AgentID}
+   */
+  sender;
+
+  /**
+   * AgentID of the recipient of the message
+   * @type {AgentID}
+   */
+  recipient;
+
+  /**
+   * ID of the message to which this message is a response
+   * @type {string}
+   */
+  inReplyTo;
+
+  /**
+   * timestamp when the message was sent
+   * @type {number}
+   */
+  sentAt;
 
   /**
   * @param {Message} [inReplyToMsg] - message to which this message is a response
@@ -56,27 +90,27 @@ export class Message {
     return { 'clazz': this.__clazz__, 'data': props };
   }
 
-
   /**
   * Create a message from a object parsed from the JSON representation of the message.
   *
-  * @param {Object} jsonObj - Object containing all the properties of the message
+  * @param {MessageJSON} jsonObj - Object containing all the properties of the message
   * @returns {Message} - A message created from the Object
-  *
   */
   static fromJSON(jsonObj) {
-    if (!( 'clazz' in jsonObj) || !( 'data' in jsonObj)) {
+    if (!('clazz' in jsonObj) || typeof jsonObj.clazz !== 'string' || !('data' in jsonObj) || typeof jsonObj.data !== 'object') {
       throw new Error(`Invalid Object for Message : ${jsonObj}`);
     }
     let qclazz = jsonObj.clazz;
     let clazz = qclazz.replace(/^.*\./, '');
+    /** @type Message */
     let rv = MessageClass[clazz] ? new MessageClass[clazz] : new Message();
     rv.__clazz__ = qclazz;
     // copy all properties from the data object
     for (var key in jsonObj.data){
       if (key === 'sender' || key === 'recipient') {
-        if (jsonObj.data[key] && typeof jsonObj.data[key] === 'string') {
-          rv[key] = AgentID.fromJSON(jsonObj.data[key]);
+        const val = jsonObj.data[key];
+        if (val && typeof val === 'string') {
+          rv[key] = AgentID.fromJSON(val);
         }
       } else rv[key] = jsonObj.data[key];
     }
@@ -101,8 +135,13 @@ export class GenericMessage extends Message {
 
 /**
 * Creates a unqualified message class based on a fully qualified name.
+*
+* @template {object} T - additional properties that the subclass adds to {@link Message}
+* @template {object} P - constructor parameters
 * @param {string} name - fully qualified name of the message class to be created
 * @param {typeof Message} [parent] - class of the parent MessageClass to inherit from
+* @returns {new (params?: Record<string, unknown>) => T & Message}
+*
 * @constructs Message
 * @example
 * const ParameterReq = MessageClass('org.arl.fjage.param.ParameterReq');
@@ -113,7 +152,7 @@ export function MessageClass(name, parent=Message) {
   if (MessageClass[sname]) return MessageClass[sname];
   let cls = class extends parent {
     /**
-    * @param {{ [x: string]: any; }} params
+    * @param {P} params
     */
     constructor(params) {
       super();
@@ -129,14 +168,24 @@ export function MessageClass(name, parent=Message) {
   };
   cls.__clazz__ = name;
   MessageClass[sname] = cls;
-  return cls;
+
+  // Safety: the assumption is that the caller is correct when passing T.
+  // This is a type hint and should thus be treated as such. There's no
+  // guarantee that the caller's type is correct, but it is their responsibility
+  // to pass the right type.
+  /** @type {any} */
+  const ret = cls;
+  return /** @type {new (args: P) => T & Message} */ ret;
 }
 
 /**
-* @typedef {Object} ParameterReq.Entry
+ * @typedef {Pick<Message, "perf" | "sender" | "recipient" | "inReplyTo">} MessageProps
+ */
+
+/**
+* @typedef {object} ParameterReqEntry
 * @property {string} param - parameter name
-* @property {Object} value - parameter value
-* @exports ParameterReq.Entry
+* @property {unknown} [value] - parameter value
 */
 
 /**
@@ -155,12 +204,15 @@ export function MessageClass(name, parent=Message) {
 * param: 'x'
 * });
 *
-* @typedef {Message} ParameterReq
+* @typedef {object} ParameterReqProps
 * @property {string} param - parameters name to be get/set if only a single parameter is to be get/set
-* @property {Object} value - parameters value to be set if only a single parameter is to be set
-* @property {Array<ParameterReq.Entry>} requests - a list of multiple parameters to be get/set
-* @property {number} [index=-1] - index of parameter(s) to be set*
-* @exports ParameterReq
+* @property {unknown} value - parameters value to be set if only a single parameter is to be set
+* @property {Array<ParameterReqEntry>} requests - a list of multiple parameters to be get/set
+* @property {number} [index=-1] - index of parameter(s) to be set
+*
+* @typedef {ParameterReqProps & Message} ParameterReq
+*
+* @type {new (params?: ParameterReqProps & MessageProps) => ParameterReq}
 */
 export const ParameterReq = MessageClass('org.arl.fjage.param.ParameterReq');
 
@@ -175,24 +227,30 @@ export const ParameterReq = MessageClass('org.arl.fjage.param.ParameterReq');
 * rsp.readonly // = [false]; indicates if the parameter is read-only
 *
 *
-* @typedef {Message} ParameterRsp
+* @typedef {object} ParameterRspProps
 * @property {string} param - parameters name if only a single parameter value was requested
-* @property {Object} value - parameters value if only a single parameter was requested
-* @property {Map<string, Object>} values - a map of multiple parameter names and their values if multiple parameters were requested
+* @property {unknown} value - parameters value if only a single parameter was requested
+* @property {Record<string, unknown>} values - a map of multiple parameter names and their values if multiple parameters were requested
 * @property {Array<boolean>} readonly - a list of booleans indicating if the parameters are read-only
 * @property {number} [index=-1] - index of parameter(s) being returned
-* @exports ParameterReq
+*
+* @typedef {ParameterRspProps & Message} ParameterRsp
+*
+* @type {new (params?: ParameterRspProps & MessageProps) => ParameterRsp}
 */
 export const ParameterRsp = MessageClass('org.arl.fjage.param.ParameterRsp');
 
 /**
 * Request to write contents to a file, or delete a file.
 *
-* @typedef {Message} PutFileReq
+* @typedef {object} PutFileReqProps
 * @property {string} filename - name of the file to be written to or deleted
 * @property {number} [content] - content to be written to the file as a byte array. If not provided, the file will be deleted.
 * @property {number} [offset=0] - offset in the file to write the content to.
-* @exports PutFileReq
+*
+* @typedef {PutFileReqProps & Message} PutFileReq
+*
+* @type {new (params?: PutFileReqProps & MessageProps) => PutFileReq}
 */
 export const PutFileReq = MessageClass('org.arl.fjage.shell.PutFileReq');
 
@@ -206,35 +264,44 @@ export const PutFileReq = MessageClass('org.arl.fjage.shell.PutFileReq');
 *
 * The time is represented as epoch time (milliseconds since 1 Jan 1970).
 *
-* @typedef {Message} GetFileReq
+* @typedef {object} GetFileReqProps
 * @property {string} filename - name of the file or directory to be read
 * @property {number} [offset=0] - offset in the file to read from (ignored for directories)
 * @property {number} [length=0] - number of bytes to read from the file (ignored for directories). If 0,
 * the entire file will be read.
-*  @exports GetFileReq
+*
+* @typedef {GetFileReqProps & Message} GetFileReq
+*
+* @type {new (params?: GetFileReqProps & MessageProps) => GetFileReq}
 */
 export const GetFileReq = MessageClass('org.arl.fjage.shell.GetFileReq');
 
 /**
 * Response to a {@link GetFileReq}, with the contents of the file or the directory.
 *
-* @typedef {Message} GetFileRsp
+* @typedef {object} GetFileRspProps
 * @property {string} filename - name of the file or directory that was read
 * @property {number} [content] - content of the file as a byte array. If the filename represents a directory,
 * the content consists of a list of files (one file per line). Each line starts with the filename
 * (with a trailing "/" if it is a directory), "\t", file size in bytes, "\t", and last modification date.
 * @property {number} [offset=0] - offset in the file that the content corresponds to (ignored for directories)
 * @property {boolean} [directory=false] - indicates if the filename represents a directory
-* @exports GetFileRsp
+*
+* @typedef {GetFileRspProps & Message} GetFileRsp
+*
+* @type {new (params?: GetFileRspProps & MessageProps) => GetFileRsp}
 */
 export const GetFileRsp = MessageClass('org.arl.fjage.shell.GetFileRsp');
 
 /**
 * Request to execute shell command/script.
 *
-* @typedef {Message} ShellExecReq
+* @typedef {object} ShellExecReqProps
 * @property {string} command - shell command or script to be executed
 * @property {boolean} ans  - indicates if the response to this request should include the output of the command/script execution
-* @exports ShellExecReq
+*
+* @typedef {ShellExecReqProps & Message} ShellExecReq
+*
+* @type {new (params?: ShellExecReqProps & MessageProps) => ShellExecReq}
 */
 export const ShellExecReq = MessageClass('org.arl.fjage.shell.ShellExecReq');

--- a/gateways/js/src/message.js
+++ b/gateways/js/src/message.js
@@ -51,7 +51,7 @@ export function registerMessageClass(className, messageClass) {
 /**
  * @typedef {Object} MessageJSON
  * @property {string} clazz - qualified or unqualified message class name
- * @property {Object.<string, *>} data - message data
+ * @property {Record<string, unknown>} data - message data
  */
 
 /**
@@ -111,6 +111,7 @@ export class Message {
    * @returns {MessageJSON} JSON representation of the message
    */
   toJSON() {
+    /** @type {Record<string, unknown>} */
     const data = {};
     for (const key of Object.keys(this)) {
       if (!key.startsWith('_')) data[key] = this[key];
@@ -187,14 +188,14 @@ export class GenericMessage extends Message {}
 /**
  * @typedef {Object} ParameterReq.Entry
  * @property {string} param - parameter name
- * @property {*} [value] - parameter value
+ * @property {unknown} [value] - parameter value
  */
 
 /** A message that requests one or more parameters of an agent. */
 export class ParameterReq extends Message {
   /** @type {string|null} */
   param = null;
-  /** @type {*} */
+  /** @type {unknown} */
   value = null;
   /** @type {Array<ParameterReq.Entry>} */
   requests = [];
@@ -206,9 +207,9 @@ export class ParameterReq extends Message {
 export class ParameterRsp extends Message {
   /** @type {string|null} */
   param = null;
-  /** @type {*} */
+  /** @type {unknown} */
   value = null;
-  /** @type {Object.<string, *>} */
+  /** @type {Record<string, unknown>} */
   values = {};
   /** @type {Array<boolean>} */
   readonly = [];

--- a/gateways/js/src/message.js
+++ b/gateways/js/src/message.js
@@ -2,6 +2,7 @@ import { Performative } from './performative.js';
 import { UUID7 } from './utils.js';
 import { AgentID } from './agentid.js';
 
+/** @type {Record<string, typeof Message>} */
 const MESSAGE_REGISTRY = Object.create(null);
 
 /**
@@ -10,7 +11,7 @@ const MESSAGE_REGISTRY = Object.create(null);
  * back to a class registered for the same unqualified name in a different package.
  *
  * @param {string} name - qualified or unqualified message class name
- * @returns {Function|undefined} registered message class
+ * @returns {typeof Message|undefined} registered message class
  */
 export function messageClassForName(name) {
   return MESSAGE_REGISTRY[name];
@@ -20,8 +21,9 @@ export function messageClassForName(name) {
  * Registers a message class for JSON serialization and inflation.
  *
  * @param {string} className - fully qualified message class name
- * @param {Function} messageClass - Message subclass to register
- * @returns {Function} registered message class
+ * @template {typeof Message} T
+ * @param {T} messageClass - Message subclass to register
+ * @returns {T} registered message class
  */
 export function registerMessageClass(className, messageClass) {
   if (typeof className !== 'string' || className.trim() === '') {
@@ -159,8 +161,8 @@ registerMessageClass('org.arl.fjage.Message', Message);
  * Creates an unqualified message class based on a fully qualified name.
  *
  * @param {string} name - fully qualified message class name
- * @param {Function} [parent] - parent Message class
- * @returns {Function} message class
+ * @param {typeof Message} [parent] - parent Message class
+ * @returns {typeof Message} message class
  */
 export function MessageClass(name, parent=Message) {
   if (!(parent === Message || parent.prototype instanceof Message)) {

--- a/gateways/js/src/message.js
+++ b/gateways/js/src/message.js
@@ -157,20 +157,28 @@ Message.prototype.__clazz__ = 'org.arl.fjage.Message';
 registerMessageClass('org.arl.fjage.Message', Message);
 
 /**
+ * A Message subclass that can also be constructed from a fields object. Used by
+ * the {@link MessageClass}, whose generated classes assign the fields object
+ * passed to their constructor.
+ *
+ * @typedef {typeof Message & (new (fields?: Record<string, unknown>) => Message)} MessageClassConstructor
+ */
+
+/**
  * @deprecated since version 3.0.0. Use `Gateway.registerMessage()` instead.
  *
  * Creates an unqualified message class based on a fully qualified name.
  *
  * @param {string} name - fully qualified message class name
  * @param {typeof Message} [parent] - parent Message class
- * @returns {typeof Message} message class
+ * @returns {MessageClassConstructor} message class
  */
 export function MessageClass(name, parent=Message) {
   if (!(parent === Message || parent.prototype instanceof Message)) {
     throw new Error(`Parent class ${parent.name} is not a subclass of Message`);
   }
   const registeredClass = messageClassForName(name);
-  if (registeredClass) return registeredClass;
+  if (registeredClass) return /** @type {MessageClassConstructor} */ (registeredClass);
   // @ts-ignore Parent is validated above.
   const messageClass = class extends parent {
     constructor(fields={}) {
@@ -179,7 +187,7 @@ export function MessageClass(name, parent=Message) {
     }
   };
   registerMessageClass(name, messageClass);
-  return messageClass;
+  return /** @type {MessageClassConstructor} */ (messageClass);
 }
 
 /** A message class that can convey generic key-value messages. */

--- a/gateways/js/src/performative.js
+++ b/gateways/js/src/performative.js
@@ -1,9 +1,9 @@
 /**
 * An action represented by a message. The performative actions are a subset of the
 * FIPA ACL recommendations for interagent communication.
-* @enum {string}
+* @enum {'REQUEST'|'AGREE'|'REFUSE'|'FAILURE'|'INFORM'|'CONFIRM'|'DISCONFIRM'|'QUERY_IF'|'NOT_UNDERSTOOD'|'CFP'|'PROPOSE'|'CANCEL'}
 */
-export const Performative = {
+export const Performative = /** @type {const} */ ({
   REQUEST: 'REQUEST',               // Request an action to be performed
   AGREE: 'AGREE',                   // Agree to performing the requested action
   REFUSE: 'REFUSE',                 // Refuse to perform the requested action
@@ -16,4 +16,4 @@ export const Performative = {
   CFP: 'CFP',                       // Call for proposal
   PROPOSE: 'PROPOSE',               // Response for CFP
   CANCEL: 'CANCEL'                  // Cancel pending request
-};
+});

--- a/gateways/js/src/services.js
+++ b/gateways/js/src/services.js
@@ -1,6 +1,7 @@
 /**
 * Services supported by fjage agents.
+* @enum {'org.arl.fjage.shell.Services.SHELL'}
 */
-export const Services = {
+export const Services = /** @type {const} */ ({
   SHELL : 'org.arl.fjage.shell.Services.SHELL'
-};
+});

--- a/gateways/js/src/tcpconnector.js
+++ b/gateways/js/src/tcpconnector.js
@@ -72,7 +72,7 @@ class TCPConnector {
     this._buf = '';
     this._firstConn = true;               // if the Gateway has managed to connect to a server before
     this._firstReConn = true;             // if the Gateway has attempted to reconnect to a server before
-    this.pendingOnOpen = [];              // list of callbacks make as soon as gateway is open
+    this.pendingOnOpen = [];              // list of callbacks invoked as soon as the gateway is open
     this.connListeners = [];              // external listeners wanting to listen connection events
     this.debug = false;
     this._sockInit(host, port);

--- a/gateways/js/src/tcpconnector.js
+++ b/gateways/js/src/tcpconnector.js
@@ -2,6 +2,15 @@ const SOCKET_OPEN = 'open';
 const SOCKET_OPENING = 'opening';
 const DEFAULT_RECONNECT_TIME = 5000;       // ms, delay between retries to connect to the server.
 
+/** @typedef {import('node:net').Socket & {send: (data: string) => void}} TCPConnectorSocket */
+
+/**
+ * @callback TCPConnectorReadCallback
+ * @param {string} data - incoming message string
+ * @returns {void}
+ */
+
+/** @type {typeof import('node:net').createConnection|undefined} */
 var createConnection;
 
 /**
@@ -9,6 +18,39 @@ var createConnection;
 * @ignore
 */
 class TCPConnector {
+
+  /** @type {URL} */
+  url;
+
+  /** @type {boolean|undefined} */
+  _keepAlive;
+
+  /** @type {number} */
+  _reconnectTime;
+
+  /** @type {string} */
+  _buf;
+
+  /** @type {boolean} */
+  _firstConn;
+
+  /** @type {boolean} */
+  _firstReConn;
+
+  /** @type {Array<() => void>} */
+  pendingOnOpen;
+
+  /** @type {Array<(connected: boolean) => void>} */
+  connListeners;
+
+  /** @type {boolean} */
+  debug;
+
+  /** @type {TCPConnectorSocket|undefined} */
+  sock;
+
+  /** @type {TCPConnectorReadCallback|undefined} */
+  _onSockRx;
 
   /**
   * Create an TCPConnector to connect to a fjage master over TCP
@@ -36,13 +78,17 @@ class TCPConnector {
     this._sockInit(host, port);
   }
 
-
+  /** @param {boolean} val */
   _sendConnEvent(val) {
     this.connListeners.forEach(l => {
       l && {}.toString.call(l) === '[object Function]' && l(val);
     });
   }
 
+  /**
+   * @param {string} host
+   * @param {number} port
+   */
   _sockInit(host, port){
     if (!createConnection){
       try {
@@ -59,17 +105,21 @@ class TCPConnector {
     }
   }
 
+  /**
+   * @param {string} host
+   * @param {number} port
+   */
   _sockSetup(host, port){
     if(!createConnection) return;
     try{
-      this.sock = createConnection({ 'host': host, 'port': port });
+      this.sock = /** @type {TCPConnectorSocket} */ (createConnection({ 'host': host, 'port': port }));
       this.sock.setEncoding('utf8');
       this.sock.on('connect', this._onSockOpen.bind(this));
       this.sock.on('error', this._sockReconnect.bind(this));
       this.sock.on('close', () => {this._sendConnEvent(false);});
       this.sock.send = data => {this.sock.write(data);};
     } catch (error) {
-      if(this.debug) console.log('Connection failed to ', this.sock.host + ':' + this.sock.port);
+      if(this.debug) console.log('Connection failed to ', host + ':' + port);
       return;
     }
   }
@@ -80,7 +130,7 @@ class TCPConnector {
     this._firstReConn = false;
     setTimeout(() => {
       this.pendingOnOpen = [];
-      this._sockSetup(this.url.hostname, this.url.port);
+      this._sockSetup(this.url.hostname, parseInt(this.url.port));
     }, this._reconnectTime);
   }
 
@@ -94,6 +144,7 @@ class TCPConnector {
     this._buf = '';
   }
 
+  /** @param {string} s */
   _processSockData(s){
     this._buf += s;
     var lines = this._buf.split('\n');
@@ -106,6 +157,7 @@ class TCPConnector {
     });
   }
 
+  /** @returns {string} */
   toString(){
     let s = '';
     s += 'TCPConnector [' + this.sock ? this.sock.remoteAddress.toString() + ':' + this.sock.remotePort.toString() : '' + ']';
@@ -131,14 +183,9 @@ class TCPConnector {
   }
 
   /**
-  * @callback TCPConnectorReadCallback
-  * @ignore
-  * @param {string} s - incoming message string
-  */
-
-  /**
   * Set a callback for receiving incoming strings from the connector
   * @param {TCPConnectorReadCallback} cb - callback that is called when the connector gets a string
+  * @returns {void}
   */
   setReadCallback(cb){
     if (cb && {}.toString.call(cb) === '[object Function]') this._onSockRx = cb;
@@ -146,7 +193,8 @@ class TCPConnector {
 
   /**
   * Add listener for connection events
-  * @param {function} listener - a listener callback that is called when the connection is opened/closed
+  * @param {(connected: boolean) => void} listener - a listener callback that is called when the connection is opened/closed
+  * @returns {void}
   */
   addConnectionListener(listener){
     this.connListeners.push(listener);
@@ -154,7 +202,7 @@ class TCPConnector {
 
   /**
   * Remove listener for connection events
-  * @param {function} listener - remove the listener for connection
+  * @param {(connected: boolean) => void} listener - remove the listener for connection
   * @return {boolean} - true if the listner was removed successfully
   */
   removeConnectionListener(listener) {
@@ -168,6 +216,7 @@ class TCPConnector {
 
   /**
   * Close the connector
+  * @returns {void}
   */
   close(){
     if (!this.sock) return;

--- a/gateways/js/src/wsconnector.js
+++ b/gateways/js/src/wsconnector.js
@@ -5,6 +5,59 @@ const DEFAULT_RECONNECT_TIME = 5000;       // ms, delay between retries to conne
 * @ignore
 */
 class WSConnector {
+  /**
+   * WebSocket URL of the master container to connect to
+   * @type {URL}
+   */
+  url;
+
+  /**
+   * Whether to try to reconnect if the connection is lost
+   * @type {boolean}
+   */
+  keepAlive;
+
+  /**
+   * Time in milliseconds before a reconnection is attempted after an error
+   * @type {number}
+   */
+  _reconnectTime;
+
+  /**
+   * Whether to log debug info to the console
+   * @type {boolean}
+   */
+  debug;
+
+  /**
+   * Whether the Gateway has managed to connect to a server before
+   * @type {boolean}
+   */
+  _firstConn;
+
+  /**
+   * Whether the Gateway has attempted to reconnect to a server before
+   * @type {boolean}
+   */
+  _firstReConn;
+
+  /**
+   * List of callbacks make as soon as gateway is open
+   * @type {(() => void)[]}
+   */
+  pendingOnOpen;
+
+  /**
+   * @callback ConnectionListener
+   * @param {boolean} val
+   * @returns {void}
+   */
+
+  /**
+   * External listeners wanting to listen connection events
+   * @type {ConnectionListener[]}
+   */
+  connListeners;
 
   /**
   * Create an WSConnector to connect to a fjage master over WebSockets
@@ -25,20 +78,26 @@ class WSConnector {
     this.url.pathname = opts.pathname || '/';
     this._keepAlive = opts.keepAlive;
     this._reconnectTime = opts.reconnectTime || DEFAULT_RECONNECT_TIME;
-    this.debug = opts.debug || false;      // debug info to be logged to console?
-    this._firstConn = true;               // if the Gateway has managed to connect to a server before
-    this._firstReConn = true;             // if the Gateway has attempted to reconnect to a server before
-    this.pendingOnOpen = [];              // list of callbacks make as soon as gateway is open
-    this.connListeners = [];              // external listeners wanting to listen connection events
+    this.debug = opts.debug || false;
+    this._firstConn = true;
+    this._firstReConn = true;
+    this.pendingOnOpen = [];
+    this.connListeners = [];
     this._websockSetup(this.url);
   }
 
+  /**
+   * @param {boolean} val
+   */
   _sendConnEvent(val) {
     this.connListeners.forEach(l => {
       l && {}.toString.call(l) === '[object Function]' && l(val);
     });
   }
 
+  /**
+   * @param {string | URL} url
+   */
   _websockSetup(url){
     try {
       this.sock = new WebSocket(url);
@@ -98,8 +157,9 @@ class WSConnector {
 
   /**
   * @callback WSConnectorReadCallback
-  * @ignore
   * @param {string} s - incoming message string
+  * @returns {void}
+  * @ignore
   */
 
   /**
@@ -113,7 +173,7 @@ class WSConnector {
 
   /**
   * Add listener for connection events
-  * @param {function} listener - a listener callback that is called when the connection is opened/closed
+  * @param {ConnectionListener} listener - a listener callback that is called when the connection is opened/closed
   */
   addConnectionListener(listener){
     this.connListeners.push(listener);
@@ -121,7 +181,7 @@ class WSConnector {
 
   /**
   * Remove listener for connection events
-  * @param {function} listener - remove the listener for connection
+  * @param {ConnectionListener} listener - remove the listener for connection
   * @return {boolean} - true if the listner was removed successfully
   */
   removeConnectionListener(listener) {

--- a/gateways/js/src/wsconnector.js
+++ b/gateways/js/src/wsconnector.js
@@ -15,7 +15,7 @@ class WSConnector {
    * Whether to try to reconnect if the connection is lost
    * @type {boolean}
    */
-  keepAlive;
+  _keepAlive;
 
   /**
    * Time in milliseconds before a reconnection is attempted after an error

--- a/gateways/js/src/wsconnector.js
+++ b/gateways/js/src/wsconnector.js
@@ -42,7 +42,7 @@ class WSConnector {
   _firstReConn;
 
   /**
-   * List of callbacks make as soon as gateway is open
+   * List of callbacks invoked as soon as the gateway is open
    * @type {(() => void)[]}
    */
   pendingOnOpen;

--- a/gateways/js/test/spec/fjage.spec.js
+++ b/gateways/js/test/spec/fjage.spec.js
@@ -474,6 +474,12 @@ describe('An AgentID', function () {
     expect(val).toEqual([0, 42]);
   });
 
+  it('should reject if an array of parameters is set with a non-array value', async function () {
+    const aid = new AgentID('S', false, gw);
+    await expectAsync(aid.set(['a', 'b'], 42))
+      .toBeRejectedWithError('Values must be an array because an array was passed for parameters');
+  });
+
   it('should get the values of all parameter on a Agent', async function () {
     const aid = new AgentID('S', false, gw);
     let val = await aid.get();

--- a/gateways/js/tsconfig.json
+++ b/gateways/js/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "allowJs": true,
         "checkJs": true,
+        "noEmit": true,
         "declaration": true,
         "target": "es2020",
         "resolveJsonModule": true,

--- a/gateways/js/tsconfig.json
+++ b/gateways/js/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "allowJs": true,
         "checkJs": true,
-        "noEmit": true,
         "declaration": true,
         "target": "es2020",
         "resolveJsonModule": true,


### PR DESCRIPTION
Some of the JSDoc types for fjagejs were incorrect. There were also a few instances where the type was correct, but, unfortunately, TypeScript doesn't support all JSDoc tags: https://github.com/microsoft/TypeScript/issues/28730, https://github.com/microsoft/TypeScript/issues/20077.

This PR fixes incorrect JSDoc types and updates them so that they only use syntax that is recognised by TS.

As much as possible, I've tried to avoid making changes to actual code, but there a few instances where that's required due to type mismatches or to improve type narrowing.

This PR also adds a `typecheck` script to `package.json` so that running `pnpm run typecheck` will actually check that types are correct.