### PR TITLE
Make fjagepy support Python 3.9

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,8 +8,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: [3.12]
-        node-version: [22.x]
+        python-version: [3.9]
+        node-version: [24.x]
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,15 +12,15 @@ jobs:
         node-version: [24.x]
         os: [ubuntu-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Setup JDK 1.8
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: 8
         cache: gradle
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -36,6 +36,6 @@ jobs:
         cache: npm
         cache-dependency-path: gateways/js/package-lock.json
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v6
     - name: Test with Gradle
       run: ./gradlew -i test

--- a/gateways/python/fjagepy/Gateway.py
+++ b/gateways/python/fjagepy/Gateway.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import uuid
 import queue
 import logging

--- a/gateways/python/fjagepy/Gateway.py
+++ b/gateways/python/fjagepy/Gateway.py
@@ -1,4 +1,4 @@
-
+from __future__ import annotations
 import uuid
 import queue
 import logging

--- a/gateways/python/fjagepy/JSONMessage.py
+++ b/gateways/python/fjagepy/JSONMessage.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import json
 import base64
 import struct

--- a/gateways/python/fjagepy/JSONMessage.py
+++ b/gateways/python/fjagepy/JSONMessage.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import json
 import base64
 import struct

--- a/gateways/python/fjagepy/Message.py
+++ b/gateways/python/fjagepy/Message.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 import logging
 import keyword

--- a/gateways/python/fjagepy/Message.py
+++ b/gateways/python/fjagepy/Message.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 import logging
 import keyword

--- a/gateways/python/pyproject.toml
+++ b/gateways/python/pyproject.toml
@@ -23,7 +23,7 @@ testpaths = ["test"]
 addopts = "-ra -q"
 
 [project.optional-dependencies]
-dev = ["pytest==8.3.5", "numpy==2.3.0", "mypy==1.19.0"]
+dev = ["pytest==8.3.5", "numpy==2.0.2", "mypy==1.19.0"]
 docs = ["sphinx==8.2.3", "sphinx-rtd-theme==3.0.2", "myst-parser==4.0.1"]
 
 [tool.mypy]


### PR DESCRIPTION
We had lost Python 3.9 support because of 

> TypeError: unsupported operand type(s) for |. 

This fixes that.