### PR TITLE
Honor receive timeout from non-gateway threads

### DIFF
--- a/src/main/java/org/arl/fjage/remote/Gateway.java
+++ b/src/main/java/org/arl/fjage/remote/Gateway.java
@@ -37,7 +37,8 @@ public class Gateway implements Messenger, Closeable {
 
   /**
    * Extra time beyond the requested receive timeout that a non-gateway thread may wait
-   * for the gateway agent to complete the receive, before giving up.
+   * for the gateway agent to complete the receive, to avoid indefinite waits if the
+   * scheduled behavior never runs (including for NON_BLOCKING receives).
    */
   private static final long RECEIVE_TIMEOUT_SLACK = 1000;
 

--- a/src/main/java/org/arl/fjage/remote/Gateway.java
+++ b/src/main/java/org/arl/fjage/remote/Gateway.java
@@ -35,6 +35,12 @@ public class Gateway implements Messenger, Closeable {
    */
   public static final long BLOCKING = -1;
 
+  /**
+   * Extra time beyond the requested receive timeout that a non-gateway thread may wait
+   * for the gateway agent to complete the receive, before giving up.
+   */
+  private static final long RECEIVE_TIMEOUT_SLACK = 1000;
+
   //////////// Private attributes
 
   protected Container container = null;
@@ -116,29 +122,55 @@ public class Gateway implements Messenger, Closeable {
 
   protected void init() {
     agent = new Agent() {
-      private Message rsp;
       private final Object sync = new Object();
       @Override
-      public Message receive(final MessageFilter filter, long timeout) {
+      public Message receive(final MessageFilter filter, final long timeout) {
         if (Thread.currentThread().getId() == tid) return super.receive(filter, timeout);
+        final Message[] rsp = new Message[1];
+        final boolean[] done = new boolean[1];
         synchronized (sync) {
-          rsp = null;
           try {
             add(new OneShotBehavior() {
               @Override
               public void action() {
-                rsp = receive(filter, timeout);
-                synchronized (sync) {
-                  sync.notify();
+                try {
+                  rsp[0] = receive(filter, timeout);
+                } finally {
+                  // notify the waiter on all exit paths, including an exception out of
+                  // receive(), so that it never sleeps past the requested timeout (issue #437)
+                  synchronized (sync) {
+                    done[0] = true;
+                    sync.notifyAll();
+                  }
                 }
               }
             });
-            sync.wait();
+            // the notify above is the normal wake-up, and stop() notifies if the agent dies;
+            // the deadline is a backstop for when the behavior cannot complete in time
+            long deadline = timeout < 0 ? -1 : currentTimeMillis() + timeout + RECEIVE_TIMEOUT_SLACK;
+            while (!done[0] && getState() != AgentState.FINISHING && getState() != AgentState.FINISHED) {
+              if (deadline < 0) sync.wait();
+              else {
+                long remaining = deadline - currentTimeMillis();
+                if (remaining <= 0) break;
+                sync.wait(remaining);
+              }
+            }
           } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
-            thread.interrupt();
+            Thread t = thread;
+            if (t != null) t.interrupt();
           }
-          return rsp;
+          return rsp[0];
+        }
+      }
+      @Override
+      public void stop() {
+        super.stop();
+        // wake any non-gateway thread waiting in receive(), as the behavior that would
+        // have notified it may never run once the agent is stopped
+        synchronized (sync) {
+          sync.notifyAll();
         }
       }
     };

--- a/src/main/java/org/arl/fjage/remote/Gateway.java
+++ b/src/main/java/org/arl/fjage/remote/Gateway.java
@@ -147,7 +147,7 @@ public class Gateway implements Messenger, Closeable {
             });
             // the notify above is the normal wake-up, and stop() notifies if the agent dies;
             // the deadline is a backstop for when the behavior cannot complete in time
-            long deadline = timeout < 0 ? -1 : currentTimeMillis() + timeout + RECEIVE_TIMEOUT_SLACK;
+            long deadline = timeout == BLOCKING ? -1 : currentTimeMillis() + timeout + RECEIVE_TIMEOUT_SLACK;
             while (!done[0] && getState() != AgentState.FINISHING && getState() != AgentState.FINISHED) {
               if (deadline < 0) sync.wait();
               else {

--- a/src/test/java/org/arl/fjage/remote/GatewayTimeoutTest.java
+++ b/src/test/java/org/arl/fjage/remote/GatewayTimeoutTest.java
@@ -1,0 +1,130 @@
+/******************************************************************************
+
+Copyright (c) 2026, Mandar Chitre
+
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
+
+******************************************************************************/
+
+package org.arl.fjage.remote;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.arl.fjage.*;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Regression tests for issue #437: Gateway.receive() called from a non-gateway
+ * thread must honor its timeout even if the internal receive behavior throws or
+ * never runs, and must return promptly when the gateway is closed mid-receive.
+ */
+public class GatewayTimeoutTest {
+
+  private static final long TIMEOUT = 10000;
+
+  private Platform platform;
+  private MasterContainer master;
+  private Gateway gw;
+
+  @After
+  public void shutdown() {
+    if (gw != null) gw.close();
+    if (master != null) master.shutdown();
+    if (platform != null) platform.shutdown();
+    gw = null;
+    master = null;
+    platform = null;
+  }
+
+  @Test(timeout = 30000)
+  public void receiveWithThrowingFilterHonorsTimeout() throws Exception {
+    setup();
+    gw = new Gateway("localhost", master.getPort());
+    addSender(gw.getAgentID());
+    long start = System.currentTimeMillis();
+    Message rsp = gw.receive(m -> { throw new RuntimeException("bad filter"); }, 1000);
+    long elapsed = System.currentTimeMillis() - start;
+    assertNull("Receive with throwing filter should return null", rsp);
+    assertTrue("Receive took " + elapsed + " ms, expected ~1000 ms", elapsed < 5000);
+  }
+
+  @Test(timeout = 30000)
+  public void receiveWhenAgentNeverRunsHonorsTimeout() {
+    platform = new RealTimePlatform();
+    Container container = new Container(platform);
+    gw = new Gateway(container);
+    // platform never started, so the gateway agent never runs the receive behavior
+    long start = System.currentTimeMillis();
+    Message rsp = gw.receive(500);
+    long elapsed = System.currentTimeMillis() - start;
+    assertNull("Receive should return null when gateway agent never runs", rsp);
+    assertTrue("Receive took " + elapsed + " ms, expected ~1500 ms", elapsed < 5000);
+  }
+
+  @Test(timeout = 30000)
+  public void closeDuringBlockingReceiveReturnsPromptly() throws Exception {
+    setup();
+    gw = new Gateway("localhost", master.getPort());
+    Thread t = new Thread(() -> gw.receive(Gateway.BLOCKING));
+    t.start();
+    Thread.sleep(300);
+    gw.close();
+    gw = null;
+    t.join(TIMEOUT);
+    assertFalse("Blocking receive did not return after gateway was closed", t.isAlive());
+  }
+
+  @Test(timeout = 30000)
+  public void interruptCancelsBlockingReceive() throws Exception {
+    setup();
+    gw = new Gateway("localhost", master.getPort());
+    final AtomicReference<Message> rsp = new AtomicReference<>();
+    Thread t = new Thread(() -> rsp.set(gw.receive(60000)));
+    t.start();
+    Thread.sleep(300);
+    t.interrupt();
+    t.join(TIMEOUT);
+    assertFalse("Interrupted receive did not return", t.isAlive());
+    assertNull(rsp.get());
+  }
+
+  @Test(timeout = 30000)
+  public void receiveDeliversMessageBeforeTimeout() throws Exception {
+    setup();
+    gw = new Gateway("localhost", master.getPort());
+    addSender(gw.getAgentID());
+    long start = System.currentTimeMillis();
+    Message rsp = gw.receive(5000);
+    long elapsed = System.currentTimeMillis() - start;
+    assertNotNull("Expected a message before the timeout", rsp);
+    assertTrue("Receive took " + elapsed + " ms, expected well under 5000 ms", elapsed < 3000);
+  }
+
+  //////// helpers
+
+  private void setup() {
+    platform = new RealTimePlatform();
+    master = new MasterContainer(platform);
+    platform.start();
+  }
+
+  /** Adds an agent on the master that periodically sends a message to the given agent. */
+  private void addSender(final AgentID aid) {
+    master.add("sender", new Agent() {
+      @Override
+      public void init() {
+        add(new TickerBehavior(100) {
+          @Override
+          public void onTick() {
+            send(new Message(aid, Performative.INFORM));
+          }
+        });
+      }
+    });
+  }
+
+}

--- a/src/test/java/org/arl/fjage/remote/GatewayTimeoutTest.java
+++ b/src/test/java/org/arl/fjage/remote/GatewayTimeoutTest.java
@@ -101,7 +101,7 @@ public class GatewayTimeoutTest {
     Message rsp = gw.receive(5000);
     long elapsed = System.currentTimeMillis() - start;
     assertNotNull("Expected a message before the timeout", rsp);
-    assertTrue("Receive took " + elapsed + " ms, expected well under 5000 ms", elapsed < 3000);
+    assertTrue("Receive took " + elapsed + " ms, expected well under 5000 ms", elapsed < 5000);
   }
 
   //////// helpers


### PR DESCRIPTION
## Summary

Fixes #437.

`Gateway.receive()` called from a non-gateway thread parked in an **untimed** `sync.wait()`; the only wake-up was a `sync.notify()` at the end of the `OneShotBehavior` that performs the real timed receive on the gateway agent thread. The requested timeout only existed *inside* the behavior, so if the behavior terminated without reaching the notify, the caller slept forever — violating the timeout contract of `receive()` and everything built on it (`request()`, UnetSocket blocking send/receive). Two ways that happened:

1. the behavior body threw — any unchecked exception out of the inner receive kills the behavior before the notify (the behavior loop catches and logs it; the waiter is never told). The NPE of #438 (fixed in #439) was a live trigger;
2. the behavior never ran — agent killed / container shutting down while the behavior sat queued.

Field signature of the hang: caller thread in state WAITING (not TIMED_WAITING) under `Gateway$1.receive`, gateway agent thread idle in `Agent.block()`; only interrupting the waiter (what `UnetSocket.cancel()` happens to do) unblocked it.

## Changes

Three cooperating pieces, each covering a distinct failure mode:

- **Notify on all exit paths** — the behavior's notify runs in a `finally`, so an exception out of the inner receive surfaces as a null response (which callers already treat as "timed out / nothing received") instead of a permanent hang.
- **Notify on agent death** — the proxy agent's `stop()` wakes any waiter. `Container.kill()` and container shutdown both go through `stop()` whether or not the agent thread ever ran, so the behavior-never-runs case is handled by an event rather than polling — including for BLOCKING receives, which have no deadline to derive.
- **Deadline backstop for timed receives** — the wait is bounded by the requested timeout plus 1 s slack (platform time, so simulation-compatible), covering an agent that is alive but unable to run the behavior in time.

The result and completion flag are per-call captured locals rather than fields shared across calls, so a stale behavior from a timed-out call cannot corrupt a later call's response. Interrupt-based cancellation is unchanged (with a null-guard on the agent thread reference, which could NPE if the agent had not started).

## Tests

New `GatewayTimeoutTest`:

- `receiveWithThrowingFilterHonorsTimeout` — a filter whose `matches()` throws: must return null in ~1 s, not hang *(fails pre-fix: 30 s test timeout, thread parked at the untimed wait)*
- `receiveWhenAgentNeverRunsHonorsTimeout` — gateway agent never runs its behaviors: `receive(500)` must still return *(fails pre-fix, same signature)*
- `closeDuringBlockingReceiveReturnsPromptly` — `gw.close()` while a BLOCKING receive is in flight
- `interruptCancelsBlockingReceive` — the `UnetSocket.cancel()` escape hatch keeps working
- `receiveDeliversMessageBeforeTimeout` — sanity: a real message still arrives promptly (guards against the backstop firing early)

Also ran `org.arl.fjage.remote.*`, `BasicTests`, `FirewallTests` and `org.arl.fjage.loadtest.*` — all pass.

Independent of #439 (branched from master); the two interact only in that #438's NPE was one trigger for this hang.