### PR TITLE
Update timeout defaults and add directory methods in Gateway spec

### DIFF
--- a/gateways/Gateways.md
+++ b/gateways/Gateways.md
@@ -52,7 +52,7 @@ All gateway agents should use names prefixed with `gateway-`.
 - Must not **block** if timeout is 0.
 - Must **block** indefinitely if timeout is -1.
 - Must **block** for timeout milliseconds otherwise.
-- Must default timeout to 1000 millisecond if not specified.
+- Must default timeout to 0 milliseconds if not specified.
 
 ### `request()` :: Message, (Int timeout) -> Message
 
@@ -60,7 +60,25 @@ All gateway agents should use names prefixed with `gateway-`.
 - Must not **block** if timeout is 0.
 - Must **block** indefinitely if timeout is -1.
 - Must **block** for timeout milliseconds otherwise.
-- Must default timeout to 1000 millisecond if not specified.
+- Must default timeout to 1000 milliseconds if not specified.
+- The default timeout may be configurable at a Gateway level.
+
+### `agents()` :: (Int timeout) -> [AgentID]
+
+- Finds all agents visible through the gateway.
+- Must default timeout to 6000 milliseconds if not specified.
+- Returns an array/list.
+
+### `containsAgent()` :: AgentID, (Int timeout) -> Boolean
+
+- Checks if an agent is visible through the gateway.
+- Must default timeout to 6000 milliseconds if not specified.
+
+### `services()` :: (Int timeout) -> [String]
+
+- Finds all services visible through the gateway.
+- Must default timeout to 6000 milliseconds if not specified.
+- Returns an array/list.
 
 ### `topic()` :: (AgentID/String topic), (String topic2) -> AgentID
 
@@ -86,13 +104,15 @@ All gateway agents should use names prefixed with `gateway-`.
 
 - Unsubscribes the gateway from a given topic.
 
-### `agentForService()` :: String -> AgentID
+### `agentForService()` :: String service, (Int timeout) -> AgentID
 
 - Finds an agent that provides a named service.
+- Must default timeout to 6000 milliseconds if not specified.
 
-### `agentsForService()` :: String -> [AgentID]
+### `agentsForService()` :: String service, (Int timeout) -> [AgentID]
 
-- Find all agents that provides a named service.
+- Find all agents that provide a named service.
+- Must default timeout to 6000 milliseconds if not specified.
 - Returns an array/list.
 
 ### `flush()` :: Void -> Void


### PR DESCRIPTION
This PR updates the timeouts and adding missing directory methods in the Gatway spec. Re: #401 