### PR TITLE
Add `DeleteFileReq` to the shell agent

### DIFF
--- a/gateways/Gateways.md
+++ b/gateways/Gateways.md
@@ -239,11 +239,12 @@ The `clazz` field should be set based on the type of the base64 array is being e
 
 ## Pre-defined Messages
 
-A fjåge Gateway may export pre-defined Message Types for the Messages defined by fjåge. These are :
+A fjåge Gateway may export pre-defined Message Types for the Messages defined by fjåge. These are:
 
 - `org.arl.fjage.shell.ShellExecReq`
 - `org.arl.fjage.shell.GetFileReq`
 - `org.arl.fjage.shell.PutFileReq`
+- `org.arl.fjage.shell.DeleteFileReq`
 - `org.arl.fjage.param.ParameterReq`
 - `org.arl.fjage.shell.GetFileRsp`
 - `org.arl.fjage.param.ParameterRsp`

--- a/src/main/java/org/arl/fjage/shell/DeleteFileReq.java
+++ b/src/main/java/org/arl/fjage/shell/DeleteFileReq.java
@@ -1,0 +1,80 @@
+/******************************************************************************
+
+Copyright (c) 2026, Mandar Chitre
+
+This file is part of fjage which is released under Simplified BSD License.
+See file LICENSE.txt or go to http://www.opensource.org/licenses/BSD-3-Clause
+for full license details.
+
+******************************************************************************/
+
+package org.arl.fjage.shell;
+
+import org.arl.fjage.AgentID;
+import org.arl.fjage.Message;
+import org.arl.fjage.Performative;
+
+/**
+ * Request to delete a file, or a directory (if the file name ends with a path separator).
+ */
+public class DeleteFileReq extends Message {
+
+  private static final long serialVersionUID = 1L;
+
+  private String filename = null;
+
+  /**
+   * Create an empty request for file deletion.
+   */
+  public DeleteFileReq() {
+    super(Performative.REQUEST);
+  }
+
+  /**
+   * Create an empty request for file deletion.
+   *
+   * @param to shell agent id.
+   */
+  public DeleteFileReq(AgentID to) {
+    super(to, Performative.REQUEST);
+  }
+
+  /**
+   * Create a request to delete a file.
+   *
+   * @param filename name of the file to delete.
+   */
+  public DeleteFileReq(String filename) {
+    super(Performative.REQUEST);
+    this.filename = filename;
+  }
+
+  /**
+   * Create a request to delete a file.
+   *
+   * @param to shell agent id.
+   * @param filename name of the file to delete.
+   */
+  public DeleteFileReq(AgentID to, String filename) {
+    super(to, Performative.REQUEST);
+    this.filename = filename;
+  }
+
+  /**
+   * Get the name of the file.
+   *
+   * @return name of the file.
+   */
+  public String getFilename() {
+    return filename;
+  }
+
+  /**
+   * Set the name of the file.
+   *
+   * @param filename name of the file.
+   */
+  public void setFilename(String filename) {
+    this.filename = filename;
+  }
+}

--- a/src/main/java/org/arl/fjage/shell/ShellAgent.java
+++ b/src/main/java/org/arl/fjage/shell/ShellAgent.java
@@ -20,6 +20,7 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
+import java.util.stream.Stream;
 
 /**
  * Shell agent runs in a container and allows execution of shell commands and scripts.
@@ -252,6 +253,7 @@ public class ShellAgent extends Agent {
         if (msg instanceof ShellExecReq) handleExecReq((ShellExecReq)msg);
         else if (msg instanceof GetFileReq) handleGetFileReq((GetFileReq)msg);
         else if (msg instanceof PutFileReq) handlePutFileReq((PutFileReq)msg);
+        else if (msg instanceof DeleteFileReq) handleDeleteFileReq((DeleteFileReq)msg);
         else if (msg.getPerformative() == Performative.REQUEST) send(new Message(msg, Performative.NOT_UNDERSTOOD));
         else {
           log.fine(msg.getSender()+" > "+msg.toString());
@@ -646,51 +648,31 @@ public class ShellAgent extends Agent {
     Closeable os = null;
     long ofs = req.getOffset();
     try {
-      boolean fileIsDir = filename.endsWith("/") || filename.endsWith(File.separator);
-      if (fileIsDir) {
-        if (ofs == 0) {
-          if (contents == null) {
-            Path pathToBeDeleted = Paths.get(filename);
-
-            Files.walk(pathToBeDeleted)
-                    .sorted(Comparator.reverseOrder())
-                    .map(Path::toFile)
-                    .forEach(File::delete);
-
-            rsp = new Message(req, Performative.AGREE);
-          } else {
-            if (!f.exists()) rsp = new Message(req, f.mkdir() ? Performative.AGREE : Performative.FAILURE);
-          }
-        }
-      } else {
-        if (contents == null && ofs == 0) {
-          if (isCache.containsKey(filename)){
-            isCache.get(filename).is.close();
-            isCache.remove(filename);
-          }
-          if (f.delete()) rsp = new Message(req, Performative.AGREE);
-        } else if (contents == null) {
+      if (ofs == 0 && contents == null) { // Delete
+        if (deletePath(filename)) rsp = new Message(req, Performative.AGREE);
+      } else if (filename.endsWith("/") || filename.endsWith(File.separator)) {
+        // Create directory
+        if (ofs == 0 && !f.exists()) rsp = new Message(req, f.mkdir() ? Performative.AGREE : Performative.FAILURE);
+      } else if (contents == null) { // Truncate file
           os = new RandomAccessFile(f, "rw");
           ((RandomAccessFile) os).setLength(ofs);
           rsp = new Message(req, Performative.AGREE);
-        } else {
-          if (ofs == f.length()) {
-            // Append if ofs != 0
-            os = new FileOutputStream(f, ofs != 0);
-            ((FileOutputStream) os).write(contents);
-            ((FileOutputStream) os).flush();
-            ((FileOutputStream) os).getFD().sync();
-          } else {
-            // Overwrite if ofs == 0
-            os = new RandomAccessFile(f, "rw");
-            if(ofs >= 0)((RandomAccessFile) os).setLength(ofs + contents.length);
-            if (ofs > 0) ((RandomAccessFile) os).skipBytes((int) ofs);
-            else if (ofs < 0) ((RandomAccessFile) os).skipBytes((int) (f.length() + ofs));
-            ((RandomAccessFile) os).write(contents);
-            ((RandomAccessFile) os).getFD().sync();
-          }
-          rsp = new Message(req, Performative.AGREE);
-        }
+      } else if (ofs == f.length()) {
+        // Append if ofs != 0
+        os = new FileOutputStream(f, ofs != 0);
+        ((FileOutputStream) os).write(contents);
+        ((FileOutputStream) os).flush();
+        ((FileOutputStream) os).getFD().sync();
+        rsp = new Message(req, Performative.AGREE);
+      } else {
+        // Overwrite if ofs == 0
+        os = new RandomAccessFile(f, "rw");
+        if(ofs >= 0)((RandomAccessFile) os).setLength(ofs + contents.length);
+        if (ofs > 0) ((RandomAccessFile) os).skipBytes((int) ofs);
+        else if (ofs < 0) ((RandomAccessFile) os).skipBytes((int) (f.length() + ofs));
+        ((RandomAccessFile) os).write(contents);
+        ((RandomAccessFile) os).getFD().sync();
+        rsp = new Message(req, Performative.AGREE);
       }
     } catch (IOException ex) {
       log.log(Level.WARNING, "File write failure: "+ex.toString(), ex);
@@ -707,4 +689,79 @@ public class ShellAgent extends Agent {
     send(rsp);
   }
 
+  private void handleDeleteFileReq(final DeleteFileReq req) {
+    String filename = req.getFilename();
+    if (filename == null) {
+      send(new Message(req, Performative.REFUSE));
+      return;
+    }
+
+    Message rsp = null;
+    try {
+      if (deletePath(filename)) rsp = new Message(req, Performative.AGREE);
+    } catch (IOException ex) {
+      log.log(Level.WARNING, "File delete failure: "+ex.toString(), ex);
+    }
+    if (rsp == null) rsp = new Message(req, Performative.FAILURE);
+    send(rsp);
+  }
+
+  private boolean deletePath(String filename) throws IOException {
+    File f = new File(filename);
+    if (!f.exists()) {
+      return false;
+    }
+
+    boolean isDir = filename.endsWith("/") || filename.endsWith(File.separator);
+    if (isDir) {
+      // If the filename ends with a file separator, we expect a directory
+      if (!f.isDirectory()) {
+        return false;
+      }
+
+      // Remove cache entries for files in the directory
+      String prefix = filename;
+      if (!prefix.endsWith("/") && !prefix.endsWith(File.separator)) {
+        prefix += File.separator;
+      }
+      Iterator<Map.Entry<String, InputStreamCacheEntry>> it = isCache.entrySet().iterator();
+      while (it.hasNext()) {
+        Map.Entry<String, InputStreamCacheEntry> entry = it.next();
+        String key = entry.getKey();
+        if (key.startsWith(prefix)) {
+          try {
+            entry.getValue().is.close();
+          } catch (IOException ex) {
+            log.log(Level.WARNING, "Input stream close failure: "+ex.toString(), ex);
+          }
+          it.remove();
+        }
+      }
+
+      // Remove the directory and its files
+      Path pathToBeDeleted = Paths.get(filename);
+      try (Stream<Path> stream = Files.walk(pathToBeDeleted)) {
+         Iterator<Path> paths = stream.sorted(Comparator.reverseOrder()).iterator();
+         while (paths.hasNext()) Files.delete(paths.next());
+      }
+      return true;
+    }
+
+    // Not a directory
+
+    // If the filename doesn't end with a file separator, we expect a file
+    if (!f.isFile()) {
+      return false;
+    }
+
+    if (isCache.containsKey(filename)){
+      try {
+        isCache.get(filename).is.close();
+      } catch (IOException ex) {
+        log.log(Level.WARNING, "Input stream close failure: "+ex.toString(), ex);
+      }
+      isCache.remove(filename);
+    }
+    return f.delete();
+  }
 }

--- a/src/main/java/org/arl/fjage/shell/ShellAgent.java
+++ b/src/main/java/org/arl/fjage/shell/ShellAgent.java
@@ -15,6 +15,7 @@ import org.arl.fjage.param.ParameterMessageBehavior;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -590,7 +591,8 @@ public class ShellAgent extends Agent {
         else if (ofs+len > length) len = length-ofs;
         if (len > Integer.MAX_VALUE) throw new IOException("File is too large!");
         byte[] bytes = new byte[(int)len];
-        InputStreamCacheEntry isce = isCache.get(filename);
+        String key = cacheKey(filename);
+        InputStreamCacheEntry isce = isCache.get(key);
         if (isce != null) {
           if (isce.pos == ofs) {
             isce.lastUsed = currentTimeMillis();
@@ -598,7 +600,7 @@ public class ShellAgent extends Agent {
             is = isce.is;
           } else {
             isce.is.close();
-            isCache.remove(filename);
+            isCache.remove(key);
           }
         }
         int offset = 0;
@@ -615,8 +617,8 @@ public class ShellAgent extends Agent {
         rsp.setOffset(ofs);
         rsp.setContents(bytes);
         if (ofs != 0) {
-          if (!isCache.containsKey(filename))
-            isCache.put(filename, new InputStreamCacheEntry(is, ofs+bytes.length));
+          if (!isCache.containsKey(key))
+            isCache.put(key, new InputStreamCacheEntry(is, ofs+bytes.length));
           is = null;
         }
       }
@@ -629,7 +631,7 @@ public class ShellAgent extends Agent {
         } catch (IOException ex) {
           // do nothing
         }
-        isCache.remove(filename);
+        isCache.remove(cacheKey(filename));
       }
     }
     if (rsp != null) send(rsp);
@@ -720,15 +722,18 @@ public class ShellAgent extends Agent {
       }
 
       // Remove cache entries for files in the directory
-      String prefix = filename;
-      if (!prefix.endsWith("/") && !prefix.endsWith(File.separator)) {
-        prefix += File.separator;
-      }
+      Path dirPath = Paths.get(filename).normalize();
       Iterator<Map.Entry<String, InputStreamCacheEntry>> it = isCache.entrySet().iterator();
       while (it.hasNext()) {
         Map.Entry<String, InputStreamCacheEntry> entry = it.next();
-        String key = entry.getKey();
-        if (key.startsWith(prefix)) {
+        Path entryPath;
+        try {
+          entryPath = Paths.get(entry.getKey());
+        } catch (InvalidPathException ex) {
+          continue;
+        }
+
+        if (entryPath.startsWith(dirPath)) {
           try {
             entry.getValue().is.close();
           } catch (IOException ex) {
@@ -754,14 +759,24 @@ public class ShellAgent extends Agent {
       return false;
     }
 
-    if (isCache.containsKey(filename)){
+    String key = cacheKey(filename);
+    if (isCache.containsKey(key)){
       try {
-        isCache.get(filename).is.close();
+        isCache.get(key).is.close();
       } catch (IOException ex) {
         log.log(Level.WARNING, "Input stream close failure: "+ex.toString(), ex);
       }
-      isCache.remove(filename);
+      isCache.remove(key);
     }
     return f.delete();
+  }
+
+  // Canonical form of a filename for use as an isCache key.
+  private String cacheKey(String filename) {
+    try {
+      return Paths.get(filename).normalize().toString();
+    } catch (InvalidPathException ex) {
+      return filename;
+    }
   }
 }

--- a/src/test/java/org/arl/fjage/test/BasicTests.java
+++ b/src/test/java/org/arl/fjage/test/BasicTests.java
@@ -344,7 +344,13 @@ public class BasicTests {
     assertTrue("Get file (offset 9, len 0) failed", agent.get3);
     assertTrue("Get file (offset 27, len 1, out of bounds) failed", agent.get4);
     assertTrue("Directory listing failed", agent.dir);
-    assertTrue("Delete file failed", agent.del);
+    assertTrue("Delete file (PutFileReq) failed", agent.delByPut);
+    assertTrue("Delete file (existing file) failed", agent.del);
+    assertTrue("Delete file (missing file) failed", agent.delMissing);
+    assertTrue("Delete file (null filename) failed", agent.delNull);
+    assertTrue("Delete directory (recursive, trailing separator) failed", agent.delDir);
+    assertTrue("Delete file with trailing separator (mismatch) failed", agent.delFileTrailingSepMismatch);
+    assertTrue("Delete directory without trailing separator (mismatch) failed", agent.delDirNoSepMismatch);
   }
 
   @Test
@@ -993,7 +999,9 @@ public class BasicTests {
   private static class ShellTestAgent extends Agent {
     private final String DIRNAME = System.getProperty("java.io.tmpdir");
     private final String FILENAME = "fjage-test.txt";
-    public boolean exec = false, put1 = false, put2 = false, put3 = false, put4 = false, get = false, get2 = false, get3 = false, get4 = false, del = false, dir = false, done = false;
+    private final String DELETE_FILENAME = "fjage-delete-test.txt";
+    private final String DELETE_DIRNAME = "fjage-delete-dir";
+    public boolean exec = false, put1 = false, put2 = false, put3 = false, put4 = false, get = false, get2 = false, get3 = false, get4 = false, delByPut = false, dir = false, del = false, delMissing = false, delNull = false, delDir = false, delFileTrailingSepMismatch = false, delDirNoSepMismatch = false, done = false;
     @Override
     public void init() {
       add(new OneShotBehavior() {
@@ -1007,7 +1015,19 @@ public class BasicTests {
           Test 7: Overwrite data to the file created in Test 1.
           Test 8: Truncate the file created in Test 1.
           Test 9: Get a listing of all files in the directory, ensure the file created in Test 1 exists.
-          Test 10: Delete file created in Test 1.
+          Test 10: Delete file created in Test 1 (via PutFileReq).
+          Test 11: Create a second file with dummy data, to be deleted via DeleteFileReq.
+          Test 12: Delete the file created in Test 11 via DeleteFileReq.
+          Test 13: Attempt to delete the (now missing) file created in Test 11 via DeleteFileReq, expect failure.
+          Test 14: Attempt a DeleteFileReq with no filename set, expect refusal.
+          Test 15: Create a directory containing a nested file and a nested subdirectory with its own file,
+                   then delete it all recursively via DeleteFileReq using a trailing path separator, expect success.
+          Test 16: Create a plain file, then attempt to delete it via DeleteFileReq using a
+                   trailing path separator (mismatch: file targeted as if it were a directory),
+                   expect failure.
+          Test 17: Create an empty directory, then attempt to delete it via DeleteFileReq without
+                   a trailing path separator (mismatch: directory targeted as if it were a file),
+                   expect failure.
          */
         @Override
         public void action() {
@@ -1117,8 +1137,74 @@ public class BasicTests {
           log.info("del rsp: "+rsp);
           if (rsp != null && rsp.getPerformative() == Performative.AGREE) {
             File f = new File(DIRNAME+File.separator+FILENAME);
+            if (!f.exists()) delByPut = true;
+          }
+
+          req = new PutFileReq(shell, DIRNAME+File.separator+DELETE_FILENAME, bytes);
+          rsp = request(req);
+          log.info("del setup put rsp: "+rsp);
+
+          req = new DeleteFileReq(shell, DIRNAME+File.separator+DELETE_FILENAME);
+          rsp = request(req);
+          log.info("del rsp: "+rsp);
+          if (rsp != null && rsp.getPerformative() == Performative.AGREE) {
+            File f = new File(DIRNAME+File.separator+DELETE_FILENAME);
             if (!f.exists()) del = true;
           }
+
+          req = new DeleteFileReq(shell, DIRNAME+File.separator+DELETE_FILENAME);
+          rsp = request(req);
+          log.info("delMissing rsp: "+rsp);
+          if (rsp != null && rsp.getPerformative() == Performative.FAILURE) delMissing = true;
+
+          req = new DeleteFileReq(shell);
+          rsp = request(req);
+          log.info("delNull rsp: "+rsp);
+          if (rsp != null && rsp.getPerformative() == Performative.REFUSE) delNull = true;
+
+          File dirToDelete = new File(DIRNAME+File.separator+DELETE_DIRNAME);
+          req = new PutFileReq(shell, dirToDelete.getPath()+File.separator, new byte[0]);
+          rsp = request(req);
+          log.info("delDir mkdir rsp: "+rsp);
+          File nested = new File(dirToDelete, "nested.txt");
+          req = new PutFileReq(shell, nested.getPath(), bytes);
+          rsp = request(req);
+          log.info("delDir nested put rsp: "+rsp);
+          File nestedDir = new File(dirToDelete, "nesteddir");
+          req = new PutFileReq(shell, nestedDir.getPath()+File.separator, new byte[0]);
+          rsp = request(req);
+          log.info("delDir nesteddir mkdir rsp: "+rsp);
+          File nestedDirFile = new File(nestedDir, "nested2.txt");
+          req = new PutFileReq(shell, nestedDirFile.getPath(), bytes);
+          rsp = request(req);
+          log.info("delDir nesteddir nested put rsp: "+rsp);
+          req = new DeleteFileReq(shell, dirToDelete.getPath()+File.separator);
+          rsp = request(req);
+          log.info("delDir rsp: "+rsp);
+          if (rsp != null && rsp.getPerformative() == Performative.AGREE
+              && !dirToDelete.exists() && !nested.exists() && !nestedDir.exists() && !nestedDirFile.exists())
+            delDir = true;
+
+          File fileForMismatch = new File(DIRNAME+File.separator+"fjage-delete-mismatch.txt");
+          req = new PutFileReq(shell, fileForMismatch.getPath(), bytes);
+          rsp = request(req);
+          log.info("delFileTrailingSepMismatch setup put rsp: "+rsp);
+          req = new DeleteFileReq(shell, fileForMismatch.getPath()+File.separator);
+          rsp = request(req);
+          log.info("delFileTrailingSepMismatch rsp: "+rsp);
+          if (rsp != null && rsp.getPerformative() == Performative.FAILURE && fileForMismatch.exists()) delFileTrailingSepMismatch = true;
+          fileForMismatch.delete();
+
+          File dirForMismatch = new File(DIRNAME+File.separator+"fjage-delete-mismatch-dir");
+          req = new PutFileReq(shell, dirForMismatch.getPath()+File.separator, new byte[0]);
+          rsp = request(req);
+          log.info("delDirNoSepMismatch mkdir rsp: "+rsp);
+          req = new DeleteFileReq(shell, dirForMismatch.getPath());
+          rsp = request(req);
+          log.info("delDirNoSepMismatch rsp: "+rsp);
+          if (rsp != null && rsp.getPerformative() == Performative.FAILURE && dirForMismatch.exists()) delDirNoSepMismatch = true;
+          dirForMismatch.delete();
+
           done = true;
         }
       });


### PR DESCRIPTION
Part of https://github.com/org-arl/fjage/issues/445. Adds a `DeleteFileReq` to the shell agent to delete a file / directory.

Behaviour should be almost identical to what `PutFileReq` did previously for deletion. If the specified path ends in a path separator, then it is expected that the target to delete is a directory, and the shell agent will delete it recursively (now, we also additionally remove the input stream cache entries that fall under that directory). If not, we expect a file and just delete it and its cache entry.

The main difference is that we now also have an additional check: if the specified path ends with a path separator (i.e., the intent is to delete a directory) but is a normal file on disk, then we respond with FAILURE. Similarly, if the specified path doesn't end with a path separator but is a directory on disk, we also respond with FAILURE.

To avoid code duplication, the handler for `DeleteFileReq` and the deletion code path for `PutFileReq` use the same `deletePath()` private method. This does mean the deletion behaviour of `PutFileReq` will change to include the additional check above.

Also, the input stream cache (`isCache`) is now keyed by a normalised form of the path (via a new `cacheKey()` helper) rather than the raw filename string. This is needed so that a nested file's cache entry can be reliably matched against the directory being deleted, regardless of how each path is formatted (e.g., trailing separators, redundant segments). `GetFileReq` handling has also been updated to use `cacheKey()` for consistency.

Also added tests for `DeleteFileReq`.