### PR TITLE
Add support for statically checking/parsing scripts.

### DIFF
--- a/src/main/groovy/org/arl/fjage/shell/GroovyScriptEngine.java
+++ b/src/main/groovy/org/arl/fjage/shell/GroovyScriptEngine.java
@@ -494,7 +494,6 @@ public class GroovyScriptEngine implements ScriptEngine {
 
   private RuntimeException rethrowParseFailure(Throwable ex) {
     if (ex instanceof GroovyBugError) ex = resolveGroovyBug(ex);
-    if (ex instanceof MultipleCompilationErrorsException) return (MultipleCompilationErrorsException) ex;
     if (ex instanceof RuntimeException) return (RuntimeException) ex;
     return new RuntimeException(ex);
   }

--- a/src/main/groovy/org/arl/fjage/shell/GroovyScriptEngine.java
+++ b/src/main/groovy/org/arl/fjage/shell/GroovyScriptEngine.java
@@ -137,16 +137,54 @@ public class GroovyScriptEngine implements ScriptEngine {
   public boolean isComplete(String cmd) {
     if (cmd == null || cmd.trim().length() == 0) return true;
     try {
-      groovy.parse(cmd);
-      return true;
+      return parse(cmd) == null;
     } catch (MultipleCompilationErrorsException ex) {
-      String s = ex.getMessage();
-      if (s == null) return true;
-      if (s.contains("unexpected token")) return false;
-      if (s.contains("expecting")) return false;
-      return true;
+      return !isIncomplete(ex);
     } catch (Throwable ex) {
       return true;
+    }
+  }
+
+  @Override
+  public MultipleCompilationErrorsException parse(String cmd) {
+    if (cmd == null || cmd.trim().length() == 0) return null;
+    synchronized(this) {
+      try {
+        busy = Thread.currentThread();
+        try {
+          groovy.parse(cmd);
+          return null;
+        } catch (MultipleCompilationErrorsException ex) {
+          return ex;
+        } catch (Throwable ex) {
+          throw rethrowParseFailure(ex);
+        }
+      } finally {
+        Thread.interrupted();
+        busy = null;
+      }
+    }
+  }
+
+  @Override
+  public MultipleCompilationErrorsException parse(File script) {
+    if (script == null) return null;
+    synchronized(this) {
+      try {
+        busy = Thread.currentThread();
+        try {
+          groovy.getClassLoader().clearCache();
+          groovy.parse(script);
+          return null;
+        } catch (MultipleCompilationErrorsException ex) {
+          return ex;
+        } catch (Throwable ex) {
+          throw rethrowParseFailure(ex);
+        }
+      } finally {
+        Thread.interrupted();
+        busy = null;
+      }
     }
   }
 
@@ -398,6 +436,21 @@ public class GroovyScriptEngine implements ScriptEngine {
     if (ex instanceof GroovyBugError) ex = resolveGroovyBug(ex);
     if (out != null) out.error(ex);
     else log.log(Level.WARNING, "Groovy execution failed", ex);
+  }
+
+  private boolean isIncomplete(MultipleCompilationErrorsException ex) {
+    String s = ex.getMessage();
+    if (s == null) return false;
+    if (s.contains("unexpected token")) return true;
+    if (s.contains("expecting")) return true;
+    return false;
+  }
+
+  private RuntimeException rethrowParseFailure(Throwable ex) {
+    if (ex instanceof GroovyBugError) ex = resolveGroovyBug(ex);
+    if (ex instanceof MultipleCompilationErrorsException) return (MultipleCompilationErrorsException) ex;
+    if (ex instanceof RuntimeException) return (RuntimeException) ex;
+    return new RuntimeException(ex);
   }
 
   private Throwable resolveGroovyBug(Throwable ex) {

--- a/src/main/groovy/org/arl/fjage/shell/GroovyScriptEngine.java
+++ b/src/main/groovy/org/arl/fjage/shell/GroovyScriptEngine.java
@@ -11,10 +11,12 @@ for full license details.
 package org.arl.fjage.shell;
 
 import groovy.lang.*;
+import groovy.transform.CompileStatic;
 import groovy.transform.ThreadInterrupt;
 import org.arl.fjage.Message;
 import org.arl.fjage.Performative;
 import org.codehaus.groovy.GroovyBugError;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
@@ -27,7 +29,9 @@ import java.io.Reader;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -75,9 +79,25 @@ public class GroovyScriptEngine implements ScriptEngine {
 
   }
 
+  ////// static attributes
+
+  // Exposes the binding of the engine currently running a static check to the
+  // CompileStatic type-checking extension (see resource ShellStaticCheck.groovy),
+  // so that shell binding variables are treated as valid during the check.
+  private static final ThreadLocal<Binding> CHECK_BINDING = new ThreadLocal<>();
+
+  /**
+   * Returns the shell binding of the engine currently performing a static check on the
+   * calling thread, or null if none. Used by the CompileStatic type-checking extension.
+   */
+  public static Binding currentCheckBinding() {
+    return CHECK_BINDING.get();
+  }
+
   ////// private attributes
 
   private GroovyShell groovy;
+  private GroovyShell groovyCheck;
   private Binding binding;
   private ImportCustomizer imports;
   private Shell out = null;
@@ -115,6 +135,16 @@ public class GroovyScriptEngine implements ScriptEngine {
     compiler.addCompilationCustomizers(imports);
     compiler.addCompilationCustomizers(new ASTTransformationCustomizer(ThreadInterrupt.class));
     groovy = new GroovyShell(gcl, binding, compiler);
+    // Separate shell used only by parse() to statically check scripts without running them.
+    // It reuses the same (mutable) imports and script base class, and adds CompileStatic with a
+    // type-checking extension that tolerates shell binding variables and dynamic shell features.
+    CompilerConfiguration checkCompiler = new CompilerConfiguration();
+    checkCompiler.setScriptBaseClass(BaseGroovyScript.class.getName());
+    checkCompiler.addCompilationCustomizers(imports);
+    Map<String,Object> checkOpts = new HashMap<>();
+    checkOpts.put("extensions", new ConstantExpression("org/arl/fjage/shell/ShellStaticCheck.groovy"));
+    checkCompiler.addCompilationCustomizers(new ASTTransformationCustomizer(checkOpts, CompileStatic.class));
+    groovyCheck = new GroovyShell(gcl, binding, checkCompiler);
     binding.setVariable("__groovy__", groovy);
     binding.setVariable("__doc__", doc);
     groovy.evaluate("__init__()");
@@ -136,12 +166,24 @@ public class GroovyScriptEngine implements ScriptEngine {
   @Override
   public boolean isComplete(String cmd) {
     if (cmd == null || cmd.trim().length() == 0) return true;
-    try {
-      return parse(cmd) == null;
-    } catch (MultipleCompilationErrorsException ex) {
-      return !isIncomplete(ex);
-    } catch (Throwable ex) {
-      return true;
+    // Use a dynamic (non-static) parse here: line-continuation detection only cares about
+    // syntactic completeness, and running the static check per keystroke would be wasteful and
+    // could misreport valid dynamic commands as errors.
+    synchronized(this) {
+      try {
+        busy = Thread.currentThread();
+        try {
+          groovy.parse(cmd);
+          return true;
+        } catch (MultipleCompilationErrorsException ex) {
+          return !isIncomplete(ex);
+        } catch (Throwable ex) {
+          return true;
+        }
+      } finally {
+        Thread.interrupted();
+        busy = null;
+      }
     }
   }
 
@@ -151,8 +193,9 @@ public class GroovyScriptEngine implements ScriptEngine {
     synchronized(this) {
       try {
         busy = Thread.currentThread();
+        CHECK_BINDING.set(binding);
         try {
-          groovy.parse(cmd);
+          groovyCheck.parse(cmd);
           return null;
         } catch (MultipleCompilationErrorsException ex) {
           return ex;
@@ -160,6 +203,7 @@ public class GroovyScriptEngine implements ScriptEngine {
           throw rethrowParseFailure(ex);
         }
       } finally {
+        CHECK_BINDING.remove();
         Thread.interrupted();
         busy = null;
       }
@@ -172,9 +216,10 @@ public class GroovyScriptEngine implements ScriptEngine {
     synchronized(this) {
       try {
         busy = Thread.currentThread();
+        CHECK_BINDING.set(binding);
         try {
-          groovy.getClassLoader().clearCache();
-          groovy.parse(script);
+          groovyCheck.getClassLoader().clearCache();
+          groovyCheck.parse(script);
           return null;
         } catch (MultipleCompilationErrorsException ex) {
           return ex;
@@ -182,6 +227,7 @@ public class GroovyScriptEngine implements ScriptEngine {
           throw rethrowParseFailure(ex);
         }
       } finally {
+        CHECK_BINDING.remove();
         Thread.interrupted();
         busy = null;
       }

--- a/src/main/groovy/org/arl/fjage/shell/GroovyScriptEngine.java
+++ b/src/main/groovy/org/arl/fjage/shell/GroovyScriptEngine.java
@@ -48,7 +48,7 @@ public class GroovyScriptEngine implements ScriptEngine {
 
   ////// inner classes
 
-  class BlockingInput {
+  static class BlockingInput {
 
     private int waiting = 0;
     private String input = null;
@@ -98,13 +98,13 @@ public class GroovyScriptEngine implements ScriptEngine {
 
   private GroovyShell groovy;
   private GroovyShell groovyCheck;
-  private Binding binding;
+  private final Binding binding;
   private ImportCustomizer imports;
   private Shell out = null;
   private Thread busy = null;
-  private Documentation doc = new Documentation();
-  private BlockingInput input = new BlockingInput();
-  private Logger log = Logger.getLogger(getClass().getName());
+  private final Documentation doc = new Documentation();
+  private final BlockingInput input = new BlockingInput();
+  private final Logger log = Logger.getLogger(getClass().getName());
 
   ////// constructor
 
@@ -165,72 +165,42 @@ public class GroovyScriptEngine implements ScriptEngine {
 
   @Override
   public boolean isComplete(String cmd) {
-    if (cmd == null || cmd.trim().length() == 0) return true;
-    // Use a dynamic (non-static) parse here: line-continuation detection only cares about
-    // syntactic completeness, and running the static check per keystroke would be wasteful and
-    // could misreport valid dynamic commands as errors.
-    synchronized(this) {
-      try {
-        busy = Thread.currentThread();
-        try {
-          groovy.parse(cmd);
-          return true;
-        } catch (MultipleCompilationErrorsException ex) {
-          return !isIncomplete(ex);
-        } catch (Throwable ex) {
-          return true;
-        }
-      } finally {
-        Thread.interrupted();
-        busy = null;
-      }
+    if (cmd == null || cmd.trim().isEmpty()) return true;
+    try {
+      groovy.parse(cmd);
+      return true;
+    } catch (MultipleCompilationErrorsException ex) {
+      return !isIncomplete(ex);
+    } catch (Throwable ex) {
+      return true;
     }
   }
 
   @Override
   public MultipleCompilationErrorsException parse(String cmd) {
-    if (cmd == null || cmd.trim().length() == 0) return null;
-    synchronized(this) {
-      try {
-        busy = Thread.currentThread();
-        CHECK_BINDING.set(binding);
-        try {
-          groovyCheck.parse(cmd);
-          return null;
-        } catch (MultipleCompilationErrorsException ex) {
-          return ex;
-        } catch (Throwable ex) {
-          throw rethrowParseFailure(ex);
-        }
-      } finally {
-        CHECK_BINDING.remove();
-        Thread.interrupted();
-        busy = null;
-      }
+    if (cmd == null || cmd.trim().isEmpty()) return null;
+    CHECK_BINDING.set(binding);
+    try {
+      groovyCheck.parse(cmd);
+      return null;
+    } catch (MultipleCompilationErrorsException ex) {
+      return ex;
+    } catch (Throwable ex) {
+      throw rethrowParseFailure(ex);
     }
   }
 
   @Override
   public MultipleCompilationErrorsException parse(File script) {
     if (script == null) return null;
-    synchronized(this) {
-      try {
-        busy = Thread.currentThread();
-        CHECK_BINDING.set(binding);
-        try {
-          groovyCheck.getClassLoader().clearCache();
-          groovyCheck.parse(script);
-          return null;
-        } catch (MultipleCompilationErrorsException ex) {
-          return ex;
-        } catch (Throwable ex) {
-          throw rethrowParseFailure(ex);
-        }
-      } finally {
-        CHECK_BINDING.remove();
-        Thread.interrupted();
-        busy = null;
-      }
+    CHECK_BINDING.set(binding);
+    try {
+      groovyCheck.parse(script);
+      return null;
+    } catch (MultipleCompilationErrorsException ex) {
+      return ex;
+    } catch (Throwable ex) {
+      throw rethrowParseFailure(ex);
     }
   }
 
@@ -488,8 +458,7 @@ public class GroovyScriptEngine implements ScriptEngine {
     String s = ex.getMessage();
     if (s == null) return false;
     if (s.contains("unexpected token")) return true;
-    if (s.contains("expecting")) return true;
-    return false;
+    return s.contains("expecting");
   }
 
   private RuntimeException rethrowParseFailure(Throwable ex) {

--- a/src/main/java/org/arl/fjage/shell/EchoScriptEngine.java
+++ b/src/main/java/org/arl/fjage/shell/EchoScriptEngine.java
@@ -11,6 +11,7 @@ for full license details.
 package org.arl.fjage.shell;
 
 import org.arl.fjage.Message;
+import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 
 import java.io.File;
 import java.io.Reader;
@@ -38,6 +39,16 @@ public class EchoScriptEngine implements ScriptEngine {
   @Override
   public boolean isComplete(String cmd) {
     return true;
+  }
+
+  @Override
+  public MultipleCompilationErrorsException parse(String cmd) {
+    return null;
+  }
+
+  @Override
+  public MultipleCompilationErrorsException parse(File script) {
+    return null;
   }
 
   @Override

--- a/src/main/java/org/arl/fjage/shell/ScriptEngine.java
+++ b/src/main/java/org/arl/fjage/shell/ScriptEngine.java
@@ -11,6 +11,7 @@ for full license details.
 package org.arl.fjage.shell;
 
 import org.arl.fjage.Message;
+import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 
 import java.io.File;
 import java.io.Reader;
@@ -44,6 +45,22 @@ public interface ScriptEngine {
    * @return true if complete, false if incomplete.
    */
   public boolean isComplete(String cmd);
+
+  /**
+   * Parse a command in the script engine context without executing it.
+   *
+   * @param cmd command to parse.
+   * @return compilation errors if parsing fails, null otherwise.
+   */
+  public MultipleCompilationErrorsException parse(String cmd);
+
+  /**
+   * Parse a script file in the script engine context without executing it.
+   *
+   * @param script script file to parse.
+   * @return compilation errors if parsing fails, null otherwise.
+   */
+  public MultipleCompilationErrorsException parse(File script);
 
   /**
    * Execute a command. The method waits for execution to be completed.

--- a/src/main/java/org/arl/fjage/shell/ShellAgent.java
+++ b/src/main/java/org/arl/fjage/shell/ShellAgent.java
@@ -559,7 +559,7 @@ public class ShellAgent extends Agent {
   private void handleCheckReq(final ShellCheckReq req) {
     Message rsp;
     if (engine == null || engine.isBusy()) {
-      log.info("Syntax check failure: engine is busy");
+      log.info("Syntax check failure: engine is " + (engine == null ? "null" : "busy"));
       rsp = new Message(req, Performative.REFUSE);
     }
     else {

--- a/src/main/java/org/arl/fjage/shell/ShellAgent.java
+++ b/src/main/java/org/arl/fjage/shell/ShellAgent.java
@@ -583,6 +583,11 @@ public class ShellAgent extends Agent {
             send(new Message(req, Performative.REFUSE));
             return;
           }
+          if (file.isDirectory()) {
+            log.info("Syntax check failure: file " + filename + " is a directory");
+            send(new Message(req, Performative.REFUSE));
+            return;
+          }
           ex = engine.parse(file);
         } else {
           String cmd = req.getCommand();

--- a/src/main/java/org/arl/fjage/shell/ShellAgent.java
+++ b/src/main/java/org/arl/fjage/shell/ShellAgent.java
@@ -603,7 +603,7 @@ public class ShellAgent extends Agent {
         if (ex != null) checkRsp.setDiagnostics(toDiagnosticsJson(ex));
         rsp = checkRsp;
       } catch (Throwable ex) {
-        log.log(Level.WARNING, "Command parse failure: "+ex.toString(), ex);
+        log.log(Level.WARNING, "Shell check parse failure: "+ex.toString(), ex);
         rsp = new Message(req, Performative.FAILURE);
       }
     }

--- a/src/main/java/org/arl/fjage/shell/ShellAgent.java
+++ b/src/main/java/org/arl/fjage/shell/ShellAgent.java
@@ -10,8 +10,15 @@ for full license details.
 
 package org.arl.fjage.shell;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import org.arl.fjage.*;
 import org.arl.fjage.param.ParameterMessageBehavior;
+import org.codehaus.groovy.control.MultipleCompilationErrorsException;
+import org.codehaus.groovy.control.messages.SyntaxErrorMessage;
+import org.codehaus.groovy.syntax.SyntaxException;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -66,6 +73,7 @@ public class ShellAgent extends Agent {
   ////// private attributes
 
   protected Shell shell;
+  protected static final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
   protected Thread consoleThread = null;
   protected ScriptEngine engine;
   protected Callable<Void> exec = null;
@@ -250,6 +258,7 @@ public class ShellAgent extends Agent {
       @Override
       public void onReceive(Message msg) {
         if (msg instanceof ShellExecReq) handleExecReq((ShellExecReq)msg);
+        else if (msg instanceof ShellCheckReq) handleCheckReq((ShellCheckReq)msg);
         else if (msg instanceof GetFileReq) handleGetFileReq((GetFileReq)msg);
         else if (msg instanceof PutFileReq) handlePutFileReq((PutFileReq)msg);
         else if (msg.getPerformative() == Performative.REQUEST) send(new Message(msg, Performative.NOT_UNDERSTOOD));
@@ -547,6 +556,55 @@ public class ShellAgent extends Agent {
     send(rsp);
   }
 
+  private void handleCheckReq(final ShellCheckReq req) {
+    Message rsp;
+    if (engine == null || engine.isBusy()) {
+      log.info("Syntax check failure: engine is busy");
+      rsp = new Message(req, Performative.REFUSE);
+    }
+    else {
+      try {
+        MultipleCompilationErrorsException ex;
+        if (req.isScript()) {
+          String filename = req.getFilename();
+          if (filename == null) {
+            log.info("Syntax check failure: filename is null");
+            send(new Message(req, Performative.REFUSE));
+            return;
+          }
+          if (filename.endsWith("/") || filename.endsWith(File.separator)) {
+            log.info("Syntax check failure: filename " + filename + " is a directory");
+            send(new Message(req, Performative.REFUSE));
+            return;
+          }
+          File file = new File(filename);
+          if (!file.exists()) {
+            log.info("Syntax check failure: file " + filename + " not found");
+            send(new Message(req, Performative.REFUSE));
+            return;
+          }
+          ex = engine.parse(file);
+        } else {
+          String cmd = req.getCommand();
+          if (cmd == null) {
+            log.info("Syntax check failure: command is null");
+            send(new Message(req, Performative.REFUSE));
+            return;
+          }
+          ex = engine.parse(cmd);
+        }
+        ShellCheckRsp checkRsp = new ShellCheckRsp(req);
+        checkRsp.setValid(ex == null);
+        if (ex != null) checkRsp.setDiagnostics(toDiagnosticsJson(ex));
+        rsp = checkRsp;
+      } catch (Throwable ex) {
+        log.log(Level.WARNING, "Command parse failure: "+ex.toString(), ex);
+        rsp = new Message(req, Performative.FAILURE);
+      }
+    }
+    send(rsp);
+  }
+
   private void handleGetFileReq(final GetFileReq req) {
     String filename = req.getFilename();
     if (filename == null) {
@@ -705,6 +763,34 @@ public class ShellAgent extends Agent {
     }
     if (rsp == null) rsp = new Message(req, Performative.FAILURE);
     send(rsp);
+  }
+
+  private String toDiagnosticsJson(MultipleCompilationErrorsException ex) {
+    JsonObject root = new JsonObject();
+    root.addProperty("message", ex.getMessage());
+    JsonArray errors = new JsonArray();
+    root.add("errors", errors);
+    if (ex.getErrorCollector() != null) {
+      for (Object obj: ex.getErrorCollector().getErrors()) {
+        JsonObject err = new JsonObject();
+        err.addProperty("type", obj.getClass().getSimpleName());
+        if (obj instanceof SyntaxErrorMessage) {
+          SyntaxException syntax = ((SyntaxErrorMessage)obj).getCause();
+          if (syntax != null) {
+            err.addProperty("message", syntax.getOriginalMessage());
+            err.addProperty("line", syntax.getStartLine());
+            err.addProperty("column", syntax.getStartColumn());
+            err.addProperty("endLine", syntax.getEndLine());
+            err.addProperty("endColumn", syntax.getEndColumn());
+            if (syntax.getSourceLocator() != null) err.addProperty("source", syntax.getSourceLocator());
+          } else err.addProperty("message", obj.toString());
+        } else {
+          err.addProperty("message", obj.toString());
+        }
+        errors.add(err);
+      }
+    }
+    return gson.toJson(root);
   }
 
 }

--- a/src/main/java/org/arl/fjage/shell/ShellCheckReq.java
+++ b/src/main/java/org/arl/fjage/shell/ShellCheckReq.java
@@ -82,11 +82,6 @@ public class ShellCheckReq extends Message {
   }
 
   /**
-   * Set the script to check.
-   *
-   * @param script script file to check.
-   */
-  /**
    * Set the filename of the script to check.
    *
    * @param filename script filename to check.

--- a/src/main/java/org/arl/fjage/shell/ShellCheckReq.java
+++ b/src/main/java/org/arl/fjage/shell/ShellCheckReq.java
@@ -1,0 +1,117 @@
+/******************************************************************************
+
+Copyright (c) 2026, Mandar Chitre
+
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
+
+******************************************************************************/
+
+package org.arl.fjage.shell;
+
+import org.arl.fjage.AgentID;
+import org.arl.fjage.Message;
+import org.arl.fjage.Performative;
+
+/**
+ * Request to check shell command/script syntax without executing it.
+ */
+public class ShellCheckReq extends Message {
+
+  private static final long serialVersionUID = 1L;
+
+  private String command = null;
+  private String filename = null;
+
+  /**
+   * Create an empty request for shell syntax check.
+   */
+  public ShellCheckReq() {
+    super(Performative.REQUEST);
+  }
+
+  /**
+   * Create an empty request for shell syntax check.
+   *
+   * @param to shell agent id.
+   */
+  public ShellCheckReq(AgentID to) {
+    super(to, Performative.REQUEST);
+  }
+
+  /**
+   * Create request for shell command syntax check.
+   *
+   * @param cmd command to check.
+   */
+  public ShellCheckReq(String cmd) {
+    super(Performative.REQUEST);
+    this.command = cmd;
+  }
+
+  /**
+   * Create request for shell command syntax check.
+   *
+   * @param to shell agent id.
+   * @param cmd command to check.
+   */
+  public ShellCheckReq(AgentID to, String cmd) {
+    super(to, Performative.REQUEST);
+    this.command = cmd;
+  }
+
+
+  /**
+   * Set the command to check.
+   *
+   * @param cmd command to check.
+   */
+  public void setCommand(String cmd) {
+    if (cmd != null && filename != null) throw new UnsupportedOperationException("ShellCheckReq can either have a command or filename, but not both");
+    this.command = cmd;
+  }
+
+  /**
+   * Get the command to check.
+   *
+   * @return command to check, null if none.
+   */
+  public String getCommand() {
+    return command;
+  }
+
+  /**
+   * Set the script to check.
+   *
+   * @param script script file to check.
+   */
+  /**
+   * Set the filename of the script to check.
+   *
+   * @param filename script filename to check.
+   */
+  public void setFilename(String filename) {
+    if (filename != null && command != null) throw new UnsupportedOperationException("ShellCheckReq can either have a command or filename, but not both");
+    this.filename = filename;
+  }
+
+  /**
+   * Get the filename of the script to check.
+   *
+   * @return script filename to check, null if none.
+   */
+  public String getFilename() {
+    return filename;
+  }
+
+  /**
+   * Check if the request is for a script file.
+   *
+   * @return true if request is for a script file, false if it is for a command.
+   */
+  public boolean isScript() {
+    return filename != null;
+  }
+
+}

--- a/src/main/java/org/arl/fjage/shell/ShellCheckRsp.java
+++ b/src/main/java/org/arl/fjage/shell/ShellCheckRsp.java
@@ -1,0 +1,87 @@
+/******************************************************************************
+
+Copyright (c) 2026, Mandar Chitre
+
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
+
+******************************************************************************/
+
+package org.arl.fjage.shell;
+
+import org.arl.fjage.Message;
+import org.arl.fjage.Performative;
+
+/**
+ * Response to a ShellCheckReq, with syntax validation result and diagnostics.
+ */
+public class ShellCheckRsp extends Message {
+
+  private static final long serialVersionUID = 1L;
+
+  private boolean valid = false;
+  private String diagnostics = null;
+
+  /**
+   * Create an empty response.
+   */
+  public ShellCheckRsp() {
+    super(Performative.INFORM);
+  }
+
+  /**
+   * Create a response to the ShellCheckReq.
+   *
+   * @param inReplyTo message to which this is a response.
+   */
+  public ShellCheckRsp(ShellCheckReq inReplyTo) {
+    super(inReplyTo, Performative.INFORM);
+  }
+
+  /**
+   * Checks if the command/script is syntactically valid.
+   *
+   * @return true if valid, false otherwise.
+   */
+  public boolean isValid() {
+    return valid;
+  }
+
+  /**
+   * Checks if the command/script is syntactically valid.
+   *
+   * @return true if valid, false otherwise.
+   */
+  public boolean getValid() {
+    return valid;
+  }
+
+  /**
+   * Marks the command/script as syntactically valid or invalid.
+   *
+   * @param valid true if valid, false otherwise.
+   */
+  public void setValid(boolean valid) {
+    this.valid = valid;
+  }
+
+  /**
+   * Get JSON diagnostics for an invalid command/script.
+   *
+   * @return JSON diagnostics string, or null if valid.
+   */
+  public String getDiagnostics() {
+    return diagnostics;
+  }
+
+  /**
+   * Set JSON diagnostics for an invalid command/script.
+   *
+   * @param diagnostics JSON diagnostics string.
+   */
+  public void setDiagnostics(String diagnostics) {
+    this.diagnostics = diagnostics;
+  }
+
+}

--- a/src/main/resources/org/arl/fjage/shell/ShellStaticCheck.groovy
+++ b/src/main/resources/org/arl/fjage/shell/ShellStaticCheck.groovy
@@ -1,0 +1,54 @@
+/******************************************************************************
+
+Copyright (c) 2016, Mandar Chitre
+
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
+
+******************************************************************************/
+
+// CompileStatic type-checking extension used by GroovyScriptEngine.parse() to statically
+// check shell scripts/commands without running them (see ShellCheckReq).
+//
+// The fjage shell shares one Binding across shell.exec() calls: any `name = value` (without
+// `def`) becomes a binding variable reused by later commands. CompileStatic has no knowledge
+// of these and would reject them as "undeclared". This extension tolerates them, and keeps
+// the shell's dynamic features (agent-name shortcuts, aid.param metaclass access,
+// methodMissing) compilable, while still letting CompileStatic flag genuine issues such as
+// syntax errors, type mismatches, unknown methods on known types and arity errors.
+
+import org.codehaus.groovy.ast.expr.BinaryExpression
+import org.codehaus.groovy.syntax.Types
+import org.arl.fjage.shell.GroovyScriptEngine
+
+// Names assigned without `def` earlier in this script; treated as dynamic locals so that a
+// later read of the same name within the script does not get flagged.
+def assigned = new HashSet<String>()
+
+unresolvedVariable { var ->
+  def b = GroovyScriptEngine.currentCheckBinding()
+  if ((b != null && b.hasVariable(var.name)) || assigned.contains(var.name)) {
+    // a known shell binding variable (or one assigned earlier in this script)
+    makeDynamic(var)
+    return
+  }
+  def bin = enclosingBinaryExpression
+  if (bin instanceof BinaryExpression && bin.operation.type == Types.ASSIGN && bin.leftExpression.is(var)) {
+    // `name = value` at the top level creates/updates a shell binding variable
+    assigned << var.name
+    makeDynamic(var)
+    return
+  }
+  // otherwise leave it unresolved so CompileStatic reports it as a real error
+}
+
+// aid.param metaclass access and other dynamic property reads/writes
+unresolvedProperty { pexp ->
+  makeDynamic(pexp)
+}
+
+// methodMissing routing (agent-name shortcuts, running scripts by name, etc.)
+methodNotFound { receiver, name, argList, argTypes, call ->
+  makeDynamic(call)
+}

--- a/src/test/java/org/arl/fjage/test/BasicTests.java
+++ b/src/test/java/org/arl/fjage/test/BasicTests.java
@@ -390,6 +390,27 @@ public class BasicTests {
   }
 
   @Test
+  public void testShellCheckStatic() {
+    log.info("testShellCheckStatic");
+    Platform platform = new RealTimePlatform();
+    Container container = new Container(platform);
+    GroovyScriptEngine engine = new GroovyScriptEngine();
+    engine.setVariable("xbind", 5);
+    container.add("shell", new ShellAgent(engine));
+    ShellCheckStaticTestAgent agent = new ShellCheckStaticTestAgent();
+    container.add("test", agent);
+    platform.start();
+    while (!agent.done)
+      platform.delay(1000);
+    platform.shutdown();
+    assertTrue("Binding variable should be valid", agent.bindingVarValid);
+    assertTrue("Assign-then-read should be valid", agent.assignReadValid);
+    assertTrue("Unknown method call should fall back to dynamic (valid)", agent.dynamicMethodValid);
+    assertTrue("Static type error should be invalid", agent.typeErrorInvalid);
+    assertTrue("Undeclared variable read should be invalid", agent.undeclaredInvalid);
+  }
+
+  @Test
   public void testListener() {
     log.info("testListener");
     Platform platform = new RealTimePlatform();
@@ -1194,6 +1215,42 @@ public class BasicTests {
         public void action() {
           Message rsp = request(new ShellCheckReq(new AgentID("shell"), "println 'hello'"));
           refused = rsp != null && rsp.getPerformative() == Performative.REFUSE;
+          done = true;
+        }
+      });
+    }
+  }
+
+  private static class ShellCheckStaticTestAgent extends Agent {
+    public boolean bindingVarValid = false, assignReadValid = false, dynamicMethodValid = false,
+                   typeErrorInvalid = false, undeclaredInvalid = false, done = false;
+
+    private static boolean isValid(Message rsp) {
+      return rsp instanceof ShellCheckRsp && ((ShellCheckRsp)rsp).isValid()
+          && ((ShellCheckRsp)rsp).getDiagnostics() == null;
+    }
+
+    private static boolean isInvalid(Message rsp) {
+      return rsp instanceof ShellCheckRsp && !((ShellCheckRsp)rsp).isValid()
+          && ((ShellCheckRsp)rsp).getDiagnostics() != null;
+    }
+
+    @Override
+    public void init() {
+      add(new OneShotBehavior() {
+        @Override
+        public void action() {
+          AgentID shell = new AgentID("shell");
+          // shell binding variable set on the engine is known to the static check
+          bindingVarValid = isValid(request(new ShellCheckReq(shell, "xbind + 1")));
+          // a `name = value` binding assignment and a later read of it in the same script
+          assignReadValid = isValid(request(new ShellCheckReq(shell, "ybind = 3\nybind + 1")));
+          // unknown method call falls back to dynamic dispatch (methodMissing / shortcuts)
+          dynamicMethodValid = isValid(request(new ShellCheckReq(shell, "foobar()")));
+          // genuine static type error on a known type is caught
+          typeErrorInvalid = isInvalid(request(new ShellCheckReq(shell, "int z = 'hello'")));
+          // read of an undeclared name not in the binding is flagged
+          undeclaredInvalid = isInvalid(request(new ShellCheckReq(shell, "zzz + 1")));
           done = true;
         }
       });

--- a/src/test/java/org/arl/fjage/test/BasicTests.java
+++ b/src/test/java/org/arl/fjage/test/BasicTests.java
@@ -11,6 +11,7 @@ for full license details.
 package org.arl.fjage.test;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.util.*;
 import java.util.logging.Logger;
@@ -345,6 +346,47 @@ public class BasicTests {
     assertTrue("Get file (offset 27, len 1, out of bounds) failed", agent.get4);
     assertTrue("Directory listing failed", agent.dir);
     assertTrue("Delete file failed", agent.del);
+  }
+
+  @Test
+  public void testShellCheck() throws IOException {
+    log.info("testShellCheck");
+    Platform platform = new RealTimePlatform();
+    Container container = new Container(platform);
+    container.add("shell", new ShellAgent(new GroovyScriptEngine()));
+    File markerFile = File.createTempFile("fjage-shell-check-marker", ".txt");
+    markerFile.delete();
+    File invalidScript = File.createTempFile("fjage-shell-check-invalid", ".groovy");
+    try (FileWriter writer = new FileWriter(invalidScript)) {
+      writer.write("def x =\n");
+    }
+    ShellCheckTestAgent agent = new ShellCheckTestAgent(markerFile, invalidScript);
+    container.add("test", agent);
+    platform.start();
+    while (!agent.done)
+      platform.delay(1000);
+    platform.shutdown();
+    assertTrue("Valid shell check failed", agent.valid);
+    assertTrue("Shell check executed code unexpectedly", agent.notExecuted);
+    assertTrue("Invalid inline shell check failed", agent.invalid);
+    assertTrue("Invalid file shell check failed", agent.invalidFile);
+    markerFile.delete();
+    invalidScript.delete();
+  }
+
+  @Test
+  public void testShellCheckRefuse() {
+    log.info("testShellCheckRefuse");
+    Platform platform = new RealTimePlatform();
+    Container container = new Container(platform);
+    container.add("shell", new ShellAgent((ScriptEngine)null));
+    ShellCheckRefuseTestAgent agent = new ShellCheckRefuseTestAgent();
+    container.add("test", agent);
+    platform.start();
+    while (!agent.done)
+      platform.delay(1000);
+    platform.shutdown();
+    assertTrue("Shell check refuse path failed", agent.refused);
   }
 
   @Test
@@ -1095,6 +1137,63 @@ public class BasicTests {
             File f = new File(DIRNAME+File.separator+FILENAME);
             if (!f.exists()) del = true;
           }
+          done = true;
+        }
+      });
+    }
+  }
+
+  private static class ShellCheckTestAgent extends Agent {
+    private final File markerFile;
+    private final File invalidScript;
+    public boolean valid = false, invalid = false, invalidFile = false, notExecuted = false, done = false;
+
+    ShellCheckTestAgent(File markerFile, File invalidScript) {
+      this.markerFile = markerFile;
+      this.invalidScript = invalidScript;
+    }
+
+    @Override
+    public void init() {
+      add(new OneShotBehavior() {
+        @Override
+        public void action() {
+          AgentID shell = new AgentID("shell");
+          String markerPath = markerFile.getAbsolutePath().replace("\\", "\\\\").replace("'", "\\'");
+          Message rsp = request(new ShellCheckReq(shell, "new File('"+markerPath+"').text = 'x'"));
+          if (rsp instanceof ShellCheckRsp) {
+            ShellCheckRsp checkRsp = (ShellCheckRsp)rsp;
+            valid = checkRsp.isValid() && checkRsp.getDiagnostics() == null;
+            notExecuted = !markerFile.exists();
+          }
+          rsp = request(new ShellCheckReq(shell, "def x =\n"));
+          if (rsp instanceof ShellCheckRsp) {
+            ShellCheckRsp checkRsp = (ShellCheckRsp)rsp;
+            invalid = !checkRsp.isValid() && checkRsp.getDiagnostics() != null && checkRsp.getDiagnostics().contains("\"errors\"");
+          }
+          ShellCheckReq fileReq = new ShellCheckReq(shell);
+          fileReq.setFilename(invalidScript.getAbsolutePath());
+          rsp = request(fileReq);
+          if (rsp instanceof ShellCheckRsp) {
+            ShellCheckRsp checkRsp = (ShellCheckRsp)rsp;
+            invalidFile = !checkRsp.isValid() && checkRsp.getDiagnostics() != null && checkRsp.getDiagnostics().contains("\"errors\"");
+          }
+          done = true;
+        }
+      });
+    }
+  }
+
+  private static class ShellCheckRefuseTestAgent extends Agent {
+    public boolean refused = false, done = false;
+
+    @Override
+    public void init() {
+      add(new OneShotBehavior() {
+        @Override
+        public void action() {
+          Message rsp = request(new ShellCheckReq(new AgentID("shell"), "println 'hello'"));
+          refused = rsp != null && rsp.getPerformative() == Performative.REFUSE;
           done = true;
         }
       });


### PR DESCRIPTION
Add a mechanism to statically parse/check scripts using the ScriptEngine.

We add a new API `ScriptEngine.parse` which takes in a script and returns `MultipleCompilationErrorsException`.

The `ShellAgent` then accepts the new `ShellCheckReq` and responds with a `ShellCheckRsp` that contains a JSON-ified version of `MultipleCompilationErrorsException`.