### PR TITLE
Add support for 2D integer arrays in message handling in fjage.c

### DIFF
--- a/gateways/c/src/fjage.c
+++ b/gateways/c/src/fjage.c
@@ -1209,6 +1209,44 @@ static const int fjage_msg_get_array(fjage_msg_t msg, const char* key, const cha
   return -1;
 }
 
+static int token_span(const jsmntok_t* tokens, int index) {
+  int count = 1;
+  if (tokens[index].type == JSMN_ARRAY) {
+    int child = index + 1;
+    for (int i = 0; i < tokens[index].size; i++) {
+      int span = token_span(tokens, child);
+      count += span;
+      child += span;
+    }
+  } else if (tokens[index].type == JSMN_OBJECT) {
+    int child = index + 1;
+    for (int i = 0; i < tokens[index].size; i++) {
+      int key_span = token_span(tokens, child);
+      child += key_span;
+      count += key_span;
+      int value_span = token_span(tokens, child);
+      child += value_span;
+      count += value_span;
+    }
+  }
+  return count;
+}
+
+static int json_object_get_value_token(_fjage_msg_t* m, int object_token, const char* key) {
+  if (m == NULL || key == NULL) return -1;
+  if (m->tokens[object_token].type != JSMN_OBJECT) return -1;
+  int child = object_token + 1;
+  int limit = object_token + token_span(m->tokens, object_token);
+  while (child + 1 < limit) {
+    if (m->tokens[child].type != JSMN_STRING) return -1;
+    char* t = m->data + m->tokens[child].start;
+    t[m->tokens[child].end-m->tokens[child].start] = 0;
+    if (!strcmp(t, key)) return child + 1;
+    child += 1 + token_span(m->tokens, child + 1);
+  }
+  return -1;
+}
+
 int fjage_msg_get_int(fjage_msg_t msg, const char* key, int defval) {
   const char* t = fjage_msg_get_string(msg, key);
   if (t == NULL) return defval;
@@ -1269,6 +1307,72 @@ int fjage_msg_get_int_array(fjage_msg_t msg, const char* key, int32_t* value, in
   return buflen/sizeof(int32_t);
 }
 
+int fjage_msg_get_int_array_2d(fjage_msg_t msg, const char* key, int32_t* value, int maxlen, int* lengths, int maxrows) {
+  if (msg == NULL) return -1;
+  _fjage_msg_t* m = msg;
+  int skip = -1;
+  for (int i = 1; i < m->ntokens-1; i += 2) {
+    char* t = m->data + m->tokens[i].start;
+    if (skip == 0 && m->tokens[i].type == JSMN_STRING && m->tokens[i+1].type == JSMN_ARRAY && !strcmp(t, key)) {
+      int total = 0;
+      int row = 0;
+      int token = i + 2;
+      for (int j = 0; j < m->tokens[i+1].size; j++) {
+        if (token >= m->ntokens) return -1;
+        if (m->tokens[token].type == JSMN_ARRAY) {
+          int rowlen = m->tokens[token].size;
+          if (lengths != NULL && row < maxrows) lengths[row] = rowlen;
+          row++;
+          int element = token + 1;
+          for (int k = 0; k < rowlen; k++) {
+            if (element >= m->ntokens) return -1;
+            if (value != NULL && total < maxlen) {
+              int32_t x = 0;
+              sscanf(m->data + m->tokens[element].start, "%d", &x);
+              value[total] = x;
+            }
+            total++;
+            element += token_span(m->tokens, element);
+          }
+        } else if (m->tokens[token].type == JSMN_OBJECT) {
+          int data_token = json_object_get_value_token(m, token, "data");
+          if (data_token < 0 || m->tokens[data_token].type != JSMN_STRING) return -1;
+          char* s = m->data + m->tokens[data_token].start;
+          s[m->tokens[data_token].end-m->tokens[data_token].start] = 0;
+          size_t buflen;
+          void* buf = b64_decode_ex(s, strlen(s), &buflen);
+          if (buf == NULL || buflen % sizeof(int32_t) != 0) {
+            free(buf);
+            return -1;
+          }
+          int rowlen = buflen/sizeof(int32_t);
+          if (lengths != NULL && row < maxrows) lengths[row] = rowlen;
+          row++;
+          if (value != NULL && total < maxlen) {
+            int copylen = rowlen;
+            if (total + copylen > maxlen) copylen = maxlen - total;
+            memcpy(value + total, buf, copylen*sizeof(int32_t));
+          }
+          total += rowlen;
+          free(buf);
+        } else {
+          return -1;
+        }
+        token += token_span(m->tokens, token);
+      }
+      return total;
+    }
+    if (skip > 0) skip--;
+    if (m->tokens[i+1].type == JSMN_ARRAY) i += m->tokens[i+1].size;
+    else if (m->tokens[i+1].type == JSMN_OBJECT) {
+      if (skip < 0) skip = 0;
+      else skip += m->tokens[i+1].size;
+    }
+  }
+  return -1;
+}
+
+
 int fjage_msg_get_float_array(fjage_msg_t msg, const char* key, float* value, int maxlen) {
   int n = fjage_msg_get_array(msg, key, "%f", value, sizeof(float), maxlen);
   if (n >= 0) return n;
@@ -1291,6 +1395,25 @@ void fjage_msg_add_string(fjage_msg_t msg, const char* key, const char* value) {
 void fjage_msg_add_int(fjage_msg_t msg, const char* key, int value) {
   char* s = msg_append(msg, strlen(key)+16);
   if (s != NULL) sprintf(s, "\"%s\": %d, ", key, value);
+}
+
+void fjage_msg_add_int_array_2d(fjage_msg_t msg, const char* key, int32_t* values, int vallen, int* lengths, int lenlen) {
+  char* s = msg_append(msg, strlen(key)+vallen*12+lenlen*4+16);
+  if (s != NULL) {
+    char* p = s;
+    p += sprintf(p, "\"%s\": [", key);
+    int vndx = 0;
+    for (int i = 0; i < lenlen; i++) {
+      p += sprintf(p, "[");
+      for (int j = 0; j < lengths[i]; j++) {
+        p += sprintf(p, "%d", values[vndx++]);
+        if (j < lengths[i]-1) p += sprintf(p, ",");
+      }
+      p += sprintf(p, "]");
+      if (i < lenlen-1) p += sprintf(p, ",");
+    }
+    p += sprintf(p, "], ");
+  }
 }
 
 void fjage_msg_add_long(fjage_msg_t msg, const char* key, long value) {

--- a/gateways/c/src/fjage.h
+++ b/gateways/c/src/fjage.h
@@ -317,6 +317,15 @@ void fjage_msg_add_byte_array(fjage_msg_t msg, const char* key, uint8_t* value, 
 
 void fjage_msg_add_int_array(fjage_msg_t msg, const char* key, int32_t* value, int len);
 
+/// Add a 2D integer array value to a message.
+/// @param msg            Message in write-only mode
+/// @param key            Key
+/// @param value          Pointer to the 2D int array (flattened)
+/// @param vallen         Length of the flattened int array (number of ints)
+/// @param lengths        Pointer to an array of lengths for each row (number of rows = number of elements in lengths array)
+/// @param lenlen         Length of the lengths array (number of rows)
+void fjage_msg_add_int_array_2d(fjage_msg_t msg, const char* key, int32_t* values, int vallen, int* lengths, int lenlen);
+
 /// Add a floating point array value to a message.
 ///
 /// @param msg            Message in write-only mode
@@ -447,6 +456,23 @@ int fjage_msg_get_byte_array(fjage_msg_t msg, const char* key, uint8_t* value, i
 /// @return               Number of ints in the byte array
 
 int fjage_msg_get_int_array(fjage_msg_t msg, const char* key, int32_t* value, int maxlen);
+
+/// Get a 2D integer array value encoded as a JSON list of lists. The array is
+/// returned in flattened row-major order in value, and the length of each row
+/// is returned in lengths. If only the lengths are desired, value may be NULL
+/// and maxlen set to 0. If only the total number of values is desired, lengths
+/// may be NULL and maxrows set to 0.
+///
+/// @param msg            Message in read-only mode
+/// @param key            Key
+/// @param value          Pointer to a flattened int array to receive data, or NULL
+/// @param maxlen         The maximum number of ints to receive, or 0 if value is NULL
+/// @param lengths        Pointer to an array to receive row lengths, or NULL
+/// @param maxrows        The maximum number of rows to receive, or 0 if lengths is NULL
+/// @return               Total number of ints in the 2D array
+
+int fjage_msg_get_int_array_2d(fjage_msg_t msg, const char* key, int32_t* value, int maxlen, int* lengths, int maxrows);
+
 
 /// Get a floating point array value. If only the length of the array is desired (so that
 /// an array can be allocated), passing NULL as value and 0 as maxlen returns

--- a/gateways/c/tests/test_fjage.c
+++ b/gateways/c/tests/test_fjage.c
@@ -140,6 +140,10 @@ int main(int argc, char* argv[]) {
   fjage_msg_add_int_array(msg, "myidata", idata, 8);
   float signal[6] = { 3,1,4,1,5,9 };
   fjage_msg_add_float_array(msg, "mysignal", signal, 6);
+  // Add int 2d array
+  int32_t myi2data[5] = { 10,11,12,13,14 };  // Flattened 2D array for [[10, 11], [12, 13, 14]]
+  int lengths[2] = { 2, 3 };  // Lengths of each row
+  fjage_msg_add_int_array_2d(msg, "myi2data", (int32_t*)myi2data, 5, lengths, 2);
   unsigned char ldata[100];
   int32_t lidata[100];
   float lsignal[100];
@@ -169,15 +173,22 @@ int main(int argc, char* argv[]) {
   test_assert("msg_get_byte_array (long len)", fjage_msg_get_byte_array(msg, "myldata", NULL, 0) == 100);
   test_assert("msg_get_int_array (long len)", fjage_msg_get_int_array(msg, "mylidata", NULL, 0) == 100);
   test_assert("msg_get_float_array (long len)", fjage_msg_get_float_array(msg, "mylsignal", NULL, 0) == 100);
+  int i2lengths[2] = { 0, 0 };
+  test_assert("msg_get_int_array_2d (len)", fjage_msg_get_int_array_2d(msg, "myi2data", NULL, 0, i2lengths, 2) == 5 && i2lengths[0] == 2 && i2lengths[1] == 3);
   memset(data, 0, sizeof(data));
   memset(idata, 0, sizeof(idata));
   memset(signal, 0, sizeof(signal));
   fjage_msg_get_byte_array(msg, "mydata", data, 7);
   fjage_msg_get_int_array(msg, "myidata", idata, 8);
   fjage_msg_get_float_array(msg, "mysignal", signal, 6);
+  memset(myi2data, 0, sizeof(myi2data));
+  i2lengths[0] = 0;
+  i2lengths[1] = 0;
+  fjage_msg_get_int_array_2d(msg, "myi2data", myi2data, 5, i2lengths, 2);
   test_assert("msg_get_byte_array", data[0] == 7 && data[1] == 6 && data[2] == 5 && data[3] == 4 && data[4] == 3 && data[5] == 2 && data[6] == 1);
   test_assert("msg_get_int_array", idata[0] == 7 && idata[1] == 6 && idata[2] == 5 && idata[3] == 4 && idata[4] == 3 && idata[5] == 2 && idata[6] == 1 && idata[7] == 0);
   test_assert("msg_get_float_array", signal[0] == 3 && signal[1] == 1 && signal[2] == 4 && signal[3] == 1 && signal[4] == 5 && signal[5] == 9);
+  test_assert("msg_get_int_array_2d", i2lengths[0] == 2 && i2lengths[1] == 3 && myi2data[0] == 10 && myi2data[1] == 11 && myi2data[2] == 12 && myi2data[3] == 13 && myi2data[4] == 14);
   memset(ldata, 0, sizeof(ldata));
   memset(lidata, 0, sizeof(lidata));
   memset(lsignal, 0, sizeof(lsignal));

--- a/src/main/groovy/org/arl/fjage/test/TestMessage.groovy
+++ b/src/main/groovy/org/arl/fjage/test/TestMessage.groovy
@@ -22,6 +22,7 @@ class TestMessage extends org.arl.fjage.Message {
   boolean myfbool
   byte[] mydata
   int[] myidata
+  int[][] myi2data
   float[] mysignal
   byte[] myldata
   int[] mylidata

--- a/src/test/groovy/org/arl/fjage/test/fjagecTest.groovy
+++ b/src/test/groovy/org/arl/fjage/test/fjagecTest.groovy
@@ -5,10 +5,19 @@ import org.arl.fjage.remote.*
 import org.arl.fjage.shell.*
 import org.arl.fjage.connectors.*
 import org.junit.Test
+import java.util.logging.Logger
 
 import static org.junit.Assert.assertEquals
 
 class fjagecTest {
+
+  private static final Logger log = Logger.getLogger(fjagecTest.class.name)
+
+  private static void logProcessOutput(String prefix, CharSequence output) {
+    output.toString().eachLine { line ->
+      log.info(prefix + line)
+    }
+  }
 
   @Test
   void fjageCTest() {
@@ -39,13 +48,15 @@ class fjagecTest {
     Thread.sleep(5)
     def ret = 0
     if (System.getProperty('manualCTest') == null){
-      println "Running automated tests."
+      log.info('Running automated tests.')
       def proc = "make -C gateways/c clean test runtest".execute()
       def sout = new StringBuilder(), serr = new StringBuilder()
       proc.consumeProcessOutput(sout, serr)
       proc.waitFor()
       ret = proc.exitValue()
-      println "C : out = $sout \n err = $serr \n ret = $ret"
+      logProcessOutput('C stdout> ', sout)
+      logProcessOutput('C stderr> ', serr)
+      log.info("C exit code: $ret")
     }else{
       println "waiting for user to run manual tests"
       while (testPending){


### PR DESCRIPTION
This pull request adds support for 2D integer arrays in the C fjage messaging library, including both serialization (adding to messages) and deserialization (extracting from messages).