### PR TITLE
Add `DeleteFileReq` to JS gateway

### DIFF
--- a/gateways/js/src/fjage.js
+++ b/gateways/js/src/fjage.js
@@ -1,4 +1,4 @@
-import { MessageClass, Message, GenericMessage, ParameterReq, ParameterRsp, PutFileReq, GetFileReq, GetFileRsp, ShellExecReq} from './message.js';
+import { MessageClass, Message, GenericMessage, ParameterReq, ParameterRsp, PutFileReq, GetFileReq, GetFileRsp, DeleteFileReq, ShellExecReq} from './message.js';
 import { Gateway, init} from './gateway.js';
 import { AgentID } from './agentid.js';
 import { Services } from './services.js';
@@ -7,4 +7,4 @@ import { JSONMessage } from './jsonmessage.js';
 
 init();
 
-export { Gateway, AgentID, Message, MessageClass, GenericMessage, Services, ParameterReq, ParameterRsp, Performative, JSONMessage, PutFileReq, GetFileReq, GetFileRsp, ShellExecReq};
+export { Gateway, AgentID, Message, MessageClass, GenericMessage, Services, ParameterReq, ParameterRsp, Performative, JSONMessage, PutFileReq, GetFileReq, GetFileRsp, DeleteFileReq, ShellExecReq};

--- a/gateways/js/src/message.js
+++ b/gateways/js/src/message.js
@@ -196,6 +196,14 @@ export const ParameterRsp = MessageClass('org.arl.fjage.param.ParameterRsp');
 */
 export const PutFileReq = MessageClass('org.arl.fjage.shell.PutFileReq');
 
+/**
+* Request to delete a file, or a directory (if the file name ends with a path separator).
+*
+* @typedef {Message} DeleteFileReq
+* @property {string} filename - name of the file or directory to delete
+* @exports DeleteFileReq
+*/
+export const DeleteFileReq = MessageClass('org.arl.fjage.shell.DeleteFileReq');
 
 /**
 * Request to read a file or a directory.

--- a/gateways/js/test/spec/create-spec.cjs
+++ b/gateways/js/test/spec/create-spec.cjs
@@ -9,7 +9,7 @@ const fs = require('fs');
 const { exit } = require('process');
 
 const cjs_includes = [
-  'const { Performative, AgentID, Message, Gateway, MessageClass, GenericMessage, JSONMessage, PutFileReq, GetFileReq, GetFileRsp, ShellExecReq } = require(\'../../dist/cjs/fjage.cjs\');',
+  'const { Performative, AgentID, Message, Gateway, MessageClass, GenericMessage, JSONMessage, PutFileReq, GetFileReq, GetFileRsp, DeleteFileReq, ShellExecReq } = require(\'../../dist/cjs/fjage.cjs\');',
   'const { isBrowser, isJsDom, isNode } = require(\'../../node_modules/browser-or-node/dist/index.js\');',
   'const dns = require(\'dns\');',
   'dns.setDefaultResultOrder(\'ipv4first\');',
@@ -18,7 +18,7 @@ const cjs_includes = [
 
 
 const esm_includes = [
-  'import { Performative, AgentID, Message, Gateway, MessageClass, GenericMessage, JSONMessage, PutFileReq, GetFileReq, GetFileRsp, ShellExecReq} from \'../../dist/esm/fjage.js\';',
+  'import { Performative, AgentID, Message, Gateway, MessageClass, GenericMessage, JSONMessage, PutFileReq, GetFileReq, GetFileRsp, DeleteFileReq, ShellExecReq} from \'../../dist/esm/fjage.js\';',
   'import { isBrowser, isNode, isJsDom } from \'../../node_modules/browser-or-node/dist/index.mjs\';',
   ''
 ];

--- a/gateways/js/test/spec/fjage.spec.js
+++ b/gateways/js/test/spec/fjage.spec.js
@@ -915,6 +915,109 @@ describe('Shell GetFile/PutFile', function () {
     expect(rsp2.contents.length).toBe(TEST_STRING.length-4+NEW_STRING.length);
     expect(new TextDecoder('utf-8').decode(new Uint8Array(rsp2.contents))).toEqual(TEST_STRING.substring(0,10) + NEW_STRING);
   });
+
+  it('should be able to delete a file using DeleteFileReq', async function () {
+    const dfr = new DeleteFileReq();
+    dfr.recipient = shell;
+    dfr.filename = DIRNAME + '/' + FILENAME;
+    const rsp = await gw.request(dfr, 3000);
+    expect(rsp).toBeTruthy();
+    expect(rsp.perf).toEqual(Performative.AGREE);
+    var gfr = new GetFileReq();
+    gfr.recipient = shell;
+    gfr.filename = DIRNAME + '/' + FILENAME;
+    const rsp2 = await gw.request(gfr);
+    expect(rsp2.perf).toEqual(Performative.FAILURE);
+  });
+
+  it('should fail to delete a file using DeleteFileReq if the file does not exist', async function () {
+    const dfr = new DeleteFileReq();
+    dfr.recipient = shell;
+    dfr.filename = DIRNAME + '/' + FILENAME;
+    const rsp = await gw.request(dfr, 3000);
+    expect(rsp).toBeTruthy();
+    expect(rsp.perf).toEqual(Performative.AGREE);
+    const rsp2 = await gw.request(dfr, 3000);
+    expect(rsp2).toBeTruthy();
+    expect(rsp2.perf).toEqual(Performative.FAILURE);
+  });
+
+  it('should refuse a DeleteFileReq with no filename set', async function () {
+    const dfr = new DeleteFileReq();
+    dfr.recipient = shell;
+    const rsp = await gw.request(dfr, 3000);
+    expect(rsp).toBeTruthy();
+    expect(rsp.perf).toEqual(Performative.REFUSE);
+  });
+
+  it('should be able to recursively delete a directory using DeleteFileReq', async function () {
+    const dirPath = DIRNAME + '/fjage-test-delete-dir';
+
+    let pfr = new PutFileReq();
+    pfr.recipient = shell;
+    pfr.filename = dirPath + '/';
+    pfr.contents = [];
+    let rsp = await gw.request(pfr, 3000);
+    expect(rsp.perf).toEqual(Performative.AGREE);
+
+    pfr = new PutFileReq();
+    pfr.recipient = shell;
+    pfr.filename = dirPath + '/nested.txt';
+    pfr.contents = Array.from((new TextEncoder('utf-8').encode(TEST_STRING)));
+    rsp = await gw.request(pfr, 3000);
+    expect(rsp.perf).toEqual(Performative.AGREE);
+
+    pfr = new PutFileReq();
+    pfr.recipient = shell;
+    pfr.filename = dirPath + '/nesteddir/';
+    pfr.contents = [];
+    rsp = await gw.request(pfr, 3000);
+    expect(rsp.perf).toEqual(Performative.AGREE);
+
+    const dfr = new DeleteFileReq();
+    dfr.recipient = shell;
+    dfr.filename = dirPath + '/';
+    const rsp2 = await gw.request(dfr, 3000);
+    expect(rsp2).toBeTruthy();
+    expect(rsp2.perf).toEqual(Performative.AGREE);
+
+    const gfr = new GetFileReq();
+    gfr.recipient = shell;
+    gfr.filename = dirPath;
+    const rsp3 = await gw.request(gfr, 3000);
+    expect(rsp3.perf).toEqual(Performative.FAILURE);
+  });
+
+  it('should fail to delete a file using DeleteFileReq when the filename has a trailing separator', async function () {
+    const dfr = new DeleteFileReq();
+    dfr.recipient = shell;
+    dfr.filename = DIRNAME + '/' + FILENAME + '/';
+    const rsp = await gw.request(dfr, 3000);
+    expect(rsp).toBeTruthy();
+    expect(rsp.perf).toEqual(Performative.FAILURE);
+  });
+
+  it('should fail to delete a directory using DeleteFileReq without a trailing separator', async function () {
+    const dirPath = DIRNAME + '/fjage-test-delete-mismatch-dir';
+    const pfr = new PutFileReq();
+    pfr.recipient = shell;
+    pfr.filename = dirPath + '/';
+    pfr.contents = [];
+    const rsp = await gw.request(pfr, 3000);
+    expect(rsp.perf).toEqual(Performative.AGREE);
+
+    const dfr = new DeleteFileReq();
+    dfr.recipient = shell;
+    dfr.filename = dirPath;
+    const rsp2 = await gw.request(dfr, 3000);
+    expect(rsp2).toBeTruthy();
+    expect(rsp2.perf).toEqual(Performative.FAILURE);
+
+    const cleanup = new DeleteFileReq();
+    cleanup.recipient = shell;
+    cleanup.filename = dirPath + '/';
+    await gw.request(cleanup, 3000);
+  });
 });
 
 async function sendTestStatus(status, trace, type) {


### PR DESCRIPTION
#449 added a `DeleteFileReq` to the shell agent. This PR defines `DeleteFileReq` in the JS gateway.