### PR TITLE
Render nested shell doc sections as sections, not bullets

### DIFF
--- a/src/main/java/org/arl/fjage/shell/Documentation.java
+++ b/src/main/java/org/arl/fjage/shell/Documentation.java
@@ -121,38 +121,50 @@ public class Documentation {
     int level = s.indexOf(' ');
     if (level <= 0) return;
     int endlevel = level;
-    if (s.startsWith("# ")) sb.append(s);
-    else sb.append(s.replaceAll(header, ""));
+    sb.append(s);
     sb.append('\n');
-    int skip = 0;
+    boolean skip = false;
     for (int i = pos+1; i < doc.size(); i++) {
       s = doc.get(i);
-      Matcher m = section.matcher(s);
-      if (m.matches()) {
-        m = heading.matcher(s);
+      if (section.matcher(s).matches()) {
         level = s.indexOf(' ');
         if (level <= endlevel) break;
-        boolean nl = false;
-        if (skip == 0 || level <= skip) {
-          if (skip > 0) nl = true;
-          skip = 0;
-          s = s.replaceAll(header, "");
-        }
-        if (m.matches()) {
-          skip = level;
+        // a "name - description" heading with no sub-headings of its own is an
+        // item, and is shown as a bullet with its body elided; anything else is
+        // a section heading, and is shown along with its body
+        boolean item = heading.matcher(s).matches() && !hasSubsections(i, level);
+        if (item) {
           sb.append("* ");
+          sb.append(s.replaceAll(header, ""));
+        } else {
+          if (skip) sb.append('\n');
           sb.append(s);
-          sb.append('\n');
-        } else if (nl) {
-          sb.append('\n');
         }
+        sb.append('\n');
+        skip = item;
+        continue;
       }
-      if (skip == 0) {
+      if (!skip) {
         sb.append(s);
         sb.append('\n');
       }
     }
     sb.append('\n');
+  }
+
+  /**
+   * Check if a heading has sub-headings nested under it.
+   *
+   * @param pos position of the heading.
+   * @param level level of the heading.
+   */
+  protected boolean hasSubsections(int pos, int level) {
+    for (int i = pos+1; i < doc.size(); i++) {
+      String s = doc.get(i);
+      if (!section.matcher(s).matches()) continue;
+      return s.indexOf(' ') > level;
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
## Problem

`Documentation.extract()` decided whether a heading was a bullet item purely from its shape — any heading matching the `heading` regex (`name - description`) became a bullet with its body elided, regardless of nesting level. Two symptoms follow.

A doc string that nests sections under a topic, e.g. UnetStack's `phy` agent which concatenates a per-modulation section per supported modulation:

```
# @@ - acoustic physical layer

## Parameters:

### @@[].detector - baseband detector number
...

## ofdm - OFDM modulation parameters

Orthogonal Frequency Division Multiplexing (OFDM) is ...

### @@[].nc - number of carriers (power of 2)
### @@[].np - cyclic prefix length
...
```

rendered as:

```
Parameters:

* phy[].detector - baseband detector number
...
* ofdm - OFDM modulation parameters          <- section collapsed into the bullet list
* ### phy[].nc - number of carriers (power of 2)   <- literal hashes leaked
* phy[].np - cyclic prefix length
```

1. `## ofdm - ...` matched `heading`, so it became a bullet in the same flat list as the parameters above it, and its prose body was elided.
2. Hashes were stripped only under `skip == 0 || level <= skip`, so the *first* `###` heading nested under such a bullet failed that test and rendered with its literal `### ` prefix. The second one onwards satisfied `level <= skip` and rendered normally, which is why only every first item was affected.

## Fix

A heading is an **item** — rendered `* name - desc` with its body elided — only if it matches `name - description` **and** has no sub-headings of its own. Anything else is a **section heading**, rendered with its body.

Hash stripping now applies to items only; section headings keep their markdown hashes at whatever level they sit. That also removes the special case which kept `# ` on level-1 topics but stripped everything deeper, so the rendering is uniform.

Result:

```
# phy - acoustic physical layer

## Parameters:

* phy[].detector - baseband detector number
...

## ofdm - OFDM modulation parameters

Orthogonal Frequency Division Multiplexing (OFDM) is a modulation technique
that is widely used in many wireless communication systems including
underwater acoustic communication...

* phy[].nc - number of carriers (power of 2)
* phy[].np - cyclic prefix length
...

## fhbfsk - FHBFSK modulation parameters
...
```

Leaf `name - description` headings still render as bullets at any level, so index-style docs are structurally unchanged — `ShellDoc`'s `## help - ...`, `## ps - ...` under `# shell - ...` remain a bullet index with bodies elided, reachable individually via `help help`.

## Testing

Rendered every reachable help topic from `ShellDoc` plus all 31 `__doc__` strings in the UnetStack tree (31 agents/shell extensions across unet-framework, unet-basic, unet-simulator, unet-licensed) through both the stock 2.6.0 renderer and this one — 820 topics.

- **2 topics change structurally**: `help phy` reached by name and by full title, i.e. the bug above.
- **816 change only by heading lines regaining their hashes** (`Parameters:` -> `## Parameters:` etc). Verified mechanically: stripping `^#+ +` from both renderings makes them byte-identical.
- **2 unchanged.**

Also verified end to end in a running UnetStack simulator with the built jar: `help phy`, `help ofdm`, `help plvl`, `help pclr` all render as expected.

`./gradlew test`: 98 tests, 3 pre-existing environmental failures unrelated to this change (`fjagecTest`, `fjagepyTest`, `fjagejsTest` — missing `python` binary and C/node toolchains locally).

## Note for reviewers

Since section headings now keep their hashes at their own level, a level-3 topic extracted on its own opens with three hashes:

```
> help plvl
### plvl - get/set TX power level for all PHY channel types
```

That is uniform but reads a little oddly with no surrounding document to be level 3 of. Capping the start line at `## ` for anything deeper than level 1 would be a two-line change if preferred.
