### PR TITLE
Fix out-of-bounds access in the C gateway on empty JSON input

### DIFF
--- a/gateways/c/src/fjage.c
+++ b/gateways/c/src/fjage.c
@@ -365,7 +365,7 @@ static jsmntok_t* json_parse(const char* json) {
   jsmn_parser parser;
   jsmn_init(&parser);
   int n = jsmn_parse(&parser, json, strlen(json), NULL, 0);
-  if (n < 0) return NULL;
+  if (n <= 0) return NULL;
   jsmntok_t* tokens = malloc(n*sizeof(jsmntok_t));
   if (tokens == NULL) return NULL;
   jsmn_init(&parser);


### PR DESCRIPTION
`json_parse` treats an empty line as a valid parse, and the token array it returns is then read out of bounds.

`jsmn_parse` returns `0` for input with no tokens — an empty or whitespace-only line. The guard only rejects `n < 0`, so `n == 0` continues to `malloc(0)`, which on glibc returns a non-NULL zero-byte allocation and so passes the `tokens == NULL` check too:

```c
int n = jsmn_parse(&parser, json, strlen(json), NULL, 0);
if (n < 0) return NULL;
jsmntok_t* tokens = malloc(n*sizeof(jsmntok_t));
if (tokens == NULL) return NULL;
```

`json_get` then reads a field count out of that empty allocation and walks it:

```c
int n = tokens[0].size;                   // out-of-bounds read
...
char* t = json + tokens[i].start;
t[tokens[i].end-tokens[i].start] = 0;     // out-of-bounds write, at an arbitrary offset
if (!strcmp(t, key)) return i+1;
```

So a single empty line gives an out-of-bounds read whose garbage becomes a loop bound, then a zero-byte write through `json + tokens[i].start` for unbounded `i`, then a `strcmp` on it. In practice it segfaults inside `strcmp`.

This is reachable from a peer that sends a bare newline, which a truncated write on a serial link produces.

## The fix

Reject `n == 0` along with the negative cases. `json_process` already handles a `NULL` return:

```c
jsmntok_t* tokens = json_parse(json);
if (tokens == NULL) return false;
```

so an empty line is simply not processed, which is the correct outcome — no caller distinguishes "empty" from "unparseable".

It also removes a platform dependency: `malloc(0)` is implementation-defined, so on an implementation that returns `NULL` the current code is accidentally safe, and on glibc it is not.

Reproduces on current `master` (`gateways/c/src/fjage.c`, `json_parse`).

## No test

`json_parse` is `static`, and `gateways/c/tests/test_fjage.c` drives the gateway against a live fjage container rather than testing internals, so there is no existing seam for this. Happy to add one if you would like the function exposed for testing.