### PR TITLE
Add `AgentID.leftShift` operator for statically compiled Groovy code

### DIFF
--- a/src/main/groovy/org/arl/fjage/GroovyExtensions.groovy
+++ b/src/main/groovy/org/arl/fjage/GroovyExtensions.groovy
@@ -22,10 +22,6 @@ import org.arl.fjage.param.*
 class GroovyExtensions {
   static void enable() {
 
-    AgentID.metaClass.leftShift = { Message msg ->
-      request(msg)
-    }
-
     Agent.metaClass.receive = { Closure filter, long timeout = 1000 ->
       MessageFilter f = new MessageFilter() {
         boolean matches(Message m) {

--- a/src/main/java/org/arl/fjage/AgentID.java
+++ b/src/main/java/org/arl/fjage/AgentID.java
@@ -174,6 +174,19 @@ public class AgentID implements Serializable, Comparable<AgentID> {
 
   /**
    * Sends a request to the agent represented by this id and waits for
+   * a return message for 1 second. This method implements the Groovy
+   * {@code <<} operator, so that {@code agentID << msg} works in both
+   * dynamically and statically compiled Groovy agents.
+   *
+   * @param msg request to send.
+   * @return response.
+   */
+  public Message leftShift(Message msg) {
+    return request(msg);
+  }
+
+  /**
+   * Sends a request to the agent represented by this id and waits for
    * a return message for a specified timeout.
    *
    * @param msg request to send.


### PR DESCRIPTION
## What

Adds `Message leftShift(Message)` to `AgentID` (Java), delegating to `request(msg)` — the exact semantics of the metaclass operator previously registered in `GroovyExtensions` (request with 1 s timeout). The metaclass registration is removed: dynamic dispatch resolves the real Java method without it, so keeping both would just be two definitions of the same operator that could drift apart.

## Why

`agentID << msg` was previously provided only by a runtime metaclass registration, which the Groovy static compiler cannot see — so `@CompileStatic` agents fail to resolve `<<`. With this method, the idiomatic `phy << msg` form works in both dynamically and statically compiled agents. A side benefit: `<<` now also works in Groovy contexts that never call `GroovyExtensions.enable()`.

Companion to #419.
