### PR TITLE
Allow Gateway constructor to throw on first-connect failure

### DIFF
--- a/gateways/Gateways.md
+++ b/gateways/Gateways.md
@@ -23,7 +23,7 @@ All gateway agents should use names prefixed with `gateway-`.
 - Creates a gateway connecting to a specified master container specified by the arguments.
 - Must accept `String hostname, Int port` arguments for TCP connections.
 - May support `String devname, Int baud, String settings` arguments if Serial connections are supported.
-- Must return a `null` if the connection to master container fails on the first attempt.
+- Must return a `null`, or throw an exception, if the connection to master container fails on the first attempt.
 - May support auto-reconnect, where, once a connection with the master container is established if the connection fails, the Gateway tries to reconnect automatically.
 - Must NOT set the `sentAt` field of the message. This field will be populated by the Container when the message is received.
 - Must respond to JSON message `{"alive": true}` from the master container with `{"alive": true}` as soon as possible to indicate that the gateway is alive.


### PR DESCRIPTION
## Summary

The Gateway API spec currently requires the constructor to **return `null`** if the initial connection to the master container fails:

> Must return a `null` if the connection to master container fails on the first attempt.

In some languages, a constructor returning anything other than the constructed object is unidiomatic or impossible — e.g. a Julia constructor must return an instance of the type, so it cannot return `null`; throwing is the natural way to signal failure. This PR relaxes the wording to permit either:

> Must return a `null`, **or throw an exception**, if the connection to master container fails on the first attempt.

This keeps the `null` option for languages that prefer it while legitimizing the throw-based approach.

## Context

Came up while making `Fjage.jl`'s `Gateway` compliant with the recently-updated discovery-method timeouts (org-arl/Fjage.jl#61). Rather than force a non-idiomatic `Union{Gateway,Nothing}` return in Julia, we relax the spec here.

One-line doc change; no code affected.