### PR TITLE
Add `DeleteFileReq` to Python gateway

### DIFF
--- a/gateways/python/fjagepy/Message.py
+++ b/gateways/python/fjagepy/Message.py
@@ -442,6 +442,16 @@ class PutFileReq(Message):
         _update_attributes(self, kwargs)
 
 
+@message('org.arl.fjage.shell.DeleteFileReq')
+class DeleteFileReq(Message):
+    filename: Optional[str]
+
+    def __init__(self, filename: Optional[str] = None, **kwargs):
+        super().__init__(perf=Performative.REQUEST)
+        self.filename: Optional[str] = filename
+        _update_attributes(self, kwargs)
+
+
 @message('org.arl.fjage.shell.GetFileReq')
 class GetFileReq(Message):
     filename: Optional[str]

--- a/gateways/python/fjagepy/__init__.py
+++ b/gateways/python/fjagepy/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 from .Gateway import Gateway
-from .Message import Message, MessageClass, message, ParameterReq, ParameterRsp, PutFileReq, GetFileReq, ShellExecReq, GetFileRsp
+from .Message import Message, MessageClass, message, ParameterReq, ParameterRsp, PutFileReq, GetFileReq, DeleteFileReq, ShellExecReq, GetFileRsp
 from .Performative import Performative
 from .AgentID import AgentID
 from .Services import Services
@@ -32,6 +32,7 @@ __all__ = [
     "ParameterRsp",
     "PutFileReq",
     "GetFileReq",
+    "DeleteFileReq",
     "ShellExecReq",
     "GetFileRsp"
 ]

--- a/gateways/python/test/test_shellreqs.py
+++ b/gateways/python/test/test_shellreqs.py
@@ -8,7 +8,7 @@ FILENAME = 'fjage-test.txt';
 TEST_STRING = 'this is a test';
 NEW_STRING = 'new test';
 
-from fjagepy import Gateway, Message, ShellExecReq, AgentID, MessageClass, Performative, JSONMessage, GetFileReq, GetFileRsp, PutFileReq
+from fjagepy import Gateway, Message, ShellExecReq, AgentID, MessageClass, Performative, JSONMessage, GetFileReq, GetFileRsp, PutFileReq, DeleteFileReq
 
 @pytest.fixture(scope="module")
 def gateway():
@@ -312,3 +312,121 @@ def test_gateway_append_file_using_offset_less_than_zero(gateway, testfile):
     assert len(rsp2.contents) == expected_length
     expected_content = (TEST_STRING[:10] + NEW_STRING).encode('utf-8')
     assert rsp2.contents == list(expected_content)
+
+def test_gateway_delete_file_using_delete_file_req(gateway, testfile):
+    """Gateway should be able to delete a file using DeleteFileReq."""
+    shell = gateway.agent('shell')
+    dfr = DeleteFileReq()
+    dfr.recipient = shell
+    dfr.filename = DIRNAME + '/' + FILENAME
+    rsp = gateway.request(dfr)
+    assert rsp is not None
+    assert rsp.perf is not None
+    assert rsp.perf == Performative.AGREE
+    gfr = GetFileReq()
+    gfr.recipient = shell
+    gfr.filename = DIRNAME + '/' + FILENAME
+    rsp2 = gateway.request(gfr)
+    assert rsp2 is not None
+    assert rsp2.perf is not None
+    assert rsp2.perf == Performative.FAILURE
+
+def test_gateway_delete_file_using_delete_file_req_missing_file(gateway, testfile):
+    """Gateway should fail to delete a file using DeleteFileReq if the file does not exist."""
+    shell = gateway.agent('shell')
+    dfr = DeleteFileReq()
+    dfr.recipient = shell
+    dfr.filename = DIRNAME + '/' + FILENAME
+    rsp = gateway.request(dfr)
+    assert rsp is not None
+    assert rsp.perf is not None
+    assert rsp.perf == Performative.AGREE
+    rsp2 = gateway.request(dfr)
+    assert rsp2 is not None
+    assert rsp2.perf is not None
+    assert rsp2.perf == Performative.FAILURE
+
+def test_gateway_delete_file_req_no_filename(gateway, testfile):
+    """Gateway should refuse a DeleteFileReq with no filename set."""
+    shell = gateway.agent('shell')
+    dfr = DeleteFileReq()
+    dfr.recipient = shell
+    rsp = gateway.request(dfr)
+    assert rsp is not None
+    assert rsp.perf is not None
+    assert rsp.perf == Performative.REFUSE
+
+def test_gateway_delete_directory_using_delete_file_req(gateway, testfile):
+    """Gateway should be able to recursively delete a directory using DeleteFileReq."""
+    shell = gateway.agent('shell')
+    dirpath = DIRNAME + '/fjage-test-delete-dir'
+
+    pfr = PutFileReq()
+    pfr.recipient = shell
+    pfr.filename = dirpath + '/'
+    pfr.contents = []
+    rsp = gateway.request(pfr)
+    assert rsp is not None and rsp.perf == Performative.AGREE
+
+    pfr = PutFileReq()
+    pfr.recipient = shell
+    pfr.filename = dirpath + '/nested.txt'
+    pfr.contents = list(TEST_STRING.encode('utf-8'))
+    rsp = gateway.request(pfr)
+    assert rsp is not None and rsp.perf == Performative.AGREE
+
+    pfr = PutFileReq()
+    pfr.recipient = shell
+    pfr.filename = dirpath + '/nesteddir/'
+    pfr.contents = []
+    rsp = gateway.request(pfr)
+    assert rsp is not None and rsp.perf == Performative.AGREE
+
+    dfr = DeleteFileReq()
+    dfr.recipient = shell
+    dfr.filename = dirpath + '/'
+    rsp2 = gateway.request(dfr)
+    assert rsp2 is not None
+    assert rsp2.perf == Performative.AGREE
+
+    gfr = GetFileReq()
+    gfr.recipient = shell
+    gfr.filename = dirpath
+    rsp3 = gateway.request(gfr)
+    assert rsp3 is not None
+    assert rsp3.perf == Performative.FAILURE
+
+def test_gateway_delete_file_req_trailing_separator_mismatch(gateway, testfile):
+    """Gateway should fail to delete a file using DeleteFileReq when the filename has a trailing separator."""
+    shell = gateway.agent('shell')
+    dfr = DeleteFileReq()
+    dfr.recipient = shell
+    dfr.filename = DIRNAME + '/' + FILENAME + '/'
+    rsp = gateway.request(dfr)
+    assert rsp is not None
+    assert rsp.perf is not None
+    assert rsp.perf == Performative.FAILURE
+
+def test_gateway_delete_directory_req_no_trailing_separator_mismatch(gateway, testfile):
+    """Gateway should fail to delete a directory using DeleteFileReq without a trailing separator."""
+    shell = gateway.agent('shell')
+    dirpath = DIRNAME + '/fjage-test-delete-mismatch-dir'
+
+    pfr = PutFileReq()
+    pfr.recipient = shell
+    pfr.filename = dirpath + '/'
+    pfr.contents = []
+    rsp = gateway.request(pfr)
+    assert rsp is not None and rsp.perf == Performative.AGREE
+
+    dfr = DeleteFileReq()
+    dfr.recipient = shell
+    dfr.filename = dirpath
+    rsp2 = gateway.request(dfr)
+    assert rsp2 is not None
+    assert rsp2.perf == Performative.FAILURE
+
+    cleanup = DeleteFileReq()
+    cleanup.recipient = shell
+    cleanup.filename = dirpath + '/'
+    gateway.request(cleanup)


### PR DESCRIPTION
#449 added a `DeleteFileReq` to the shell agent. This PR defines `DeleteFileReq` in the Python gateway.