### PR TITLE
Avoid NPE when master connection is lost

### DIFF
--- a/src/main/java/org/arl/fjage/remote/SlaveContainer.java
+++ b/src/main/java/org/arl/fjage/remote/SlaveContainer.java
@@ -119,10 +119,11 @@ public class SlaveContainer extends RemoteContainer {
    * @return true if authenticated, false otherwise.
    */
   public boolean authenticate(String creds) {
-    if (master == null) return false;
+    ConnectionHandler localMaster = master;
+    if (localMaster == null) return false;
     JsonMessage rq = JsonMessage.createActionRequest(Action.AUTH);
     rq.creds = creds;
-    JsonMessage rsp = master.request(rq, REQUEST_TIMEOUT);
+    JsonMessage rsp = localMaster.request(rq, REQUEST_TIMEOUT);
     return rsp != null && rsp.auth != null && rsp.auth;
   }
 
@@ -132,7 +133,8 @@ public class SlaveContainer extends RemoteContainer {
    * INTERNAL USE ONLY.
    */
   public void checkAuthFailure(String id) {
-    if (master.checkAuthFailure(id)) throw new AuthFailureException();
+    ConnectionHandler localMaster = master;    // master may be nulled on connection loss
+    if (localMaster != null && localMaster.checkAuthFailure(id)) throw new AuthFailureException();
   }
 
   /////////////// Container interface methods to override
@@ -140,10 +142,11 @@ public class SlaveContainer extends RemoteContainer {
   @Override
   protected boolean isDuplicate(AgentID aid) {
     if (super.isDuplicate(aid)) return true;
-    if (master == null) return false;
+    ConnectionHandler localMaster = master;
+    if (localMaster == null) return false;
     JsonMessage rq = JsonMessage.createActionRequest(Action.CONTAINS_AGENT);
     rq.agentID = aid;
-    JsonMessage rsp = master.request(rq, DIRECTORY_QUERY_TIMEOUT);
+    JsonMessage rsp = localMaster.request(rq, DIRECTORY_QUERY_TIMEOUT);
     return rsp != null && rsp.answer != null && rsp.answer;
   }
 
@@ -248,7 +251,9 @@ public class SlaveContainer extends RemoteContainer {
   @Override
   protected void initComplete() {
     log.fine("Waiting for master...");
-    while (!quit && (master == null || !master.isConnectionAlive())) {
+    while (!quit) {
+      ConnectionHandler localMaster = master;
+      if (localMaster != null && localMaster.isConnectionAlive()) break;
       try {
         Thread.sleep(100);
       } catch(InterruptedException e) {
@@ -261,7 +266,8 @@ public class SlaveContainer extends RemoteContainer {
   @Override
   public void shutdown() {
     quit = true;
-    if (master != null) master.close();
+    ConnectionHandler localMaster = master;
+    if (localMaster != null) localMaster.close();
     Thread t = connectionManager;
     if (t != null) {
       t.interrupt();

--- a/src/test/java/org/arl/fjage/remote/SlaveContainerConnectionLossTest.java
+++ b/src/test/java/org/arl/fjage/remote/SlaveContainerConnectionLossTest.java
@@ -1,0 +1,111 @@
+/******************************************************************************
+
+Copyright (c) 2026, Mandar Chitre
+
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
+
+******************************************************************************/
+
+package org.arl.fjage.remote;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.arl.fjage.*;
+import org.arl.fjage.loadtest.ThrottlingTcpProxy;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Regression tests for issue #438: connection loss to the master container must
+ * surface as null responses through the Gateway API, never as a raw NPE from
+ * SlaveContainer dereferencing a nulled master connection.
+ */
+public class SlaveContainerConnectionLossTest {
+
+  private static final long TIMEOUT = 10000;
+
+  private Platform platform;
+  private MasterContainer master;
+  private ThrottlingTcpProxy proxy;
+  private Gateway gw;
+
+  @After
+  public void shutdown() {
+    if (gw != null) gw.close();
+    if (proxy != null) proxy.shutdownProxy();
+    if (master != null) master.shutdown();
+    if (platform != null) platform.shutdown();
+    gw = null;
+    proxy = null;
+    master = null;
+    platform = null;
+  }
+
+  @Test(timeout = 30000)
+  public void requestAfterConnectionLossReturnsNull() throws Exception {
+    setup();
+    gw = new Gateway("localhost", proxy.getPort());
+    SlaveContainer slave = (SlaveContainer)gw.getContainer();
+    dropMaster();
+    slave.checkAuthFailure("some-message-id");   // must not throw NPE
+    Message rsp = gw.request(new Message(new AgentID("echo"), Performative.REQUEST), 1000);
+    assertNull("Request after connection loss should return null", rsp);
+  }
+
+  @Test(timeout = 30000)
+  public void requestDuringConnectionLossReturnsNull() throws Exception {
+    setup();
+    gw = new Gateway("localhost", proxy.getPort());
+    final AtomicReference<Message> rsp = new AtomicReference<>();
+    final AtomicReference<Throwable> thrown = new AtomicReference<>();
+    Thread t = new Thread(() -> {
+      try {
+        rsp.set(gw.request(new Message(new AgentID("echo"), Performative.REQUEST), 3000));
+      } catch (Throwable ex) {
+        thrown.set(ex);
+      }
+    });
+    t.start();
+    Thread.sleep(300);
+    dropMaster();
+    t.join(TIMEOUT);
+    assertFalse("Request did not complete after connection loss", t.isAlive());
+    assertNull("Request threw " + thrown.get() + " on connection loss", thrown.get());
+    assertNull("Request during connection loss should return null", rsp.get());
+  }
+
+  //////// helpers
+
+  private void setup() throws Exception {
+    platform = new RealTimePlatform();
+    master = new MasterContainer(platform);
+    proxy = new ThrottlingTcpProxy("localhost", master.getPort());
+    proxy.start();
+    platform.start();
+  }
+
+  /**
+   * Abruptly drops the TCP connection between the slave and the master, and refuses
+   * reconnection attempts, simulating a network failure (not a graceful shutdown).
+   */
+  private void dropMaster() throws Exception {
+    SlaveContainer slave = (SlaveContainer)gw.getContainer();
+    proxy.setRefuse(true);
+    proxy.dropConnections();
+    assertTrue("Slave did not notice connection loss",
+      waitUntil(() -> slave.getState().contains("connecting")));
+  }
+
+  private boolean waitUntil(java.util.concurrent.Callable<Boolean> condition) throws Exception {
+    long deadline = System.currentTimeMillis() + TIMEOUT;
+    while (System.currentTimeMillis() < deadline) {
+      if (Boolean.TRUE.equals(condition.call())) return true;
+      Thread.sleep(50);
+    }
+    return false;
+  }
+
+}


### PR DESCRIPTION
## Summary

Fixes #438.

`SlaveContainer.checkAuthFailure()` dereferenced the volatile `master` field without a null guard. `master` is nulled by the connection-manager thread when the TCP connection to the master container is lost, so a raw `NullPointerException` escaped through the public `Gateway.receive()`/`request()` API exactly when a connection dropped mid-call:

```
INFO: Connection to localhost:1102 lost
java.lang.NullPointerException
  at org.arl.fjage.remote.SlaveContainer.checkAuthFailure
  at org.arl.fjage.remote.Gateway.receive
  at org.arl.fjage.remote.Gateway.request
```

This NPE (when thrown on the gateway agent thread) is also one of the triggers for the untimed-wait hang in #437, which will be fixed separately.

## Changes

- `checkAuthFailure()`: snapshot `master` into a local and treat null as "no auth failure" — connection loss then surfaces as a null response through the existing reconnect/close handling, which is what callers already expect.
- Audit of the rest of `SlaveContainer` for the same pattern: `authenticate()`, `isDuplicate()`, `initComplete()` and `shutdown()` all had check-then-reread races on the volatile field; they now snapshot into a local, matching the pattern already used in `send()` and the directory-query methods.

## Tests

New `SlaveContainerConnectionLossTest` uses `ThrottlingTcpProxy` to drop the slave→master TCP connection abruptly (RST, no SIGN_OFF — a graceful `MasterContainer.shutdown()` sends a SHUTDOWN action and doesn't reproduce the bug):

- `requestAfterConnectionLossReturnsNull` — drop the connection, then `checkAuthFailure()` must not throw and `request()` must return null.
- `requestDuringConnectionLossReturnsNull` — drop the connection while a `request()` is waiting; it must return null, never NPE.

Both tests fail with the exact field-observed NPE before the fix and pass after. Also ran `org.arl.fjage.remote.*`, `BasicTests` and `FirewallTests` — all pass.