### PR TITLE
Add SerialConnector for serial port communication to fjagepy

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,8 @@
 
 ### 2.6.0
 
+* Add `SerialConnector` to the Python gateway: `Gateway(connector=SerialConnector('/dev/ttyUSB0', 115200))`, needing the optional `fjagepy[serial]` dependency
+* Breaking (fjagepy): connectors take explicit constructor arguments, and `Gateway(connector=...)` now takes a `Connector` instance instead of a class
 * Add `services()` to the Gateway API to list all services visible through a gateway
 * Split gateway default timeouts: 1 s for `request()`, 6 s for directory queries and 0 for `receive()`
 * Gateway spec: allow constructors to throw on first-connect failure, instead of only returning `null`

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,8 +2,6 @@
 
 ### 2.6.0
 
-* Add `SerialConnector` to the Python gateway: `Gateway(connector=SerialConnector('/dev/ttyUSB0', 115200))`, needing the optional `fjagepy[serial]` dependency
-* Breaking (fjagepy): connectors take explicit constructor arguments, and `Gateway(connector=...)` now takes a `Connector` instance instead of a class
 * Add `services()` to the Gateway API to list all services visible through a gateway
 * Split gateway default timeouts: 1 s for `request()`, 6 s for directory queries and 0 for `receive()`
 * Gateway spec: allow constructors to throw on first-connect failure, instead of only returning `null`

--- a/gateways/python/README.md
+++ b/gateways/python/README.md
@@ -62,6 +62,18 @@ shell << msg
 gw.close()
 ```
 
+### Serial Connection
+
+To connect to a fjåge container over a serial port, specify `devname` (and
+optionally `baud`, defaults to 9600) instead of a hostname and port. This needs
+the optional `pyserial` dependency (`pip install "fjagepy[serial]"`):
+
+```python
+from fjagepy import Gateway
+
+gw = Gateway(devname='/dev/ttyUSB0', baud=115200)
+```
+
 ### Request-Response Pattern
 
 ```python
@@ -141,6 +153,9 @@ Implement custom connectors by extending the `Connector` base class:
 from fjagepy import Connector
 
 class MyCustomConnector(Connector):
+    def __init__(self, **kwargs):
+        self.url = kwargs.get('url')
+
     def connect(self):
         # Implementation
         pass
@@ -153,9 +168,13 @@ class MyCustomConnector(Connector):
         # Implementation
         pass
 
-# Use custom connector
-gw = Gateway(connector=MyCustomConnector)
+# Use custom connector; extra keyword arguments are passed on to the connector
+gw = Gateway(connector=MyCustomConnector, url='ws://localhost:8080/ws')
 ```
+
+Connectors are constructed with `reconnect_delay` (5 or -1, depending on the
+Gateway's `reconnect` flag), plus `host`/`port` or `devname`/`baud`, and any
+extra keyword arguments given to `Gateway()`.
 
 ### Logging and Debugging
 

--- a/gateways/python/README.md
+++ b/gateways/python/README.md
@@ -64,14 +64,14 @@ gw.close()
 
 ### Serial Connection
 
-To connect to a fjåge container over a serial port, specify `devname` (and
-optionally `baud`, defaults to 9600) instead of a hostname and port. This needs
-the optional `pyserial` dependency (`pip install "fjagepy[serial]"`):
+To connect to a fjåge container over a serial port, pass a `SerialConnector`
+instead of a hostname and port. This needs the optional `pyserial` dependency
+(`pip install "fjagepy[serial]"`):
 
 ```python
-from fjagepy import Gateway
+from fjagepy import Gateway, SerialConnector
 
-gw = Gateway(devname='/dev/ttyUSB0', baud=115200)
+gw = Gateway(connector=SerialConnector('/dev/ttyUSB0', 115200))
 ```
 
 ### Request-Response Pattern
@@ -153,8 +153,8 @@ Implement custom connectors by extending the `Connector` base class:
 from fjagepy import Connector
 
 class MyCustomConnector(Connector):
-    def __init__(self, **kwargs):
-        self.url = kwargs.get('url')
+    def __init__(self, url: str):
+        self.url = url
 
     def connect(self):
         # Implementation
@@ -168,13 +168,16 @@ class MyCustomConnector(Connector):
         # Implementation
         pass
 
-# Use custom connector; extra keyword arguments are passed on to the connector
-gw = Gateway(connector=MyCustomConnector, url='ws://localhost:8080/ws')
+# Construct the connector yourself and hand it to the Gateway
+gw = Gateway(connector=MyCustomConnector('ws://localhost:8080/ws'))
 ```
 
-Connectors are constructed with `reconnect_delay` (5 or -1, depending on the
-Gateway's `reconnect` flag), plus `host`/`port` or `devname`/`baud`, and any
-extra keyword arguments given to `Gateway()`.
+A connector defines its own constructor arguments; the Gateway simply uses the
+instance it is given. `TCPConnector(hostname, port, reconnect_delay)` may also be
+constructed explicitly, which is the only way to set a custom `reconnect_delay`.
+
+> **Note:** up to fjagepy 2.2.0, `connector` took a Connector *class*
+> (`Gateway(connector=TCPConnector)`). It now takes an instance.
 
 ### Logging and Debugging
 

--- a/gateways/python/fjagepy/Gateway.py
+++ b/gateways/python/fjagepy/Gateway.py
@@ -44,43 +44,29 @@ class Gateway:
     NON_BLOCKING = 0
     BLOCKING = -1
 
-    def __init__(self, hostname: str = 'localhost', port: int = 1100, connector: Optional[Type[Connector]] = None, reconnect: bool = True, timeout: int = DEFAULT_REQUEST_TIMEOUT, directory_timeout: int = DEFAULT_DIRECTORY_TIMEOUT, devname: Optional[str] = None, baud: int = 9600, **connector_kwargs: Any) -> None:
+    def __init__(self, hostname: str = 'localhost', port: int = 1100, connector: Optional[Connector] = None, reconnect: bool = True, timeout: int = DEFAULT_REQUEST_TIMEOUT, directory_timeout: int = DEFAULT_DIRECTORY_TIMEOUT) -> None:
         """Creates a new Gateway instance.
 
-        Connects over TCP by default. If `devname` is specified, connects over a
-        serial port instead (requires the optional `pyserial` dependency).
+        Connects over TCP by default. To use any other transport, construct its
+        Connector and pass it as `connector`, e.g. `SerialConnector` for a serial
+        port; `hostname`, `port` and `reconnect` are then ignored.
 
         Args:
             hostname : hostname of the fjage container. Defaults to 'localhost'.
             port : port of the fjage container. Defaults to 1100.
-            connector : Connector class to use. Defaults to SerialConnector if devname is specified, TCPConnector otherwise.
+            connector : a Connector instance to use, instead of connecting over TCP.
             reconnect : whether to keep the connection alive. Defaults to True.
             timeout : default timeout in milliseconds for request(). Defaults to 1000.
             directory_timeout : default timeout in milliseconds for directory queries. Defaults to 6000.
-            devname : serial device name (e.g. '/dev/ttyUSB0') to connect over serial instead of TCP.
-            baud : serial baud rate, used only with devname. Defaults to 9600.
-            connector_kwargs : additional keyword arguments passed to the connector.
         """
-        if devname is not None:
-            if not isinstance(devname, str) or devname.strip() == "": 
-                raise ValueError("devname must be a non-empty string")
-            if not isinstance(baud, int) or baud <= 0:
-                raise ValueError("baud must be a positive integer")
-            opts: dict[str, Any] = {'devname': devname, 'baud': baud}
+        if connector is not None:
+            if not isinstance(connector, Connector):
+                raise ValueError("connector must be a Connector instance")
         else:
             if not isinstance(hostname, str) or not hostname:
                 raise ValueError("hostname must be a non-empty string")
             if not isinstance(port, int) or not (0 < port < 65536):
                 raise ValueError("port must be an integer 1-65535")
-            opts = {'host': hostname, 'port': port}
-        if connector is None:
-            if devname is not None:
-                from .SerialConnector import SerialConnector
-                connector = SerialConnector
-            else:
-                connector = TCPConnector
-        if not isinstance(connector, type) or not issubclass(connector, Connector):
-            raise ValueError("connector must be a subclass of Connector")
         if not isinstance(reconnect, bool):
             raise ValueError("reconnect must be a boolean")
         if not isinstance(timeout, int) or timeout <= 0:
@@ -95,9 +81,7 @@ class Gateway:
         self._timeout = timeout
         self._directory_timeout = directory_timeout
         self.aid = AgentID("gateway-" + str(uuid.uuid4()), owner=self)
-        opts['reconnect_delay'] = 5 if reconnect else -1
-        opts.update(connector_kwargs)
-        self.connector = connector(**opts)
+        self.connector = connector or TCPConnector(hostname, port, 5 if reconnect else -1)
         self.connector.set_receive_callback(self._msg_rx)
         try :
             self.connector.connect()

--- a/gateways/python/fjagepy/Gateway.py
+++ b/gateways/python/fjagepy/Gateway.py
@@ -44,22 +44,42 @@ class Gateway:
     NON_BLOCKING = 0
     BLOCKING = -1
 
-    def __init__(self, hostname: str = 'localhost', port: int = 1100, connector: Type[Connector] = TCPConnector, reconnect: bool = True, timeout: int = DEFAULT_REQUEST_TIMEOUT, directory_timeout: int = DEFAULT_DIRECTORY_TIMEOUT) -> None:
+    def __init__(self, hostname: str = 'localhost', port: int = 1100, connector: Optional[Type[Connector]] = None, reconnect: bool = True, timeout: int = DEFAULT_REQUEST_TIMEOUT, directory_timeout: int = DEFAULT_DIRECTORY_TIMEOUT, devname: Optional[str] = None, baud: int = 9600, **connector_kwargs: Any) -> None:
         """Creates a new Gateway instance.
+
+        Connects over TCP by default. If `devname` is specified, connects over a
+        serial port instead (requires the optional `pyserial` dependency).
 
         Args:
             hostname : hostname of the fjage container. Defaults to 'localhost'.
             port : port of the fjage container. Defaults to 1100.
-            connector : Connector class to use. Defaults to TCPConnector.
+            connector : Connector class to use. Defaults to SerialConnector if devname is specified, TCPConnector otherwise.
             reconnect : whether to keep the connection alive. Defaults to True.
             timeout : default timeout in milliseconds for request(). Defaults to 1000.
             directory_timeout : default timeout in milliseconds for directory queries. Defaults to 6000.
+            devname : serial device name (e.g. '/dev/ttyUSB0') to connect over serial instead of TCP.
+            baud : serial baud rate, used only with devname. Defaults to 9600.
+            connector_kwargs : additional keyword arguments passed to the connector.
         """
-        if not isinstance(hostname, str) or not hostname:
-            raise ValueError("hostname must be a non-empty string")
-        if not isinstance(port, int) or not (0 < port < 65536):
-            raise ValueError("port must be an integer 1-65535")
-        if not issubclass(connector, Connector):
+        if devname is not None:
+            if not isinstance(devname, str) or not devname:
+                raise ValueError("devname must be a non-empty string")
+            if not isinstance(baud, int) or baud <= 0:
+                raise ValueError("baud must be a positive integer")
+            opts: dict[str, Any] = {'devname': devname, 'baud': baud}
+        else:
+            if not isinstance(hostname, str) or not hostname:
+                raise ValueError("hostname must be a non-empty string")
+            if not isinstance(port, int) or not (0 < port < 65536):
+                raise ValueError("port must be an integer 1-65535")
+            opts = {'host': hostname, 'port': port}
+        if connector is None:
+            if devname is not None:
+                from .SerialConnector import SerialConnector
+                connector = SerialConnector
+            else:
+                connector = TCPConnector
+        if not isinstance(connector, type) or not issubclass(connector, Connector):
             raise ValueError("connector must be a subclass of Connector")
         if not isinstance(reconnect, bool):
             raise ValueError("reconnect must be a boolean")
@@ -75,12 +95,14 @@ class Gateway:
         self._timeout = timeout
         self._directory_timeout = directory_timeout
         self.aid = AgentID("gateway-" + str(uuid.uuid4()), owner=self)
-        self.connector = connector(host=hostname, port=port, reconnect_delay=5 if reconnect else -1)
+        opts['reconnect_delay'] = 5 if reconnect else -1
+        opts.update(connector_kwargs)
+        self.connector = connector(**opts)
         self.connector.set_receive_callback(self._msg_rx)
         try :
             self.connector.connect()
         except Exception as e:
-            logger.error(f"Failed to connect to {hostname}:{port}: {e}")
+            logger.error(f"Failed to connect to {self.connector.__details__()}: {e}")
             raise e
         self._update_watch()
 
@@ -427,10 +449,10 @@ class Gateway:
         self.close()
 
     def __details__(self):
-        return f"(host:{self.connector.__details__()} connected={self.is_connected()})"
+        return f"({self.connector.__details__()} connected={self.is_connected()})"
 
     def __str__(self) -> str:
-        return f"Gateway(self.__details__())"
+        return f"Gateway{self.__details__()}"
 
     def _repr_pretty_(self, p, cycle):
         p.text(str(self) if not cycle else '...')

--- a/gateways/python/fjagepy/Gateway.py
+++ b/gateways/python/fjagepy/Gateway.py
@@ -62,7 +62,7 @@ class Gateway:
             connector_kwargs : additional keyword arguments passed to the connector.
         """
         if devname is not None:
-            if not isinstance(devname, str) or not devname:
+            if not isinstance(devname, str) or devname.strip() == "": 
                 raise ValueError("devname must be a non-empty string")
             if not isinstance(baud, int) or baud <= 0:
                 raise ValueError("baud must be a positive integer")

--- a/gateways/python/fjagepy/SerialConnector.py
+++ b/gateways/python/fjagepy/SerialConnector.py
@@ -15,14 +15,14 @@ class SerialConnector(Connector):
     Requires the optional `pyserial` dependency (`pip install fjagepy[serial]`).
     """
 
-    def __init__(self, devname: str, baud: int = 9600, reconnect_delay: float = -2):
+    def __init__(self, devname: str, reconnect_delay: float, baud: int = 9600):
         self.devname = devname
         if not self.devname or not isinstance(self.devname, str) or self.devname.strip() == "":
             raise ValueError("devname must be a non-empty string")
         self.baud = baud
         if not isinstance(self.baud, int) or self.baud <= 0:
             raise ValueError("baud must be a positive integer")
-        self.reconnect_delay = kwargs.get("reconnect_delay", None)
+        self.reconnect_delay = reconnect_delay
         if not isinstance(self.reconnect_delay, (int, float)) or self.reconnect_delay < -1:
             raise ValueError("reconnect_delay must be a non-negative number or -1 for no reconnect")
 

--- a/gateways/python/fjagepy/SerialConnector.py
+++ b/gateways/python/fjagepy/SerialConnector.py
@@ -1,4 +1,3 @@
-import socket
 import logging
 import threading
 import time
@@ -10,23 +9,31 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
+class SerialConnector(Connector):
+    """Simple serial port connector using pyserial.
 
-class TCPConnector(Connector):
-    """Simple TCP connector using synchronous sockets."""
+    Requires the optional `pyserial` dependency (`pip install fjagepy[serial]`).
+    """
 
-    def __init__(self, **kwargs: Any ):
-        self.host = kwargs.get("host")
-        if not self.host or not isinstance(self.host, str) or self.host.strip() == "":
-            raise ValueError("host must be a non-empty string")
-        self.port:int = kwargs.get("port", 0)
-        if not isinstance(self.port, int) or not (0 < self.port < 65536):
-            raise ValueError("port must be an integer 1-65535")
-        self.reconnect_delay:int = kwargs.get("reconnect_delay", -2)
+    def __init__(self, **kwargs: Any):
+        self.devname = kwargs.get("devname")
+        if not self.devname or not isinstance(self.devname, str) or self.devname.strip() == "":
+            raise ValueError("devname must be a non-empty string")
+        self.baud: int = kwargs.get("baud", 9600)
+        if not isinstance(self.baud, int) or self.baud <= 0:
+            raise ValueError("baud must be a positive integer")
+        self.reconnect_delay = kwargs.get("reconnect_delay", -2)
         if not isinstance(self.reconnect_delay, (int, float)) or self.reconnect_delay < -1:
             raise ValueError("reconnect_delay must be a non-negative number or -1 for no reconnect")
 
-        # Socket and connection state
-        self._socket: Optional[socket.socket] = None
+        try:
+            import serial  # type: ignore[import-untyped]  # local import, so that pyserial stays an optional dependency
+        except ImportError as e:
+            raise ImportError("SerialConnector requires pyserial: pip install pyserial") from e
+        self._serial = serial
+
+        # Port and connection state
+        self._port: Optional[Any] = None
         self._connected = False
         self._callback: Optional[Callable[[List[str]], None]] = None
 
@@ -42,17 +49,16 @@ class TCPConnector(Connector):
         self._callback = callback
 
     def connect(self) -> None:
-        """Establish the connection."""
+        """Open the serial port."""
         with self._lock:
             if self._connected:
                 return
 
             try:
-                self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                self._socket.settimeout(10.0)  # 10 second connection timeout
-                self._socket.connect((self.host, self.port))
+                # serial_for_url() accepts device names as well as URLs (eg. loop://)
+                self._port = self._serial.serial_for_url(self.devname, baudrate=self.baud, timeout=0.1)
                 self._connected = True
-                logger.debug(f"Connected to {self.host}:{self.port}")
+                logger.debug(f"Connected to {self.devname}@{self.baud}")
 
                 # Start read thread if callback is set
                 if self._callback:
@@ -61,18 +67,18 @@ class TCPConnector(Connector):
                     self._read_thread.start()
 
             except Exception as e:
-                self._cleanup_socket()
-                raise ConnectionError(f"Failed to connect to {self.host}:{self.port}: {e}")
+                self._cleanup_port()
+                raise ConnectionError(f"Failed to connect to {self.devname}@{self.baud}: {e}")
 
     def disconnect(self) -> None:
-        """Close the connection."""
+        """Close the serial port."""
         with self._lock:
             if not self._connected:
                 return
 
             self._stop_event.set()
             self._connected = False
-            self._cleanup_socket()
+            self._cleanup_port()
 
             # Wait for read thread to finish
             if self._read_thread and self._read_thread.is_alive():
@@ -87,56 +93,48 @@ class TCPConnector(Connector):
     def send(self, msg: str) -> None:
         """Send a message."""
         with self._lock:
-            if not self._connected or not self._socket:
+            if not self._connected or not self._port:
                 raise ConnectionError("Not connected")
             try:
-                message = msg + "\n"
-                self._socket.sendall(message.encode())
+                self._port.write((msg + "\n").encode())
             except Exception as e:
                 self._connected = False
-                self._cleanup_socket()
+                self._cleanup_port()
                 raise ConnectionError(f"Failed to send message: {e}")
 
     def __details__(self):
-        return f"host:{self.host}:{self.port}"
+        return f"dev:{self.devname}@{self.baud}"
 
     def __repr__(self):
-        return f"TCPConnector(host={self.host}, port={self.port}, connected={self.is_connected()})"
+        return f"SerialConnector(devname={self.devname}, baud={self.baud}, connected={self.is_connected()})"
 
     # Internal methods
 
-    def _cleanup_socket(self) -> None:
-        """Clean up socket resources."""
-        if self._socket:
+    def _cleanup_port(self) -> None:
+        """Clean up serial port resources."""
+        if self._port:
             try:
-                self._socket.close()
+                self._port.close()
             except Exception:
                 pass
-            self._socket = None
+            self._port = None
 
     def _read_loop(self) -> None:
         """Background thread that reads data and calls the callback."""
         buffer = ""
 
         try:
-            if not self._socket:
-                return
-
-            # Set socket to non-blocking for periodic stop checks
-            self._socket.settimeout(0.1)
-
             while not self._stop_event.is_set() and self._connected:
+                port = self._port
+                if not port:
+                    break
                 try:
-                    data = self._socket.recv(4096)
+                    # read() blocks for at most the port timeout (0.1s), allowing periodic stop checks
+                    data = port.read(port.in_waiting or 1)
                     if not data:
-                        # Connection closed by peer
-                        with self._lock:
-                            self._connected = False
-                            self._cleanup_socket()
-                        logger.warning("Connection closed by peer")
-                        break
+                        continue
 
-                    buffer += data.decode()
+                    buffer += data.decode(errors="replace")
                     lines = buffer.split("\n")
                     buffer = lines.pop()  # Keep incomplete line
 
@@ -146,15 +144,12 @@ class TCPConnector(Connector):
                         except Exception as e:
                             logger.warning(f"Callback error: {e}")
 
-                except socket.timeout:
-                    # Normal timeout, continue loop
-                    continue
                 except Exception as e:
                     if self._connected:  # Only log if we expect to be connected
                         logger.warning(f"Read error: {e}")
                         with self._lock:
                             self._connected = False
-                            self._cleanup_socket()
+                            self._cleanup_port()
                     break
 
         except Exception as e:
@@ -165,7 +160,7 @@ class TCPConnector(Connector):
                 self._attempt_reconnect()
 
     def _attempt_reconnect(self) -> None:
-        """Attempt to reconnect with delay."""
+        """Attempt to reopen the port with delay."""
         while not self._stop_event.is_set() and self.reconnect_delay >= 0:
             try:
                 logger.debug(f"Attempting to reconnect in {self.reconnect_delay}s...")

--- a/gateways/python/fjagepy/SerialConnector.py
+++ b/gateways/python/fjagepy/SerialConnector.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import threading
 import time
 from typing import Any, Callable, List, Optional
@@ -22,6 +23,18 @@ class SerialConnector(Connector):
             baud : baud rate. Defaults to 9600.
             reconnect_delay : seconds to wait before reconnecting, or -1 to disable reconnection. Defaults to 5.
         """
+        if not isinstance(devname, str) or not devname.strip():
+            raise ValueError("devname must be a non-empty string")
+        if isinstance(baud, bool) or not isinstance(baud, int) or baud <= 0:
+            raise ValueError("baud must be a positive integer")
+        if (
+            isinstance(reconnect_delay, bool)
+            or not isinstance(reconnect_delay, (int, float))
+            or not math.isfinite(reconnect_delay)
+            or reconnect_delay < -1
+        ):
+            raise ValueError("reconnect_delay must be a finite non-negative number or -1")
+
         self.devname = devname
         self.baud = baud
         self.reconnect_delay = reconnect_delay

--- a/gateways/python/fjagepy/SerialConnector.py
+++ b/gateways/python/fjagepy/SerialConnector.py
@@ -15,14 +15,14 @@ class SerialConnector(Connector):
     Requires the optional `pyserial` dependency (`pip install fjagepy[serial]`).
     """
 
-    def __init__(self, **kwargs: Any):
-        self.devname = kwargs.get("devname")
+    def __init__(self, devname: str, baud: int = 9600, reconnect_delay: float = -2):
+        self.devname = devname
         if not self.devname or not isinstance(self.devname, str) or self.devname.strip() == "":
             raise ValueError("devname must be a non-empty string")
-        self.baud: int = kwargs.get("baud", 9600)
+        self.baud = baud
         if not isinstance(self.baud, int) or self.baud <= 0:
             raise ValueError("baud must be a positive integer")
-        self.reconnect_delay = kwargs.get("reconnect_delay", -2)
+        self.reconnect_delay = reconnect_delay
         if not isinstance(self.reconnect_delay, (int, float)) or self.reconnect_delay < -1:
             raise ValueError("reconnect_delay must be a non-negative number or -1 for no reconnect")
 
@@ -67,6 +67,7 @@ class SerialConnector(Connector):
                     self._read_thread.start()
 
             except Exception as e:
+                self._connected = False
                 self._cleanup_port()
                 raise ConnectionError(f"Failed to connect to {self.devname}@{self.baud}: {e}")
 
@@ -121,7 +122,7 @@ class SerialConnector(Connector):
 
     def _read_loop(self) -> None:
         """Background thread that reads data and calls the callback."""
-        buffer = ""
+        buffer: str = ""
 
         try:
             while not self._stop_event.is_set() and self._connected:
@@ -164,10 +165,8 @@ class SerialConnector(Connector):
         while not self._stop_event.is_set() and self.reconnect_delay >= 0:
             try:
                 logger.debug(f"Attempting to reconnect in {self.reconnect_delay}s...")
-                time.sleep(self.reconnect_delay)
-
-                if self._stop_event.is_set():
-                    break
+                if self._stop_event.wait(timeout=self.reconnect_delay):
+                    break 
 
                 self.connect()
                 return  # Successfully reconnected

--- a/gateways/python/fjagepy/SerialConnector.py
+++ b/gateways/python/fjagepy/SerialConnector.py
@@ -22,7 +22,7 @@ class SerialConnector(Connector):
         self.baud = baud
         if not isinstance(self.baud, int) or self.baud <= 0:
             raise ValueError("baud must be a positive integer")
-        self.reconnect_delay = reconnect_delay
+        self.reconnect_delay = kwargs.get("reconnect_delay", None)
         if not isinstance(self.reconnect_delay, (int, float)) or self.reconnect_delay < -1:
             raise ValueError("reconnect_delay must be a non-negative number or -1 for no reconnect")
 
@@ -166,7 +166,7 @@ class SerialConnector(Connector):
             try:
                 logger.debug(f"Attempting to reconnect in {self.reconnect_delay}s...")
                 if self._stop_event.wait(timeout=self.reconnect_delay):
-                    break 
+                    break
 
                 self.connect()
                 return  # Successfully reconnected

--- a/gateways/python/fjagepy/SerialConnector.py
+++ b/gateways/python/fjagepy/SerialConnector.py
@@ -15,16 +15,16 @@ class SerialConnector(Connector):
     Requires the optional `pyserial` dependency (`pip install fjagepy[serial]`).
     """
 
-    def __init__(self, devname: str, reconnect_delay: float, baud: int = 9600):
+    def __init__(self, devname: str, baud: int = 9600, reconnect_delay: float = 5) -> None:
+        """
+        Args:
+            devname : serial device name (e.g. '/dev/ttyUSB0'), or a pyserial URL (e.g. 'loop://').
+            baud : baud rate. Defaults to 9600.
+            reconnect_delay : seconds to wait before reconnecting, or -1 to disable reconnection. Defaults to 5.
+        """
         self.devname = devname
-        if not self.devname or not isinstance(self.devname, str) or self.devname.strip() == "":
-            raise ValueError("devname must be a non-empty string")
         self.baud = baud
-        if not isinstance(self.baud, int) or self.baud <= 0:
-            raise ValueError("baud must be a positive integer")
         self.reconnect_delay = reconnect_delay
-        if not isinstance(self.reconnect_delay, (int, float)) or self.reconnect_delay < -1:
-            raise ValueError("reconnect_delay must be a non-negative number or -1 for no reconnect")
 
         try:
             import serial  # type: ignore[import-untyped]  # local import, so that pyserial stays an optional dependency

--- a/gateways/python/fjagepy/TCPConnector.py
+++ b/gateways/python/fjagepy/TCPConnector.py
@@ -14,16 +14,16 @@ logger.addHandler(logging.NullHandler())
 class TCPConnector(Connector):
     """Simple TCP connector using synchronous sockets."""
 
-    def __init__(self, **kwargs: Any ):
-        self.host = kwargs.get("host")
-        if not self.host or not isinstance(self.host, str) or self.host.strip() == "":
-            raise ValueError("host must be a non-empty string")
-        self.port:int = kwargs.get("port", 0)
-        if not isinstance(self.port, int) or not (0 < self.port < 65536):
-            raise ValueError("port must be an integer 1-65535")
-        self.reconnect_delay:int = kwargs.get("reconnect_delay", -2)
-        if not isinstance(self.reconnect_delay, (int, float)) or self.reconnect_delay < -1:
-            raise ValueError("reconnect_delay must be a non-negative number or -1 for no reconnect")
+    def __init__(self, hostname: str = 'localhost', port: int = 1100, reconnect_delay: float = 5):
+        """
+        Args:
+            hostname : hostname or IP address of the fjåge container. Defaults to 'localhost'.
+            port : port of the fjåge container. Defaults to 1100.
+            reconnect_delay : seconds to wait before reconnecting, or -1 to disable reconnection. Defaults to 5.
+        """
+        self.hostname = hostname
+        self.port = port
+        self.reconnect_delay = reconnect_delay
 
         # Socket and connection state
         self._socket: Optional[socket.socket] = None
@@ -50,9 +50,9 @@ class TCPConnector(Connector):
             try:
                 self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self._socket.settimeout(10.0)  # 10 second connection timeout
-                self._socket.connect((self.host, self.port))
+                self._socket.connect((self.hostname, self.port))
                 self._connected = True
-                logger.debug(f"Connected to {self.host}:{self.port}")
+                logger.debug(f"Connected to {self.hostname}:{self.port}")
 
                 # Start read thread if callback is set
                 if self._callback:
@@ -62,7 +62,7 @@ class TCPConnector(Connector):
 
             except Exception as e:
                 self._cleanup_socket()
-                raise ConnectionError(f"Failed to connect to {self.host}:{self.port}: {e}")
+                raise ConnectionError(f"Failed to connect to {self.hostname}:{self.port}: {e}")
 
     def disconnect(self) -> None:
         """Close the connection."""
@@ -98,10 +98,10 @@ class TCPConnector(Connector):
                 raise ConnectionError(f"Failed to send message: {e}")
 
     def __details__(self):
-        return f"host:{self.host}:{self.port}"
+        return f"host:{self.hostname}:{self.port}"
 
     def __repr__(self):
-        return f"TCPConnector(host={self.host}, port={self.port}, connected={self.is_connected()})"
+        return f"TCPConnector(host={self.hostname}, port={self.port}, connected={self.is_connected()})"
 
     # Internal methods
 

--- a/gateways/python/fjagepy/TCPConnector.py
+++ b/gateways/python/fjagepy/TCPConnector.py
@@ -1,5 +1,6 @@
 import socket
 import logging
+import math
 import threading
 import time
 from typing import Any, Callable, List, Optional
@@ -21,6 +22,18 @@ class TCPConnector(Connector):
             port : port of the fjåge container. Defaults to 1100.
             reconnect_delay : seconds to wait before reconnecting, or -1 to disable reconnection. Defaults to 5.
         """
+        if not isinstance(hostname, str) or not hostname.strip():
+            raise ValueError("hostname must be a non-empty string")
+        if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
+            raise ValueError("port must be an integer between 1 and 65535")
+        if (
+            isinstance(reconnect_delay, bool)
+            or not isinstance(reconnect_delay, (int, float))
+            or not math.isfinite(reconnect_delay)
+            or reconnect_delay < -1
+        ):
+            raise ValueError("reconnect_delay must be a finite non-negative number or -1")
+
         self.hostname = hostname
         self.port = port
         self.reconnect_delay = reconnect_delay

--- a/gateways/python/fjagepy/__init__.py
+++ b/gateways/python/fjagepy/__init__.py
@@ -6,7 +6,9 @@ from .Performative import Performative
 from .AgentID import AgentID
 from .Services import Services
 
+from .Connector import Connector
 from .TCPConnector import TCPConnector
+from .SerialConnector import SerialConnector
 from .JSONMessage import JSONMessage
 
 
@@ -22,7 +24,9 @@ __all__ = [
     "Performative",
     "AgentID",
     "Services",
+    "Connector",
     "TCPConnector",
+    "SerialConnector",
     "JSONMessage",
     "ParameterReq",
     "ParameterRsp",

--- a/gateways/python/pyproject.toml
+++ b/gateways/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fjagepy"
-version = "2.2.0"
+version = "3.0.0"
 description = "fjage Gateway in Python"
 readme = "README.md"
 license = {text = "BSD-3-Clause"}

--- a/gateways/python/pyproject.toml
+++ b/gateways/python/pyproject.toml
@@ -23,7 +23,7 @@ testpaths = ["test"]
 addopts = "-ra -q"
 
 [project.optional-dependencies]
-dev = ["pytest==8.3.5", "numpy==2.0.2", "mypy==1.19.0"]
+dev = ["pytest==8.3.5", "numpy==2.0.2", "mypy==1.19.0", "pyserial>=3.5"]
 docs = ["sphinx==8.2.3", "sphinx-rtd-theme==3.0.2", "myst-parser==4.0.1"]
 
 [tool.mypy]

--- a/gateways/python/test/test_serialconnector.py
+++ b/gateways/python/test/test_serialconnector.py
@@ -1,0 +1,70 @@
+import time
+
+import pytest
+
+pytest.importorskip("serial")
+
+from fjagepy import SerialConnector
+
+
+@pytest.fixture
+def connector():
+    """SerialConnector on a pyserial loopback port, so writes come back as reads."""
+    conn = SerialConnector(devname='loop://', baud=9600, reconnect_delay=-1)
+    yield conn
+    conn.disconnect()
+
+
+def collect(conn):
+    """Attach a receive callback, returning the list it appends lines to."""
+    lines = []
+    conn.set_receive_callback(lines.extend)
+    return lines
+
+
+def wait_for(lines, n, timeout=2.0):
+    deadline = time.time() + timeout
+    while len(lines) < n and time.time() < deadline:
+        time.sleep(0.01)
+    return lines
+
+
+def test_serialconnector_validates_devname():
+    """SerialConnector should reject a missing or empty device name."""
+    with pytest.raises(ValueError):
+        SerialConnector(devname='')
+    with pytest.raises(ValueError):
+        SerialConnector(baud=9600)
+
+
+def test_serialconnector_send_receive(connector):
+    """A line sent on a loopback port should come back to the receive callback."""
+    lines = collect(connector)
+    connector.connect()
+    assert connector.is_connected()
+    connector.send('{"alive": true}')
+    assert wait_for(lines, 1) == ['{"alive": true}']
+
+
+def test_serialconnector_reassembles_split_lines(connector):
+    """Partial writes should be buffered until a complete line arrives."""
+    lines = collect(connector)
+    connector.connect()
+    connector._port.write(b'{"ali')
+    time.sleep(0.2)
+    assert lines == []
+    connector._port.write(b've": true}\n{"partial"')
+    assert wait_for(lines, 1) == ['{"alive": true}']
+    time.sleep(0.2)
+    assert len(lines) == 1  # incomplete line not delivered
+
+
+def test_serialconnector_disconnect(connector):
+    """Disconnect should close the port and stop the read thread."""
+    collect(connector)
+    connector.connect()
+    connector.disconnect()
+    assert not connector.is_connected()
+    assert not connector._read_thread.is_alive()
+    with pytest.raises(ConnectionError):
+        connector.send('nope')

--- a/gateways/python/test/test_serialconnector.py
+++ b/gateways/python/test/test_serialconnector.py
@@ -10,7 +10,7 @@ from fjagepy import SerialConnector
 @pytest.fixture
 def connector():
     """SerialConnector on a pyserial loopback port, so writes come back as reads."""
-    conn = SerialConnector(devname='loop://', baud=9600, reconnect_delay=-1)
+    conn = SerialConnector('loop://', reconnect_delay=-1)
     yield conn
     conn.disconnect()
 
@@ -29,12 +29,10 @@ def wait_for(lines, n, timeout=2.0):
     return lines
 
 
-def test_serialconnector_validates_devname():
-    """SerialConnector should reject a missing or empty device name."""
-    with pytest.raises(ValueError):
-        SerialConnector(devname='')
-    with pytest.raises(ValueError):
-        SerialConnector(baud=9600)
+def test_serialconnector_requires_devname():
+    """SerialConnector should require a device name."""
+    with pytest.raises(TypeError):
+        SerialConnector()   # type: ignore[call-arg]
 
 
 def test_serialconnector_send_receive(connector):

--- a/gateways/python/test/test_serialconnector.py
+++ b/gateways/python/test/test_serialconnector.py
@@ -35,6 +35,21 @@ def test_serialconnector_requires_devname():
         SerialConnector()   # type: ignore[call-arg]
 
 
+@pytest.mark.parametrize(
+    ("devname", "baud", "reconnect_delay"),
+    [
+        ("", 9600, 5),
+        ("loop://", 0, 5),
+        ("loop://", True, 5),
+        ("loop://", 9600, -2),
+        ("loop://", 9600, float("inf")),
+    ],
+)
+def test_serialconnector_validates_constructor_arguments(devname, baud, reconnect_delay):
+    with pytest.raises(ValueError):
+        SerialConnector(devname, baud, reconnect_delay)
+
+
 def test_serialconnector_send_receive(connector):
     """A line sent on a loopback port should come back to the receive callback."""
     lines = collect(connector)

--- a/gateways/python/test/test_tcpconnector.py
+++ b/gateways/python/test/test_tcpconnector.py
@@ -1,0 +1,19 @@
+import pytest
+
+from fjagepy import TCPConnector
+
+
+@pytest.mark.parametrize(
+    ("hostname", "port", "reconnect_delay"),
+    [
+        ("", 1100, 5),
+        ("localhost", 0, 5),
+        ("localhost", 65536, 5),
+        ("localhost", True, 5),
+        ("localhost", 1100, -2),
+        ("localhost", 1100, float("nan")),
+    ],
+)
+def test_tcpconnector_validates_constructor_arguments(hostname, port, reconnect_delay):
+    with pytest.raises(ValueError):
+        TCPConnector(hostname, port, reconnect_delay)


### PR DESCRIPTION
This pull request adds support for connecting to fjåge containers over serial ports in the Python gateway, alongside the existing TCP support. It introduces a new `SerialConnector` class that allows connecting to fjåge Master container from a fjage.py Gateway.

This PR also changes the API for `Gateway()` where it now takes in an optional `Connector` instance (instead of type in the past). This simplifies the logic inside the Gateway. But since this breaks the API, this PR also uprevs the MAJOR version for fjage.py.