### PR TITLE
fjagejs: remove browser gateway cache

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,6 +11,7 @@
 * Bugfix: WebSocket writes are now bounded and non-blocking, so a slow client can no longer stall the container
 * Bugfix: Correct handling of closed state in `BlockingByteQueue`, `PseudoInputStream` and `PseudoOutputStream`
 * Chore: Migrate the developer's guide from Sphinx/ReadTheDocs to Quarto
+* Browser gateways are no longer cached: each `new Gateway()` creates a new connection with its own options, matching Node.js behavior
 * Classify gateway connections (single `gateway-` prefixed agent) as lightweight: not asked directory queries.
 
 ### 2.5.0

--- a/docs/jsgw.qmd
+++ b/docs/jsgw.qmd
@@ -41,6 +41,8 @@ Here `WebServer.addStatic()` serves the static web resources bundled in the fjå
 
 fjage.js is distributed as ready-to-use bundles for the common JavaScript module systems (ESM, CommonJS and UMD). In a web application built with a bundler, you simply `import { Gateway } from 'fjage'`; in a plain web page, you can either load the UMD bundle with `<script src="fjage.min.js"></script>`, or import the ESM bundle (`dist/esm/fjage.js`) directly from a `<script type="module">`. Examples for each module system are available in the [examples](https://github.com/org-arl/fjage/tree/master/gateways/js/examples) directory.
 
+Each `new Gateway()` opens its own connection to the master container, even when another gateway is already connected to the same master. If several parts of your application need to talk to the same master, construct one gateway and share it, rather than constructing a gateway in each of them.
+
 It is easiest to illustrate the use of the JavaScript API though a simple code example:
 
 ``` javascript

--- a/gateways/js/src/gateway.js
+++ b/gateways/js/src/gateway.js
@@ -1,5 +1,3 @@
-/* global global */
-
 import { isBrowser, isNode, isJsDom, isWebWorker } from 'browser-or-node';
 import { AgentID } from './agentid.js';
 import { Message, registerMessageClass } from './message.js';
@@ -22,31 +20,24 @@ const GATEWAY_DEFAULTS = {
 };
 
 let DEFAULT_URL;
-let gObj = {};
 
 /**
 *
 * @private
 *
 * Initializes the Gateway module. This function should be called before using the Gateway class.
-* It sets up the default values for the Gateway and initializes the global object.
-* It also sets up the default URL for the Gateway based on the environment (browser, Node.js, etc.).
+* It sets up the default values for the Gateway based on the environment (browser, Node.js, etc.).
 * @returns {void}
 */
 export function init(){
   if (isBrowser || isWebWorker){
-    gObj = window;
     Object.assign(GATEWAY_DEFAULTS, {
-      'hostname': gObj.location.hostname,
-      'port': gObj.location.port,
+      'hostname': window.location.hostname,
+      'port': window.location.port,
       'pathname' : '/ws/'
     });
     DEFAULT_URL = new URL('ws://localhost');
-    // Enable caching of Gateways in browser
-    if (typeof gObj.fjage === 'undefined') gObj.fjage = {};
-    if (typeof gObj.fjage.gateways == 'undefined') gObj.fjage.gateways = [];
   } else if (isJsDom || isNode){
-    gObj = global;
     Object.assign(GATEWAY_DEFAULTS, {
       'hostname': 'localhost',
       'port': '1100',
@@ -66,6 +57,10 @@ export function init(){
 *
 * @example <caption>Connects to the origin</caption>
 * const gw = new Gateway();
+*
+* Every construction opens a new connection to the master container, even if one already
+* exists to the same master. Applications that want a shared connection should construct
+* one gateway and reuse it, rather than constructing a second one.
 *
 * @class
 * @property {AgentID} aid - agent id of the gateway
@@ -107,8 +102,6 @@ export class Gateway {
     url.hostname = opts.hostname;
     url.port = opts.port;
     url.pathname = opts.pathname;
-    let existing = this._getGWCache(url);
-    if (existing) return existing;
     this._timeout = opts.timeout;         // timeout for request() and receive()
     this._directoryTimeout = opts.directoryTimeout; // timeout for directory queries
     this._keepAlive = opts.keepAlive;     // reconnect if connection gets closed/errored
@@ -124,7 +117,6 @@ export class Gateway {
     this.debug = false;                   // debug info to be logged to console?
     this.aid = new AgentID('gateway-'+_guid(4));         // gateway agent name
     this.connector = this._createConnector(url);
-    this._addGWCache(this);
   }
 
   /**
@@ -367,40 +359,6 @@ export class Gateway {
     let matchedMsg = this._queue.find( msg => this._matchMessage(filter, msg));
     if (matchedMsg) this._queue.splice(this._queue.indexOf(matchedMsg), 1);
     return matchedMsg;
-  }
-
-  /**
-  * Gets a cached gateway object for the given URL (if it exists).
-  * @private
-  * @param {URL} url - URL object of the master container to connect to
-  * @returns {Gateway|void} - gateway object for the given URL
-  */
-  _getGWCache(url){
-    if (!gObj.fjage || !gObj.fjage.gateways) return null;
-    var f = gObj.fjage.gateways.filter(g => g.connector.url.toString() == url.toString());
-    if (f.length ) return f[0];
-    return null;
-  }
-
-  /**
-  * Adds a gateway object to the cache if it doesn't already exist.
-  * @private
-  * @param {Gateway} gw - gateway object to be added to the cache
-  */
-  _addGWCache(gw){
-    if (!gObj.fjage || !gObj.fjage.gateways) return;
-    gObj.fjage.gateways.push(gw);
-  }
-
-  /**
-  * Removes a gateway object from the cache if it exists.
-  * @private
-  * @param {Gateway} gw - gateway object to be removed from the cache
-  */
-  _removeGWCache(gw){
-    if (!gObj.fjage || !gObj.fjage.gateways) return;
-    var index = gObj.fjage.gateways.indexOf(gw);
-    if (index != null) gObj.fjage.gateways.splice(index,1);
   }
 
   /** @private */
@@ -702,7 +660,6 @@ export class Gateway {
       this.connector.write('{"alive": false}');
       this.connector.close();
     }
-    this._removeGWCache(this);
   }
 
 }

--- a/gateways/js/test/spec/fjage.spec.js
+++ b/gateways/js/test/spec/fjage.spec.js
@@ -1,4 +1,4 @@
-/* global global isBrowser isJsDom isNode Performative, AgentID, Message, MessageClass, Gateway, JSONMessage it expect expectAsync describe spyOn beforeAll afterAll beforeEach jasmine PutFileReq, GetFileReq, GetFileRsp, DeleteFileReq, ShellExecReq*/
+/* global isBrowser isJsDom isNode Performative, AgentID, Message, MessageClass, Gateway, JSONMessage it expect expectAsync describe spyOn beforeAll afterAll beforeEach jasmine PutFileReq, GetFileReq, GetFileRsp, DeleteFileReq, ShellExecReq*/
 
 const DIRNAME = '.';
 const FILENAME = 'fjage-test.txt';
@@ -41,10 +41,8 @@ const ValidFjageActions = ['agents', 'containsAgent', 'services', 'agentForServi
 const ValidFjagePerformatives = ['REQUEST', 'AGREE', 'REFUSE', 'FAILURE', 'INFORM', 'CONFIRM', 'DISCONFIRM', 'QUERY_IF', 'NOT_UNDERSTOOD', 'CFP', 'PROPOSE', 'CANCEL', ];
 
 var gwOpts;
-var gObj = {};
 var testType;
 if (isBrowser){
-  gObj = window;
   gwOpts = {
     hostname: 'localhost',
     port : '8080',
@@ -52,7 +50,6 @@ if (isBrowser){
   };
   testType = 'browser';
 } else if (isJsDom || isNode){
-  gObj = global;
   gwOpts = {
     hostname: 'localhost',
     port : '5081',
@@ -144,12 +141,15 @@ describe('A Gateway', function () {
     gw.close();
   });
 
-  it('should cache Gateways to the same url+port in browser', async function () {
-    if (!isBrowser) return;
+  it('should create independent gateways for the same url+port', async function () {
     const gw = new Gateway(gwOpts);
-    const gw2 = new Gateway(gwOpts);
-    expect(gw).toBe(gw2);
+    const gw2 = new Gateway(Object.assign({}, gwOpts, { timeout: 2500 }));
+    expect(gw2).not.toBe(gw);
+    expect(gw2.connector).not.toBe(gw.connector);
+    expect(gw._timeout).toBe(1000);
+    expect(gw2._timeout).toBe(2500);
     gw.close();
+    gw2.close();
   });
 
   it('should use split default timeouts for requests and directory queries', async function () {
@@ -160,13 +160,6 @@ describe('A Gateway', function () {
     gw.close();
   });
 
-  it('should register itself with the global fjage object', async function () {
-    if (!isBrowser) return;
-    var gw = new Gateway(gwOpts);
-    expect(gObj.fjage.gateways).toContain(gw);
-    gw.close();
-  });
-
   it('should close the socket when close is called on it', async function () {
     const gw = new Gateway(gwOpts);
     await delay(700);
@@ -174,15 +167,6 @@ describe('A Gateway', function () {
     gw.close();
     await delay(300);
     expect([gw.connector.sock.CLOSED, 'closed']).toContain(gw.connector.sock.readyState);
-  });
-
-  it('should remove itself from global array when closed', async function () {
-    if (!isBrowser) return;
-    const gw = new Gateway(gwOpts);
-    await delay(300);
-    gw.close();
-    await delay(300);
-    expect(gObj.fjage.gateways.find(el => el == gw)).toBeUndefined();
   });
 
   it('should match a registered message class used as a receive filter', function () {


### PR DESCRIPTION
Closes #462.

## Problem

In browsers, fjage.js kept a cache of gateways in `window.fjage.gateways`. A second `new Gateway()` for a URL that already had a gateway returned the cached instance and silently discarded the second call's options — so a caller asking for, say, a different `timeout` got a gateway that ignored it. Node.js had no such cache, so the two environments behaved differently for the same code.

## Change

- Removed the cache: the constructor lookup and early return, `_addGWCache()`/`_getGWCache()`/`_removeGWCache()`, the `close()` cleanup, and the `window.fjage.gateways` array.
- Removed the now-unused `gObj`/`global` plumbing; browser defaults read `window.location` directly.
- The global message-class registry is untouched — it is unrelated to gateway instance caching.

Every construction now opens its own connection with its own options, in both environments.

## Behavior change

This is user-visible in browsers: code relying on two `new Gateway()` calls collapsing into one connection now gets two. Applications that want a shared connection should construct one gateway and reuse it. Documented in the `Gateway` JSDoc, in the JavaScript Gateway guide (`docs/jsgw.qmd`), and under 2.6.0 in `ReleaseNotes.md`.

## Tests

The "should cache Gateways…" spec is replaced by "should create independent gateways for the same url+port", which constructs two gateways for the same endpoint with different `timeout` values and asserts distinct instances, distinct connectors, and per-instance options. It runs unconditionally, so it covers both the browser (where the bug lived) and Node.js. The two `window.fjage.gateways` registration/removal specs and the `gObj` fixture are gone.

## Validation

- `npm run build` — eslint, tsc, rollup clean
- `./gradlew test --tests org.arl.fjage.test.fjagejsTest --rerun-tasks` — Node.js 84 specs / 0 failures, browser test PASSED
- `npm run docs` and `quarto render docs` — both build