### PR TITLE
Exception handling and hygiene improvements

### DIFF
--- a/src/main/java/org/arl/fjage/Container.java
+++ b/src/main/java/org/arl/fjage/Container.java
@@ -57,7 +57,7 @@ public class Container {
   protected Method doClone;
   protected boolean autoclone = false;
   protected final Set<AgentID> idle = new HashSet<>();
-  protected final Set<MessageListener> listeners = new HashSet<>();
+  protected final Set<MessageListener> listeners = new CopyOnWriteArraySet<>();
 
   //////////// Interface methods
 
@@ -320,15 +320,15 @@ public class Container {
   /**
    * Adds a listener to the container. A listener is able to snoop on all
    * messages passing through the container, and optionally able to ask the
-   * container to drop a message.
+   * container to drop a message. A listener that throws an exception has the
+   * exception logged and ignored, so that a misbehaving listener cannot
+   * disrupt message delivery.
    *
    * @param listener listener.
    * @return true if successfully added, false otherwise.
    */
   public boolean addListener(MessageListener listener) {
-    synchronized (listeners) {
-      return listeners.add(listener);
-    }
+    return listeners.add(listener);
   }
 
   /**
@@ -338,9 +338,7 @@ public class Container {
    * @return true if successfully removed, false otherwise.
    */
   public boolean removeListener(MessageListener listener) {
-    synchronized (listeners) {
-      return listeners.remove(listener);
-    }
+    return listeners.remove(listener);
   }
 
   /**
@@ -366,9 +364,12 @@ public class Container {
   public boolean send(Message m, boolean relay) {
     if (relay) log.warning("Container does not support relaying");
     if (m.getSentAt() == null) m.setSentAt(platform.currentTimeMillis());
-    synchronized (listeners) {
-      for (MessageListener listener: listeners)
+    for (MessageListener listener: listeners) {
+      try {
         if (listener.onReceive(m)) return true;
+      } catch (Throwable ex) {
+        log.log(Level.WARNING, "MessageListener: "+ex.toString(), ex);
+      }
     }
     AgentID aid = m.getRecipient();
     if (aid == null) return false;

--- a/src/main/java/org/arl/fjage/Container.java
+++ b/src/main/java/org/arl/fjage/Container.java
@@ -367,8 +367,8 @@ public class Container {
     for (MessageListener listener: listeners) {
       try {
         if (listener.onReceive(m)) return true;
-      } catch (Throwable ex) {
-        log.log(Level.WARNING, "MessageListener: "+ex.toString(), ex);
+      } catch (RuntimeException ex) {
+        log.log(Level.WARNING, "MessageListener: "+ ex, ex);
       }
     }
     AgentID aid = m.getRecipient();

--- a/src/main/java/org/arl/fjage/connectors/WebServer.java
+++ b/src/main/java/org/arl/fjage/connectors/WebServer.java
@@ -214,6 +214,7 @@ public class WebServer {
     }
   }
 
+
   /**
    * Stops the web server. Once this method is called, the server cannot be restarted.
    */
@@ -444,11 +445,25 @@ public class WebServer {
    * @return true if a handler is already registered, false otherwise.
    */
   public boolean hasHandler(String context) {
-    // find any handler in contexts.getHandlers() that has getContextPath() == context
-    return Arrays.stream(contexts.getHandlers())
+    // find any handler in handlers() that has getContextPath() == context
+    return Arrays.stream(handlers())
         .filter(h -> h instanceof ContextHandler)
         .map(h -> (ContextHandler) h)
         .anyMatch(h -> h.getContextPath().equals(context));
+  }
+
+  /**
+   * Gets the context handlers currently registered on the server. Jetty returns a null
+   * handler array (rather than an empty one) when no handlers are registered, so this
+   * method normalizes that to an empty array. It also returns an empty array if the
+   * server has been stopped.
+   *
+   * @return context handlers, empty array if none.
+   */
+  private Handler[] handlers() {
+    if (contexts == null) return new Handler[0];
+    Handler[] h = contexts.getHandlers();
+    return h == null ? new Handler[0] : h;
   }
 
   /**
@@ -478,11 +493,9 @@ public class WebServer {
     if (errorHandler == null) throw new IllegalArgumentException("Error handler cannot be null");
     this.defaultErrorHandler = errorHandler;
     this.defaultErrorHandler.setServer(server);
-    if (contexts != null) {
-      for (Handler h : contexts.getHandlers()) {
-        if (h instanceof ContextHandler) {
-          ((ContextHandler) h).setErrorHandler(errorHandler);
-        }
+    for (Handler h : handlers()) {
+      if (h instanceof ContextHandler) {
+        ((ContextHandler) h).setErrorHandler(errorHandler);
       }
     }
   }
@@ -502,12 +515,10 @@ public class WebServer {
     if (errorHandler == null) throw new IllegalArgumentException("Error handler cannot be null");
     errorHandler.setServer(server);
     boolean updated = false;
-    if (contexts != null) {
-      for (Handler h : contexts.getHandlers()) {
-        if (h instanceof ContextHandler && ((ContextHandler) h).getContextPath().equals(context)) {
-          ((ContextHandler) h).setErrorHandler(errorHandler);
-          updated = true;
-        }
+    for (Handler h : handlers()) {
+      if (h instanceof ContextHandler && ((ContextHandler) h).getContextPath().equals(context)) {
+        ((ContextHandler) h).setErrorHandler(errorHandler);
+        updated = true;
       }
     }
     return updated;

--- a/src/main/java/org/arl/fjage/connectors/WebServer.java
+++ b/src/main/java/org/arl/fjage/connectors/WebServer.java
@@ -31,6 +31,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
 import java.io.*;
+import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -210,10 +211,26 @@ public class WebServer {
       log.info("Started web server on port "+port);
       started = true;
     } catch (Exception ex) {
-      log.log(Level.WARNING, "Unable to start web server on port "+port, ex);
+      // a web server that fails to start is not fatal, but the caller gets back a server
+      // that quietly serves nothing, so name the most common cause explicitly
+      if (isPortInUse(ex)) log.log(Level.WARNING, "Unable to start web server: port "+port+" is already in use", ex);
+      else log.log(Level.WARNING, "Unable to start web server on port "+port, ex);
     }
   }
 
+  /**
+   * Checks if an exception was caused by a port already being in use.
+   *
+   * @param ex exception to check.
+   * @return true if caused by a bind failure, false otherwise.
+   */
+  private static boolean isPortInUse(Throwable ex) {
+    while (ex != null) {
+      if (ex instanceof BindException) return true;
+      ex = ex.getCause();
+    }
+    return false;
+  }
 
   /**
    * Stops the web server. Once this method is called, the server cannot be restarted.

--- a/src/main/java/org/arl/fjage/connectors/WebServer.java
+++ b/src/main/java/org/arl/fjage/connectors/WebServer.java
@@ -433,6 +433,9 @@ public class WebServer {
     if (!context.startsWith("/")) throw new IllegalArgumentException("Context must start with '/'");
     if (handler == null) throw new IllegalArgumentException("Handler cannot be null");
     ContextHandler c = new ContextHandler(context);
+    // serve the bare context path directly, rather than redirecting it to the path with a
+    // trailing slash; web socket clients cannot follow a redirect on an upgrade request
+    c.setAllowNullPathInfo(true);
     c.setHandler(handler);
     if (add(c)) return c;
     return null;

--- a/src/main/java/org/arl/fjage/remote/EnumTypeAdapter.java
+++ b/src/main/java/org/arl/fjage/remote/EnumTypeAdapter.java
@@ -85,7 +85,15 @@ public class EnumTypeAdapter extends TypeAdapter<Object> {
     if (pos < 0) return new NamedParameter(s);
     String value = s.substring(pos+1);
     Class<? extends Enum> cls = enumClass(s.substring(0,pos));
-    if (cls != null) return Enum.valueOf(cls, value);
+    if (cls != null) {
+      try {
+        return Enum.valueOf(cls, value);
+      } catch (IllegalArgumentException ex) {
+        // the constant is unknown, perhaps because it was removed in a newer version;
+        // fall back to a named parameter, so that the rest of the message survives
+        log.fine("No enum constant "+s+", treating as named parameter");
+      }
+    }
     return new NamedParameter(s);
   }
 

--- a/src/test/java/org/arl/fjage/connectors/WebServerTest.java
+++ b/src/test/java/org/arl/fjage/connectors/WebServerTest.java
@@ -17,8 +17,15 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Request;
@@ -119,6 +126,34 @@ public class WebServerTest {
     svr.start();
     assertEquals(200, statusOf(svr, "/ws"));
     assertEquals(200, statusOf(svr, "/ws/"));
+  }
+
+  //////////// a server that cannot bind serves nothing, so say why
+
+  @Test
+  public void portAlreadyInUseIsReported() throws IOException {
+    try (ServerSocket blocker = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
+      svr = WebServer.getInstance(blocker.getLocalPort());
+      Logger logger = Logger.getLogger(WebServer.class.getName());
+      final List<LogRecord> records = new ArrayList<>();
+      Handler handler = new Handler() {
+        @Override public void publish(LogRecord r) { records.add(r); }
+        @Override public void flush() { }
+        @Override public void close() { }
+      };
+      logger.addHandler(handler);
+      try {
+        svr.start();
+      } finally {
+        logger.removeHandler(handler);
+      }
+      assertFalse("server should not report itself as started", svr.started);
+      boolean reported = false;
+      for (LogRecord r: records) {
+        if (r.getLevel() == Level.WARNING && r.getMessage().contains("port "+blocker.getLocalPort()+" is already in use")) reported = true;
+      }
+      assertTrue("expected a warning naming the busy port, got: "+records, reported);
+    }
   }
 
   @Test

--- a/src/test/java/org/arl/fjage/connectors/WebServerTest.java
+++ b/src/test/java/org/arl/fjage/connectors/WebServerTest.java
@@ -1,0 +1,97 @@
+/******************************************************************************
+
+Copyright (c) 2026, Mandar Chitre
+
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
+
+******************************************************************************/
+
+package org.arl.fjage.connectors;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.junit.After;
+import org.junit.Test;
+
+public class WebServerTest {
+
+  private WebServer svr = null;
+
+  @After
+  public void teardown() {
+    if (svr != null) {
+      svr.stop();
+      svr = null;
+    }
+  }
+
+  private static int freePort() throws IOException {
+    try (ServerSocket s = new ServerSocket(0)) {
+      return s.getLocalPort();
+    }
+  }
+
+  private WebServer newServer() throws IOException {
+    svr = WebServer.getInstance(freePort());
+    return svr;
+  }
+
+  private static AbstractHandler okHandler() {
+    return new AbstractHandler() {
+      @Override
+      public void handle(String target, Request baseRequest, HttpServletRequest request,
+                         HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.getWriter().print("ok");
+        baseRequest.setHandled(true);
+      }
+    };
+  }
+
+  //////////// Jetty returns a null handler array when no handlers are registered
+
+  @Test
+  public void hasHandlerOnEmptyServerReturnsFalse() throws IOException {
+    WebServer svr = newServer();
+    assertFalse(svr.hasHandler("/nosuch"));
+    assertFalse(svr.hasStatic("/nosuch"));
+  }
+
+  @Test
+  public void hasHandlerAfterRemovingLastHandlerReturnsFalse() throws IOException {
+    WebServer svr = newServer();
+    ContextHandler h = svr.addHandler("/ws", okHandler());
+    assertNotNull(h);
+    assertTrue(svr.hasHandler("/ws"));
+    assertTrue(svr.removeHandler(h));
+    assertFalse(svr.hasHandler("/ws"));
+  }
+
+  @Test
+  public void setErrorHandlerOnEmptyServerDoesNotThrow() throws IOException {
+    WebServer svr = newServer();
+    svr.setErrorHandler(new ErrorHandler());
+    assertFalse(svr.setErrorHandler("/nosuch", new ErrorHandler()));
+  }
+
+  @Test
+  public void setErrorHandlerAppliesToRegisteredContext() throws IOException {
+    WebServer svr = newServer();
+    assertNotNull(svr.addHandler("/ws", okHandler()));
+    assertTrue(svr.setErrorHandler("/ws", new ErrorHandler()));
+    assertFalse(svr.setErrorHandler("/other", new ErrorHandler()));
+  }
+
+}

--- a/src/test/java/org/arl/fjage/connectors/WebServerTest.java
+++ b/src/test/java/org/arl/fjage/connectors/WebServerTest.java
@@ -10,12 +10,15 @@ for full license details.
 
 package org.arl.fjage.connectors;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.ServerSocket;
+import java.net.URL;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Request;
@@ -60,6 +63,19 @@ public class WebServerTest {
     };
   }
 
+  private static int statusOf(WebServer svr, String path) throws IOException {
+    URL url = new URL("http://127.0.0.1:"+svr.getPort()+path);
+    HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+    conn.setInstanceFollowRedirects(false);
+    conn.setConnectTimeout(5000);
+    conn.setReadTimeout(5000);
+    try {
+      return conn.getResponseCode();
+    } finally {
+      conn.disconnect();
+    }
+  }
+
   //////////// Jetty returns a null handler array when no handlers are registered
 
   @Test
@@ -92,6 +108,26 @@ public class WebServerTest {
     assertNotNull(svr.addHandler("/ws", okHandler()));
     assertTrue(svr.setErrorHandler("/ws", new ErrorHandler()));
     assertFalse(svr.setErrorHandler("/other", new ErrorHandler()));
+  }
+
+  //////////// web socket clients cannot follow a redirect on an upgrade request
+
+  @Test
+  public void handlerContextIsServedOnBarePath() throws IOException {
+    WebServer svr = newServer();
+    assertNotNull(svr.addHandler("/ws", okHandler()));
+    svr.start();
+    assertEquals(200, statusOf(svr, "/ws"));
+    assertEquals(200, statusOf(svr, "/ws/"));
+  }
+
+  @Test
+  public void staticContextStillRedirectsBarePath() throws IOException {
+    WebServer svr = newServer();
+    // any resource directory on the test classpath will do
+    assertFalse(svr.addStatic("/static", "org/arl/fjage/shell").isEmpty());
+    svr.start();
+    assertEquals(302, statusOf(svr, "/static"));
   }
 
 }

--- a/src/test/java/org/arl/fjage/remote/EnumTypeAdapterTest.java
+++ b/src/test/java/org/arl/fjage/remote/EnumTypeAdapterTest.java
@@ -1,0 +1,136 @@
+/******************************************************************************
+
+Copyright (c) 2026, Mandar Chitre
+
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
+
+******************************************************************************/
+
+package org.arl.fjage.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.arl.fjage.Agent;
+import org.arl.fjage.Container;
+import org.arl.fjage.Message;
+import org.arl.fjage.OneShotBehavior;
+import org.arl.fjage.Platform;
+import org.arl.fjage.RealTimePlatform;
+import org.arl.fjage.param.NamedParameter;
+import org.arl.fjage.param.Parameter;
+import org.arl.fjage.param.ParameterMessageBehavior;
+import org.arl.fjage.param.ParameterReq;
+import org.arl.fjage.param.ParameterRsp;
+import org.junit.Test;
+
+/**
+ * Tests that a parameter enum constant that is unknown to this version does not
+ * abort deserialization of the whole message (issue #441).
+ */
+public class EnumTypeAdapterTest {
+
+  public enum TestParam implements Parameter {
+    alpha, beta
+  }
+
+  private static final String BETA = TestParam.class.getName().replace('$','.')+".beta";
+  private static final String GAMMA = TestParam.class.getName().replace('$','.')+".gamma";
+
+  /**
+   * Serializes a request for alpha and beta, then renames beta to gamma, to simulate a
+   * peer that was built against a version in which the parameter still existed.
+   */
+  private static String requestWithUnknownParam() {
+    ParameterReq req = new ParameterReq();
+    req.get(TestParam.alpha);
+    req.get(TestParam.beta);
+    JsonMessage jm = new JsonMessage();
+    jm.action = Action.SEND;
+    jm.message = req;
+    String json = jm.toJson();
+    assertTrue(json.contains(BETA));
+    return json.replace(BETA, GAMMA);
+  }
+
+  @Test
+  public void knownEnumConstantRoundTrips() {
+    ParameterReq req = new ParameterReq();
+    req.get(TestParam.alpha);
+    JsonMessage jm = new JsonMessage();
+    jm.action = Action.SEND;
+    jm.message = req;
+    JsonMessage rx = JsonMessage.fromJson(jm.toJson());
+    assertNotNull(rx.message);
+    List<ParameterReq.Entry> requests = ((ParameterReq)rx.message).requests();
+    assertEquals(1, requests.size());
+    assertEquals(TestParam.alpha, requests.get(0).param);
+  }
+
+  @Test
+  public void unknownEnumConstantDoesNotAbortDeserialization() {
+    JsonMessage rx = JsonMessage.fromJson(requestWithUnknownParam());
+    assertNotNull(rx.message);
+    assertTrue(rx.message instanceof ParameterReq);
+    List<ParameterReq.Entry> requests = ((ParameterReq)rx.message).requests();
+    assertEquals(2, requests.size());
+    assertEquals(TestParam.alpha, requests.get(0).param);
+    // the unknown constant degrades to a named parameter, keeping its qualified name so
+    // that it cannot be mistaken for an unrelated parameter of the same short name
+    assertTrue(requests.get(1).param instanceof NamedParameter);
+    assertEquals(GAMMA, requests.get(1).param.toString());
+  }
+
+  @Test
+  public void unknownEnumConstantStillYieldsParameterResponse() {
+    Platform platform = new RealTimePlatform();
+    Container container = new Container(platform);
+    ParamAgent server = new ParamAgent();
+    ParamClient client = new ParamClient((ParameterReq)JsonMessage.fromJson(requestWithUnknownParam()).message);
+    container.add("S", server);
+    container.add("C", client);
+    platform.start();
+    platform.delay(2000);
+    platform.shutdown();
+    ParameterRsp rsp = client.rsp;
+    assertNotNull("no response to a request naming an unknown parameter", rsp);
+    assertEquals(42, rsp.get(TestParam.alpha));
+    assertTrue(rsp.parameters().contains(TestParam.alpha));
+    assertFalse(rsp.parameters().contains(new NamedParameter(GAMMA)));
+  }
+
+  // must be public, so that the parameter behavior can reflect on its public fields
+  public static class ParamAgent extends Agent {
+    public int alpha = 42;
+    public int beta = 7;
+    @Override
+    public void init() {
+      add(new ParameterMessageBehavior(TestParam.class));
+    }
+  }
+
+  private static class ParamClient extends Agent {
+    private final ParameterReq req;
+    public volatile ParameterRsp rsp = null;
+    ParamClient(ParameterReq req) {
+      this.req = req;
+    }
+    @Override
+    public void init() {
+      add(new OneShotBehavior() {
+        @Override
+        public void action() {
+          req.setRecipient(agent.agent("S"));
+          Message m = agent.request(req, 1000);
+          if (m instanceof ParameterRsp) rsp = (ParameterRsp)m;
+        }
+      });
+    }
+  }
+
+}

--- a/src/test/java/org/arl/fjage/test/BasicTests.java
+++ b/src/test/java/org/arl/fjage/test/BasicTests.java
@@ -403,6 +403,28 @@ public class BasicTests {
   }
 
   @Test
+  public void testListener3() {
+    log.info("testListener3");
+    Platform platform = new RealTimePlatform();
+    Container container = new Container(platform);
+    ServerAgent server = new ServerAgent();
+    ClientAgent2 client = new ClientAgent2();
+    container.add("S", server);
+    container.add("C", client);
+    MyMessageListener listener = new MyMessageListener();
+    listener.fail = true;
+    assertTrue(container.addListener(listener));
+    platform.start();
+    platform.delay(1000);
+    platform.shutdown();
+    // a listener that throws must not disrupt delivery, nor break the sending agent
+    assertTrue(listener.n > 0);
+    assertEquals(5, client.nuisance);
+    assertEquals(listener.n, client.nuisance);
+    assertEquals(client.nuisance, server.nuisance);
+  }
+
+  @Test
   public void testTunnel() {
     log.info("testTunnel");
     Platform platform = new RealTimePlatform();
@@ -958,10 +980,12 @@ public class BasicTests {
     public List<Message> msgs = Collections.synchronizedList(new ArrayList<Message>());
     public int n = 0;
     public boolean eat = false;
+    public boolean fail = false;
     @Override
     public boolean onReceive(Message msg) {
       msgs.add(msg);
       n++;
+      if (fail) throw new RuntimeException("deliberate listener failure");
       return eat;
     }
   }


### PR DESCRIPTION
Five fixes with a common flavor: an exception in a peripheral path causes bad behavior in an unrelated core path. One fix per commit, each with a regression test.

### `Container` — listener exceptions break message delivery

- **Problem:** `send()` invoked `MessageListener.onReceive()` with no guard, so a throwing listener lost the message and the exception surfaced inside the *sending* agent's `send()` call, making it look like a bug in whichever agent happened to be sending.
- **Fix:** Catch and log per listener. The listener set also becomes a `CopyOnWriteArraySet`, removing a lock-ordering hazard: listeners were called while holding the `listeners` monitor, with the container monitor acquired only afterwards, so a listener calling a synchronized container method inverted the lock order.
- **Outcome:** A broken listener is now a logged warning rather than a broken container.

### `EnumTypeAdapter` — unknown enum constant kills the whole message (#441)

- **Problem:** `Enum.valueOf()` throws when a parameter enum constant is unknown to this version, aborting deserialization of the entire `JsonMessage`. The request was never delivered, so the sender got no response at all.
- **Fix:** An unknown constant degrades to a `NamedParameter`, exactly as an unloadable enum class already did. `ParameterMessageBehavior` finds no match and drops that entry, so the response carries every valid parameter and omits the unknown one, matching how mis-named `NamedParameter`s already behave.
- **Caveat:** The fully qualified name is retained, so a removed constant cannot be mistaken for an unrelated parameter with the same short name.

### `WebServer` — NPE on a server with no handlers

- **Problem:** Jetty's `getHandlers()` returns null rather than an empty array when nothing is registered, so `hasHandler()`, `hasStatic()` and both `setErrorHandler()` overloads threw `NullPointerException` on an empty server. Reachable whenever a component registers contexts and later removes them.
- **Fix:** Route the three iterating call sites through a helper that normalizes a null collection and a null handler array to an empty array. The `setErrorHandler()` overloads already guarded the former but not the latter.

### `WebServer` — web socket upgrades on bare context paths

- **Problem:** `ContextHandler` defaults `allowNullPathInfo` to false, so a bare context path gets a 302 to the trailing-slash form. Browsers do not follow redirects on a web socket upgrade, so a client connecting to `/shell/ws` rather than `/shell/ws/` silently fails to connect. Our clients all compensate, but the requirement was undocumented.
- **Fix:** Serve the bare path directly for handlers added via `addHandler()`, matching what `addUpload()` already does.
- **Note:** Deliberately not applied to `addStatic()`, where the redirect is wanted.

### `WebServer` — report when the port is already in use

- **Problem:** A failed `start()` was logged vaguely, leaving callers with a server that quietly serves nothing while every dependent component fails later in unrelated ways. The usual cause, another process holding the port, had to be inferred from a stack trace.
- **Fix:** Name bind failures explicitly, so the log says which port is taken. Startup remains non-fatal, so this changes diagnostics only.
